### PR TITLE
Refactor AclUtils to not have so much repetition

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
@@ -161,10 +161,10 @@ public class AccessControlListEditor implements AccessControlListEditorView.Pres
 			if (ra==null) {
 				ra = new ResourceAccess();
 				ra.setPrincipalId(principalId);
-				ra.setAccessType(new HashSet<ACCESS_TYPE>(AclUtils.getACCESS_TYPEs(permissionLevel)));
+				ra.setAccessType(AclUtils.getACCESS_TYPEs(permissionLevel));
 				acl.getResourceAccess().add(ra);
 			} else {
-				ra.setAccessType(new HashSet<ACCESS_TYPE>(AclUtils.getACCESS_TYPEs(permissionLevel)));
+				ra.setAccessType(AclUtils.getACCESS_TYPEs(permissionLevel));
 			}
 		} catch (Exception e) {
 			showErrorMessage("Creation of local sharing settings failed. Please try again.");
@@ -417,8 +417,7 @@ public class AccessControlListEditor implements AccessControlListEditorView.Pres
 	public static void addOwnerAdministrativeAccess(AccessControlList acl, Long creatorPrincipalId) {
 		ResourceAccess ra = new ResourceAccess();
 		ra.setPrincipalId(creatorPrincipalId);
-		Set<ACCESS_TYPE> ats = new HashSet<ACCESS_TYPE>();
-		ats.addAll(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_ADMINISTER));
+		Set<ACCESS_TYPE> ats = AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_ADMINISTER);
 		ra.setAccessType(ats);
 
 		acl.getResourceAccess().add(ra);

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorViewImpl.java
@@ -2,9 +2,11 @@ package org.sagebionetworks.web.client.widget.sharing;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.IconsImageBundle;
@@ -443,7 +445,7 @@ public class AccessControlListEditorViewImpl extends LayoutContainer implements 
 			AclPrincipal principal = aclEntry.getPrincipal();
 			this.set(PRINCIPAL_COLUMN_ID, principal);			
 			this.set(REMOVE_COLUMN_ID, principal);			
-			PermissionLevel level = AclUtils.getPermissionLevel(aclEntry.getAccessTypes());			
+			PermissionLevel level = AclUtils.getPermissionLevel(new HashSet<ACCESS_TYPE>(aclEntry.getAccessTypes()));			
 			if(level != null) {
 				this.set(ACCESS_COLUMN_ID, permissionDisplay.get(level)); 
 			}			

--- a/src/main/java/org/sagebionetworks/web/shared/users/AclUtils.java
+++ b/src/main/java/org/sagebionetworks/web/shared/users/AclUtils.java
@@ -1,9 +1,10 @@
 package org.sagebionetworks.web.shared.users;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.web.client.SynapseClientAsync;
@@ -11,17 +12,54 @@ import org.sagebionetworks.web.shared.NodeType;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
-public class AclUtils {	 
+public class AclUtils {
 
-	
+	private static Map<PermissionLevel, Set<ACCESS_TYPE>> permToACCESS_TYPE;
+
+	private static Map<ACCESS_TYPE, Set<PermissionLevel>> accessTypeToPerm;
+
+	// Build up a list of increasing permissions, starting with VIEW
+	// It's acceptable to use the shallow copy of the ArrayList(arrList) constructor
+	// because the elements are all ENUMS.
+	static {
+		permToACCESS_TYPE = new HashMap<PermissionLevel, Set<ACCESS_TYPE>>();
+		TreeSet<ACCESS_TYPE> accessList = new TreeSet<ACCESS_TYPE>();
+
+		accessList.add(ACCESS_TYPE.READ);
+		permToACCESS_TYPE.put(PermissionLevel.CAN_VIEW, new TreeSet<ACCESS_TYPE>(accessList));
+		permToACCESS_TYPE.put(PermissionLevel.CAN_DOWNLOAD, new TreeSet<ACCESS_TYPE>(accessList));
+
+		accessList.add(ACCESS_TYPE.CREATE);
+		accessList.add(ACCESS_TYPE.UPDATE);
+		permToACCESS_TYPE.put(PermissionLevel.CAN_EDIT, new TreeSet<ACCESS_TYPE>(accessList));
+
+		accessList.add(ACCESS_TYPE.DELETE);
+		accessList.add(ACCESS_TYPE.CHANGE_PERMISSIONS);
+		permToACCESS_TYPE.put(PermissionLevel.CAN_ADMINISTER, new TreeSet<ACCESS_TYPE>(accessList));
+
+		// Build the reverse mapping from the first map
+		accessTypeToPerm = new HashMap<ACCESS_TYPE, Set<PermissionLevel>>();
+		for (ACCESS_TYPE type : ACCESS_TYPE.values()) {
+			TreeSet<PermissionLevel> levels = new TreeSet<PermissionLevel>();
+
+			for (Entry<PermissionLevel, Set<ACCESS_TYPE>> entry : permToACCESS_TYPE
+					.entrySet()) {
+				if (entry.getValue().contains(type)) {
+					levels.add(entry.getKey());
+				}
+			}
+			accessTypeToPerm.put(type, levels);
+		}
+	}
+
 	/**
 	 * Returns the highest permission level for the logged in user for the given entity
 	 * @param nodeType
 	 * @param nodeId
 	 * @return
 	 */
-	public static void getHighestPermissionLevel(final NodeType nodeType, final String nodeId, final SynapseClientAsync synapseClient, final AsyncCallback<PermissionLevel> callback) {		
-		
+	public static void getHighestPermissionLevel(final NodeType nodeType, final String nodeId, final SynapseClientAsync synapseClient, final AsyncCallback<PermissionLevel> callback) {
+
 		// TODO : making two rest calls is not ideal. need to change hasAccess API to include multi params
 		synapseClient.hasAccess(nodeId, ACCESS_TYPE.UPDATE.name(), new AsyncCallback<Boolean>() {
 			@Override
@@ -43,7 +81,7 @@ public class AclUtils {
 						public void onFailure(Throwable caught) {
 							callback.onFailure(caught);
 						}
-					});				
+					});
 				} else {
 					// user can only view
 					callback.onSuccess(PermissionLevel.CAN_VIEW);
@@ -57,78 +95,32 @@ public class AclUtils {
 		});
 	}
 
-	public static PermissionLevel getPermissionLevel(List<ACCESS_TYPE> accessTypes) {		
-		// TODO : this should be updated to be more generic
-		if(accessTypes.contains(ACCESS_TYPE.READ)
-			&& accessTypes.contains(ACCESS_TYPE.CREATE)
-			&& accessTypes.contains(ACCESS_TYPE.UPDATE)
-			&& accessTypes.contains(ACCESS_TYPE.DELETE)
-			&& accessTypes.contains(ACCESS_TYPE.CHANGE_PERMISSIONS)) {
-			return PermissionLevel.CAN_ADMINISTER;
-		} else if(accessTypes.contains(ACCESS_TYPE.READ) 
-				&& accessTypes.contains(ACCESS_TYPE.CREATE)
-				&& accessTypes.contains(ACCESS_TYPE.UPDATE)
-				&& !accessTypes.contains(ACCESS_TYPE.DELETE)
-				&& !accessTypes.contains(ACCESS_TYPE.CHANGE_PERMISSIONS)) {
-			return PermissionLevel.CAN_EDIT;
-		} else if(accessTypes.contains(ACCESS_TYPE.READ) 
-				&& !accessTypes.contains(ACCESS_TYPE.CREATE)
-				&& !accessTypes.contains(ACCESS_TYPE.UPDATE)
-				&& !accessTypes.contains(ACCESS_TYPE.DELETE)
-				&& !accessTypes.contains(ACCESS_TYPE.CHANGE_PERMISSIONS)) {
-			return PermissionLevel.CAN_VIEW;
-		} else {
-			return null;
+	public static PermissionLevel getPermissionLevel(Set<ACCESS_TYPE> accessTypes) {
+		for (PermissionLevel level : PermissionLevel.values()) {
+			if (accessTypes.equals(permToACCESS_TYPE.get(level))) {
+				return level;
+			}
 		}
+		return null;
 	}
-	
-	public static List<ACCESS_TYPE> getACCESS_TYPEs(PermissionLevel permissionLevel) {
-		return getPermissionLevelMap().get(permissionLevel);
+
+	public static Set<ACCESS_TYPE> getACCESS_TYPEs(PermissionLevel permissionLevel) {
+		return permToACCESS_TYPE.get(permissionLevel);
 	}
-	
+
+	public static Set<PermissionLevel> getPermisionLevels(ACCESS_TYPE accessType) {
+		return accessTypeToPerm.get(accessType);
+	}
+
 	public static ACCESS_TYPE getACCESS_TYPE(String accessType) {
-		if(ACCESS_TYPE.READ.toString().equals(accessType)) return ACCESS_TYPE.READ;
-		else if(ACCESS_TYPE.CREATE.toString().equals(accessType)) return ACCESS_TYPE.CREATE;
-		else if(ACCESS_TYPE.DELETE.toString().equals(accessType)) return ACCESS_TYPE.DELETE;
-		else if(ACCESS_TYPE.CHANGE_PERMISSIONS.toString().equals(accessType)) return ACCESS_TYPE.CHANGE_PERMISSIONS;
-		else if(ACCESS_TYPE.UPDATE.toString().equals(accessType)) return ACCESS_TYPE.UPDATE;
-		else return null;
-	}
+		ACCESS_TYPE valueOf;
+		try {
+			valueOf = ACCESS_TYPE.valueOf(accessType);
+		} catch (IllegalArgumentException e) {
+			valueOf = null;
+		}
 
-
-	private static Map<PermissionLevel, List<ACCESS_TYPE>> getPermissionLevelMap() {
-		Map<PermissionLevel, List<ACCESS_TYPE>> permToACCESS_TYPE = new HashMap<PermissionLevel, List<ACCESS_TYPE>>();
-		permToACCESS_TYPE.put(PermissionLevel.CAN_VIEW,
-				Arrays.asList(new ACCESS_TYPE[] { ACCESS_TYPE.READ }));
-		permToACCESS_TYPE.put(
-				PermissionLevel.CAN_EDIT,
-				Arrays.asList(new ACCESS_TYPE[] { ACCESS_TYPE.READ,
-						ACCESS_TYPE.READ, ACCESS_TYPE.CREATE,
-						ACCESS_TYPE.UPDATE }));
-		permToACCESS_TYPE.put(PermissionLevel.CAN_ADMINISTER,
-				Arrays.asList(new ACCESS_TYPE[] { 
-						ACCESS_TYPE.READ, ACCESS_TYPE.CREATE,
-						ACCESS_TYPE.UPDATE, ACCESS_TYPE.DELETE,
-						ACCESS_TYPE.CHANGE_PERMISSIONS }));
-		
-		return permToACCESS_TYPE;
-	}
-	
-	private static Map<ACCESS_TYPE, List<PermissionLevel>> getACCESS_TYPEMap() {
-		Map<ACCESS_TYPE, List<PermissionLevel>> accessTypeToPerm = new HashMap<ACCESS_TYPE, List<PermissionLevel>>();
-		
-		accessTypeToPerm.put(ACCESS_TYPE.READ,
-				Arrays.asList(new PermissionLevel[] { PermissionLevel.CAN_VIEW, PermissionLevel.CAN_EDIT, PermissionLevel.CAN_ADMINISTER }));
-		accessTypeToPerm.put(ACCESS_TYPE.CREATE,
-				Arrays.asList(new PermissionLevel[] { PermissionLevel.CAN_EDIT, PermissionLevel.CAN_ADMINISTER }));
-		accessTypeToPerm.put(ACCESS_TYPE.UPDATE,
-				Arrays.asList(new PermissionLevel[] { PermissionLevel.CAN_EDIT, PermissionLevel.CAN_ADMINISTER }));
-		accessTypeToPerm.put(ACCESS_TYPE.DELETE,
-				Arrays.asList(new PermissionLevel[] { PermissionLevel.CAN_ADMINISTER }));
-		accessTypeToPerm.put(ACCESS_TYPE.CHANGE_PERMISSIONS,
-				Arrays.asList(new PermissionLevel[] { PermissionLevel.CAN_ADMINISTER }));
-		
-		return accessTypeToPerm;
+		return valueOf;
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/web/shared/users/PermissionLevel.java
+++ b/src/main/java/org/sagebionetworks/web/shared/users/PermissionLevel.java
@@ -1,5 +1,5 @@
 package org.sagebionetworks.web.shared.users;
 
 public enum PermissionLevel {
-	CAN_EDIT, CAN_VIEW, CAN_ADMINISTER
+	CAN_VIEW, CAN_DOWNLOAD, CAN_EDIT, CAN_ADMINISTER
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessControlListEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessControlListEditorTest.java
@@ -138,7 +138,7 @@ public class AccessControlListEditorTest {
 								if (1L == ra.getPrincipalId()) {
 									foundIt=true;
 									Set<ACCESS_TYPE> ats = ra.getAccessType();
-									assertEquals(new HashSet<ACCESS_TYPE>(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_EDIT)), ats);
+									assertEquals(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_EDIT), ats);
 								}
 							}
 							assertTrue(foundIt);
@@ -179,7 +179,7 @@ public class AccessControlListEditorTest {
 								if (1L == ra.getPrincipalId()) {
 									foundIt=true;
 									Set<ACCESS_TYPE> ats = ra.getAccessType();
-									assertEquals(new HashSet<ACCESS_TYPE>(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_EDIT)), ats);
+									assertEquals(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_EDIT), ats);
 								}
 							}
 							assertTrue(foundIt);

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -144,7 +144,7 @@ public class SynapseClientImplTest {
 		Set<ResourceAccess> ras = new HashSet<ResourceAccess>();
 		ResourceAccess ra = new ResourceAccess();
 		ra.setPrincipalId(101L);
-		ra.setAccessType(new HashSet<ACCESS_TYPE>(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_ADMINISTER)));
+		ra.setAccessType(AclUtils.getACCESS_TYPEs(PermissionLevel.CAN_ADMINISTER));
 		acl.setResourceAccess(ras);
 		when(mockSynapse.getACL(anyString())).thenReturn(acl);
 		when(mockSynapse.createACL((AccessControlList)any())).thenReturn(acl);


### PR DESCRIPTION
Now there's one canonical mapping of ACCESS_TYPE to PermissionLevel
and the other representations are built off that.
