### PR TITLE
SWC-364: only refresh the attachments of the entity when the edit dialog is visible

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
@@ -6,7 +6,6 @@ import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.Locationable;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserSessionData;
-import org.sagebionetworks.repo.model.widget.WidgetDescriptor;
 import org.sagebionetworks.schema.ObjectSchema;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyForm.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyForm.java
@@ -72,7 +72,7 @@ public class EntityPropertyForm implements EntityPropertyFormView.Presenter {
 				@Override
 				public void onPersistSuccess(EntityUpdatedEvent event) {
 					//ask for the new entity, update our attachments and etag, and reconfigure the attachments widget
-					if (view.isComponentRendered())
+					if (view.isComponentVisible() && bundle != null && bundle.getEntity() != null && bundle.getEntity().getId() != null)
 						refreshEntityAttachments();
 				}
 			};
@@ -93,7 +93,6 @@ public class EntityPropertyForm implements EntityPropertyFormView.Presenter {
 		callback.saveEntity(adapter, annos);	
 	}
 
-		
 	@Override
 	public void removeAnnotation() {
 		// Show a form for adding an Annotations

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormView.java
@@ -22,7 +22,7 @@ public interface EntityPropertyFormView extends SynapseWidgetView, IsWidget {
 	public void insertMarkdown(String md);
 	public BaseEditWidgetDescriptorPresenter getWidgetDescriptorEditor();
 	public void showEditEntityDialog(final String windowTitle);
-	public boolean isComponentRendered();
+	public boolean isComponentVisible();
 	
 	/**
 	 * Presenter interface

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPropertyFormViewImpl.java
@@ -195,8 +195,8 @@ public class EntityPropertyFormViewImpl extends FormPanel implements EntityPrope
 	}
 
 	@Override
-	public boolean isComponentRendered(){
-		return isRendered();
+	public boolean isComponentVisible(){
+		return this.isVisible();
 	}
 	
 	public void showFormattingGuideDialog() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
@@ -4,10 +4,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.sagebionetworks.repo.model.widget.ImageAttachmentWidgetDescriptor;
-import org.sagebionetworks.repo.model.widget.ProvenanceWidgetDescriptor;
-import org.sagebionetworks.repo.model.widget.WidgetDescriptor;
-import org.sagebionetworks.repo.model.widget.YouTubeWidgetDescriptor;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.DisplayConstants;


### PR DESCRIPTION
(we don't care if it's rendered or not).  
also add tests around this functionality
