### PR TITLE
Fix for PLFM-1396

### DIFF
--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -375,5 +375,7 @@ a.shortBtn {
 	height:	50px;
 }
 
-
+h1, h2, h3, h4, h5, h6 {
+	word-wrap: break-word;
+}
 	


### PR DESCRIPTION
All header elements will now break on overly-long words.
Added the word-wrap:break-word property to h1-h6.

The style applies cleanly and additively to the existing page styles.
