### PR TITLE
SWC-639: fix upload for IE (for now limit to 5mb)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
@@ -169,7 +169,9 @@ public class SynapseJSNIUtilsImpl implements SynapseJSNIUtils {
 	
 	private final static native boolean _isDirectUploadSupported() /*-{ 
 		//if Safari, direct upload is not supported
-		if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1)
+		var userAgentString = navigator.userAgent.toLowerCase();
+		if ((userAgentString.indexOf('safari') != -1 && userAgentString.indexOf('chrome') == -1) ||	//Safari or
+			(userAgentString.indexOf('msie') != -1))												//IE
 			return false;
 		var xhr = new XMLHttpRequest();
 		// This test is from http://blogs.msdn.com/b/ie/archive/2012/02/09/cors-for-xhr-in-ie10.aspx

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/dialog/AddAttachmentDialog.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/dialog/AddAttachmentDialog.java
@@ -170,7 +170,9 @@ public class AddAttachmentDialog {
 			GwtAdapterFactory factory = new GwtAdapterFactory();
 			//search for the first ">" (end of the pre tag)
 			int closeIndex = html.indexOf(">")+1;
-			String json = html.substring(closeIndex, (html.length()-"</pre>".length()));
+			String json = html;
+			if (html.contains("</pre>"))
+				json = html.substring(closeIndex, (html.length()-"</pre>".length()));
 			JSONObjectAdapter adapter;
 			try {
 				adapter = factory.createNew(json);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
@@ -483,6 +483,7 @@ public class Uploader implements UploaderView.Presenter, SynapseWidgetPresenter,
 		// response from server
 		//try to parse
 		UploadResult uploadResult = null;
+		String detailedErrorMessage = null;
 		try{
 			uploadResult = AddAttachmentDialog.getUploadResult(resultHtml);
 			if (uploadResult.getUploadStatus() == UploadStatus.SUCCESS) {
@@ -491,13 +492,13 @@ public class Uploader implements UploaderView.Presenter, SynapseWidgetPresenter,
 				//get the entity, and report success
 				refreshAfterSuccessfulUpload(entityId, isNewlyRestricted);
 			}else {
-				uploadError(null);
+				uploadError("Upload result status indicated upload was unsuccessful.");
 			}
-		} catch (Throwable th) {};//wasn't an UplaodResult
+		} catch (Throwable th) {detailedErrorMessage = th.getMessage();};//wasn't an UplaodResult
 		
 		if (uploadResult == null) {
 			if(!resultHtml.contains(DisplayUtils.UPLOAD_SUCCESS)) {
-				uploadError(null);
+				uploadError(detailedErrorMessage);
 			} else {
 				uploadSuccess(isNewlyRestricted);
 			}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleServlet.java
@@ -204,6 +204,9 @@ public class FileHandleServlet extends HttpServlet {
 				String name = item.getFieldName();
 				InputStream stream = item.openStream();
 				String fileName = item.getName();
+				if (fileName.contains("\\")){
+					fileName = fileName.substring(fileName.lastIndexOf("\\")+1);
+				}
                 File tempDir = Files.createTempDir();
 				File temp = new File(tempDir.getAbsolutePath() + File.separator + fileName);
 


### PR DESCRIPTION
fixed multiple issues with IE upload. Chunked upload caused Network Error 0x2efe (SWC-639).  File name from windows box included full path, so there was always an error on rename.  And json response is automatically unwrapped in some cases, so need to detect that.  Also improved error handling (show the detailed error if unable to create UploadResult object from response json.  
Tested on Mac: Firefox 21, Chrome 27, and Safari 6.  And Windows: IE 10 and Chrome 27.
