### PR TITLE
SWC-232: Fix regression in allowed entity names

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyForm.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyForm.java
@@ -236,7 +236,7 @@ public class EntityPropertyForm extends FormPanel {
 		nameField = (TextField<String>) formFactory.createField(model.getName());
 		nameField.setAllowBlank(false);
 		nameField.setRegex(WebConstants.VALID_ENTITY_NAME_REGEX);
-		nameField.getMessages().setRegexText("Entity names may only contain letters, numbers, '_' and '.'");
+		nameField.getMessages().setRegexText(WebConstants.INVALID_ENTITY_NAME_MESSAGE);
 		descriptionField = formFactory.createTextAreaField(model.getDescription());
 
 		// Create the list of fields

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -17,7 +17,9 @@ public class WebConstants {
 	 * compatibility across services and clients.
 	 * 
 	 */
-	public static final String VALID_ENTITY_NAME_REGEX = "^[a-z,A-Z,0-9,_,.]+";
+	public static final String VALID_ENTITY_NAME_REGEX = "^[a-z,A-Z,0-9,_,., ,\\-,\\+,(,)]+";
+	
+	public static final String INVALID_ENTITY_NAME_MESSAGE = "Entity names may only contain letters, numbers, spaces, underscores, hypens, periods, plus signs, and parentheses.";
 	
 	/**
 	 * Regex defining a valid annotation name. Characters are selected to ensure


### PR DESCRIPTION
On 9/7, this fix was applied to release-1.7 as a production hotfix, then back into develop. It appears that release-1.8 (now prod) was peeled off of develop just before the fix was merged in.

This hotfix has been previously reviewed and applied to prod. It is also present in develop and release-1.9 (current staging).
