### PR TITLE
Fix for SWC-147 - Alert display offset

### DIFF
--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -310,7 +310,7 @@ a.shortBtn {
 }
 
 #alertWrapper {
-	position: absolute;
+	position: fixed;
 	width: 100%;
 	top: 5px;
 	left: 0;


### PR DESCRIPTION
Changed css to display "global" alerts at a fixed screen position
so the alert is visible regardless of where the user is scrolled to.
