### PR TITLE
SWC-354: always reset the version UI when cleared (when entity is change...

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.java
@@ -281,6 +281,10 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 
 	private void clear() {
 		dataUseContainer.clear();
+        //reset versions ui
+        setVersionsVisible(false);
+        previousVersions.setVisible(false);
+        allVersions.setText(DisplayConstants.SHOW_VERSIONS);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormViewImpl.java
@@ -359,6 +359,7 @@ public class EntityPropertyFormViewImpl extends FormPanel implements EntityPrope
 		mdCommands.setVerticalAlign(VerticalAlignment.MIDDLE);
 		mdCommands.addStyleName("view header-inner-commands-container");
 		Button insertButton = new Button("Insert", AbstractImagePrototype.create(iconsImageBundle.add16()));
+		insertButton.setWidth(55);
 		insertButton.setMenu(createWidgetMenu());
 		FormData descriptionLabelFormData = new FormData();
 		descriptionLabelFormData.setMargins(new Margins(0,15,0,17));
@@ -408,6 +409,7 @@ public class EntityPropertyFormViewImpl extends FormPanel implements EntityPrope
 		
 		final Button formatLink = new Button(DisplayConstants.ENTITY_DESCRIPTION_TIPS_TEXT);
 		formatLink.setIcon(AbstractImagePrototype.create(iconsImageBundle.slideInfo16()));
+		formatLink.setWidth(120);
 		mdCommands.add(formatLink);
 		mdCommands.add(insertButton);
 		formatLink.addSelectionListener(new SelectionListener<ButtonEvent>() {


### PR DESCRIPTION
...d).  Also explicitly set the width of buttons in entity property form, since the automatically calculated width is not right in some browsers (looks ok in FF, but not Chrome)
