### PR TITLE
SWC-701 Added bookmark/in-page linking feature to the markdown processor

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
@@ -337,7 +337,8 @@ public class DisplayConstants {
 	public static final String ACTIVITY = "Activity";
 	public static final String ERROR_NAME_PATTERN_MISMATCH = "Names may only contain letters, numbers, spaces, underscores, hypens, periods, plus signs, and parentheses.";
 	public static final String ERROR_WIDGET_NAME_PATTERN_MISMATCH = "Names may only contain letters, numbers, spaces, hypens, periods, plus signs, and parentheses.";
-
+	public static final String ERROR_BOOKMARK_ID = "ID names may only contain letters, numbers, hypens, underscores, colons, and periods.";
+	
 	/**
 	 * Widget editors
 	 */
@@ -352,6 +353,7 @@ public class DisplayConstants {
 	public static final String IMAGE_CONFIG_ALT_TEXT = "Alternate Text:";
 	public static final String IMAGE_FAILED_TO_LOAD = "Image failed to load: ";
 	public static final String URL_LABEL = "URL:";
+	public static final String LINK_TEXT_LABEL = "Link Text:";
 	public static final String TABLE_LABEL = "Tab Delimitted Table Contents:";
 	public static final String UPLOAD_SUCCESSFUL_STATUS_TEXT = "Uploaded successfully";
 	public static final String YOUTUBE_VIDEO_URL_LABEL = "Video URL:";

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -42,6 +42,7 @@ import org.sagebionetworks.web.client.widget.entity.renderer.APITableColumnRende
 import org.sagebionetworks.web.client.widget.entity.renderer.APITableColumnRendererUserId;
 import org.sagebionetworks.web.client.widget.entity.renderer.APITableWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.AttachmentPreviewWidget;
+import org.sagebionetworks.web.client.widget.entity.renderer.BookmarkWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.ButtonLinkWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.EntityListWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.ImageWidget;
@@ -131,6 +132,7 @@ public interface PortalGinInjector extends Ginjector {
 	public ButtonLinkConfigEditor getButtonLinkConfigEditor();
 	
 	////// Renderers
+	public BookmarkWidget getBookmarkRenderer();
 	public ReferenceWidget getReferenceRenderer();
 	public YouTubeWidget getYouTubeRenderer();
 	public ProvenanceWidget getProvenanceRenderer();

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -24,6 +24,7 @@ import org.sagebionetworks.web.client.widget.entity.MarkdownWidget;
 import org.sagebionetworks.web.client.widget.entity.browse.EntityTreeBrowser;
 import org.sagebionetworks.web.client.widget.entity.editor.APITableConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.AttachmentConfigEditor;
+import org.sagebionetworks.web.client.widget.entity.editor.BookmarkConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.ButtonLinkConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.EntityListConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.ImageConfigEditor;
@@ -116,6 +117,7 @@ public interface PortalGinInjector extends Ginjector {
 	 *  Markdown Widgets
 	 */
 	////// Editors
+	public BookmarkConfigEditor getBookmarkConfigEditor();
 	public ReferenceConfigEditor getReferenceConfigEditor();
 	public YouTubeConfigEditor getYouTubeConfigEditor();
 	public ProvenanceConfigEditor getProvenanceConfigEditor();

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -115,6 +115,8 @@ import org.sagebionetworks.web.client.widget.entity.editor.APITableConfigView;
 import org.sagebionetworks.web.client.widget.entity.editor.APITableConfigViewImpl;
 import org.sagebionetworks.web.client.widget.entity.editor.AttachmentConfigView;
 import org.sagebionetworks.web.client.widget.entity.editor.AttachmentConfigViewImpl;
+import org.sagebionetworks.web.client.widget.entity.editor.BookmarkConfigView;
+import org.sagebionetworks.web.client.widget.entity.editor.BookmarkConfigViewImpl;
 import org.sagebionetworks.web.client.widget.entity.editor.ButtonLinkConfigView;
 import org.sagebionetworks.web.client.widget.entity.editor.ButtonLinkConfigViewImpl;
 import org.sagebionetworks.web.client.widget.entity.editor.EntityListConfigView;
@@ -489,6 +491,7 @@ public class PortalGinModule extends AbstractGinModule {
 		bind(WidgetRegistrar.class).to(WidgetRegistrarImpl.class);
 		
 		// UI Widget Descriptor editor
+		bind(BookmarkConfigView.class).to(BookmarkConfigViewImpl.class);
 		bind(BaseEditWidgetDescriptorView.class).to(BaseEditWidgetDescriptorViewImpl.class);
 		bind(ReferenceConfigView.class).to(ReferenceConfigViewImpl.class);
 		bind(YouTubeConfigView.class).to(YouTubeConfigViewImpl.class);

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -149,6 +149,8 @@ import org.sagebionetworks.web.client.widget.entity.renderer.APITableWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.APITableWidgetViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.AttachmentPreviewWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.AttachmentPreviewWidgetViewImpl;
+import org.sagebionetworks.web.client.widget.entity.renderer.BookmarkWidgetView;
+import org.sagebionetworks.web.client.widget.entity.renderer.BookmarkWidgetViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.ButtonLinkWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.ButtonLinkWidgetViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.EntityListWidgetView;
@@ -503,6 +505,7 @@ public class PortalGinModule extends AbstractGinModule {
 		bind(ButtonLinkConfigView.class).to(ButtonLinkConfigViewImpl.class);
 		
 		// UI Widget Renderers
+		bind(BookmarkWidgetView.class).to(BookmarkWidgetViewImpl.class);
 		bind(ReferenceWidgetView.class).to(ReferenceWidgetViewImpl.class);
 		bind(YouTubeWidgetView.class).to(YouTubeWidgetViewImpl.class);
 		bind(OldImageWidgetView.class).to(OldImageWidgetViewImpl.class);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
@@ -384,6 +384,11 @@ public class MarkdownEditorWidget extends LayoutContainer {
 	     */
 	    if (DisplayUtils.isInTestWebsite(cookies)) {
 	    	menu.add(new SeparatorMenuItem());
+	    	menu.add(getNewCommand(WidgetConstants.BOOKMARK_FRIENDLY_NAME, new SelectionListener<ComponentEvent>() {
+	    		public void componentSelected(ComponentEvent ce) {
+	    			handleInsertWidgetCommand(WidgetConstants.BOOKMARK_CONTENT_TYPE, callback);
+	    		}
+	    	}));
 	    	menu.add(getNewCommand(WidgetConstants.REFERENCE_FRIENDLY_NAME, new SelectionListener<ComponentEvent>() {
 		    	public void componentSelected(ComponentEvent ce) {
 		    		handleInsertWidgetCommand(WidgetConstants.REFERENCE_CONTENT_TYPE, callback);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/SharedMarkdownUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/SharedMarkdownUtils.java
@@ -14,18 +14,24 @@ public class SharedMarkdownUtils {
 	}
 	
 	public static String getWidgetHTML(int widgetIndex, String suffix, String widgetProperties){
+		boolean inlineWidget = false;
 		StringBuilder sb = new StringBuilder();
+		if(widgetProperties.contains(WidgetConstants.INLINE_WIDGET_KEY + "=true")) {
+			inlineWidget = true;
+		}
+	
 		sb.append("<div id=\"");
 		sb.append(WebConstants.DIV_ID_WIDGET_PREFIX);
 		sb.append(widgetIndex);
 		sb.append(suffix);
 		
 		//Some widgets will be inline
-		if(widgetProperties.contains(WidgetConstants.INLINE_WIDGET_KEY + "=true")) {
+		if(inlineWidget) {
 			sb.append("\" class=\"inlineWidgetContainer\" widgetParams=\"");
 		} else {
 			sb.append("\" class=\"widgetContainer\" widgetParams=\"");
 		}
+		
 		sb.append(widgetProperties);
 		sb.append("\">");
 		sb.append("</div>");

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigEditor.java
@@ -11,6 +11,7 @@ import com.google.inject.Inject;
 
 public class BookmarkConfigEditor implements BookmarkConfigView.Presenter, WidgetEditorPresenter{
 	private BookmarkConfigView view;
+	private Map<String, String> descriptor;
 	
 	@Inject
 	public BookmarkConfigEditor(BookmarkConfigView view) {
@@ -27,11 +28,15 @@ public class BookmarkConfigEditor implements BookmarkConfigView.Presenter, Widge
 	@Override
 	public void configure(WikiPageKey wikiKey,
 			Map<String, String> widgetDescriptor) {
+		descriptor = widgetDescriptor;
+		view.configure(wikiKey, descriptor);
 	}
 
 	@Override
 	public void updateDescriptorFromView() throws IllegalArgumentException {
 		view.checkParams();
+		descriptor.put(WidgetConstants.TEXT_KEY, view.getLinkText());
+		descriptor.put(WidgetConstants.BOOKMARK_KEY, view.getBookmarkId());
 	}
 
 	@Override
@@ -46,7 +51,7 @@ public class BookmarkConfigEditor implements BookmarkConfigView.Presenter, Widge
 
 	@Override
 	public String getTextToInsert() {
-		return "[" + view.getLinkText() + "](" + WidgetConstants.BOOKMARK_LINK_IDENTIFIER + ":" + view.getTargetId() + ")\n${" + WidgetConstants.BOOKMARK_TARGET_CONTENT_TYPE + "?" + WidgetConstants.BOOKMARK_KEY + "=" + view.getTargetId() + "}";
+		return "[" + view.getLinkText() + "](" + WidgetConstants.BOOKMARK_LINK_IDENTIFIER + ":" + view.getBookmarkId() + ")\n${" + WidgetConstants.BOOKMARK_TARGET_CONTENT_TYPE + "?" + WidgetConstants.BOOKMARK_KEY + "=" + view.getBookmarkId() + "}";
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigEditor.java
@@ -9,34 +9,29 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
-public class ReferenceConfigEditor implements ReferenceConfigView.Presenter, WidgetEditorPresenter {
-	private Map<String, String> descriptor;
-	private ReferenceConfigView view;
+public class BookmarkConfigEditor implements BookmarkConfigView.Presenter, WidgetEditorPresenter{
+	private BookmarkConfigView view;
 	
 	@Inject
-	public ReferenceConfigEditor(ReferenceConfigView view) {
+	public BookmarkConfigEditor(BookmarkConfigView view) {
 		this.view = view;
 		view.setPresenter(this);
 		view.initView();
 	}
 	
 	@Override
-	public void configure(WikiPageKey wikiKey, Map<String, String> widgetDescriptor) {
-		descriptor = widgetDescriptor;
-	}
-	
-	@Override
 	public Widget asWidget() {
 		return view.asWidget();
 	}
-	
+
 	@Override
-	public void updateDescriptorFromView() {
+	public void configure(WikiPageKey wikiKey,
+			Map<String, String> widgetDescriptor) {
+	}
+
+	@Override
+	public void updateDescriptorFromView() throws IllegalArgumentException {
 		view.checkParams();
-		
-		//Add the inline parameter to make the widget render inline
-		descriptor.put(WidgetConstants.INLINE_WIDGET_KEY, "true");
-		descriptor.put(WidgetConstants.TEXT_KEY, view.getReference());
 	}
 
 	@Override
@@ -51,6 +46,7 @@ public class ReferenceConfigEditor implements ReferenceConfigView.Presenter, Wid
 
 	@Override
 	public String getTextToInsert() {
-		return null;
+		return "[" + view.getLinkText() + "](" + WidgetConstants.BOOKMARK_LINK_IDENTIFIER + ":" + view.getTargetId() + ")\n${" + WidgetConstants.BOOKMARK_TARGET_CONTENT_TYPE + "?" + WidgetConstants.BOOKMARK_KEY + "=" + view.getTargetId() + "}";
 	}
+
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigView.java
@@ -1,0 +1,28 @@
+package org.sagebionetworks.web.client.widget.entity.editor;
+
+import org.sagebionetworks.web.client.widget.WidgetEditorView;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface BookmarkConfigView extends IsWidget, WidgetEditorView {
+	/**
+	 * Set the presenter.
+	 * @param presenter
+	 */
+	public void setPresenter(Presenter presenter);
+
+	public void setLinkText(String linkText);
+	public String getLinkText();
+	
+	public void setTargetId(String targetId);
+	public String getTargetId();
+	
+	
+	/**
+	 * Presenter interface
+	 */
+	public interface Presenter {
+
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigView.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
+import java.util.Map;
+
 import org.sagebionetworks.web.client.widget.WidgetEditorView;
+import org.sagebionetworks.web.shared.WikiPageKey;
 
 import com.google.gwt.user.client.ui.IsWidget;
 
@@ -10,12 +13,12 @@ public interface BookmarkConfigView extends IsWidget, WidgetEditorView {
 	 * @param presenter
 	 */
 	public void setPresenter(Presenter presenter);
-
+	public void configure(WikiPageKey wikiKey, Map<String, String> widgetDescriptor);
 	public void setLinkText(String linkText);
 	public String getLinkText();
 	
-	public void setTargetId(String targetId);
-	public String getTargetId();
+	public void setBookmarkId(String targetId);
+	public String getBookmarkId();
 	
 	
 	/**

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
@@ -1,8 +1,13 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
+import java.util.Date;
+import java.util.Map;
+
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
+import org.sagebionetworks.web.client.widget.entity.registration.WidgetConstants;
 import org.sagebionetworks.web.shared.WebConstants;
+import org.sagebionetworks.web.shared.WikiPageKey;
 
 import com.extjs.gxt.ui.client.Style.VerticalAlignment;
 import com.extjs.gxt.ui.client.widget.HorizontalPanel;
@@ -15,7 +20,7 @@ import com.google.inject.Inject;
 public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkConfigView {
 	private Presenter presenter;
 	private TextField<String> linkTextField;
-	private TextField<String> bookmarkIdField;
+	private Date bookmarkId;
 	
 	@Inject
 	public BookmarkConfigViewImpl() {
@@ -35,24 +40,20 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 		hp.add(linkTextField);
 		hp.addStyleName("margin-top-left-10");
 		vp.add(hp);
-		
-		hp = new HorizontalPanel();
-		hp.setVerticalAlign(VerticalAlignment.MIDDLE);
-		bookmarkIdField = new TextField<String>();
-		bookmarkIdField.setAllowBlank(false);
-		bookmarkIdField.setRegex(WebConstants.VALID_BOOKMARK_ID_REGEX);
-		bookmarkIdField.getMessages().setRegexText(DisplayConstants.ERROR_BOOKMARK_ID);
-		Label bookmarkIdLabel = new Label("Bookmark ID:");
-		bookmarkIdLabel.setWidth(70);
-		bookmarkIdField.setWidth(270);
-		hp.add(bookmarkIdLabel);
-		hp.add(bookmarkIdField);
-		hp.addStyleName("margin-top-left-10");
-		vp.add(hp);
-		
 		add(vp);
+		
+		bookmarkId = new Date();
 	}
 
+	@Override
+	public void configure(WikiPageKey wikiKey,
+			Map<String, String> widgetDescriptor) {
+		String text = widgetDescriptor.get(WidgetConstants.TEXT_KEY);
+		if (text != null) {
+			linkTextField.setValue(text);
+		}
+	}
+	
 	@Override
 	public int getDisplayHeight() {
 		return 60;
@@ -68,9 +69,6 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 		if (!linkTextField.isValid()) {
 			throw new IllegalArgumentException(linkTextField.getErrorMessage());
 		} 
-		if (!bookmarkIdField.isValid()) {
-			throw new IllegalArgumentException(bookmarkIdField.getErrorMessage());
-		}
 	}
 
 	@Override
@@ -87,9 +85,6 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 	public void clear() {
 		if (linkTextField != null) {
 			linkTextField.setValue("");
-		}
-		if (bookmarkIdField != null) {
-			bookmarkIdField.setValue("");
 		}
 	}
 
@@ -109,13 +104,16 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 	}
 
 	@Override
-	public void setTargetId(String targetId) {
-		bookmarkIdField.setValue(targetId);
+	public void setBookmarkId(String targetId) {
+		try {
+			bookmarkId.setTime(Long.valueOf(targetId));
+		} catch(NumberFormatException e) {
+		}
 	}
 
 	@Override
-	public String getTargetId() {
-		return bookmarkIdField.getValue();
+	public String getBookmarkId() {
+		return String.valueOf(bookmarkId.getTime());
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
@@ -20,7 +20,7 @@ import com.google.inject.Inject;
 public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkConfigView {
 	private Presenter presenter;
 	private TextField<String> linkTextField;
-	private Date bookmarkId;
+	private String bookmarkId;
 	
 	@Inject
 	public BookmarkConfigViewImpl() {
@@ -42,7 +42,8 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 		vp.add(hp);
 		add(vp);
 		
-		bookmarkId = new Date();
+		Date time = new Date();
+		bookmarkId = String.valueOf(time.getTime());
 	}
 
 	@Override
@@ -52,6 +53,7 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 		if (text != null) {
 			linkTextField.setValue(text);
 		}
+		bookmarkId = widgetDescriptor.get(WidgetConstants.BOOKMARK_KEY);
 	}
 	
 	@Override
@@ -105,15 +107,12 @@ public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkC
 
 	@Override
 	public void setBookmarkId(String targetId) {
-		try {
-			bookmarkId.setTime(Long.valueOf(targetId));
-		} catch(NumberFormatException e) {
-		}
+		bookmarkId = targetId;
 	}
 
 	@Override
 	public String getBookmarkId() {
-		return String.valueOf(bookmarkId.getTime());
+		return bookmarkId;
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.java
@@ -1,0 +1,126 @@
+package org.sagebionetworks.web.client.widget.entity.editor;
+
+import org.sagebionetworks.web.client.DisplayConstants;
+import org.sagebionetworks.web.client.DisplayUtils;
+import org.sagebionetworks.web.shared.WebConstants;
+
+import com.extjs.gxt.ui.client.Style.VerticalAlignment;
+import com.extjs.gxt.ui.client.widget.HorizontalPanel;
+import com.extjs.gxt.ui.client.widget.Label;
+import com.extjs.gxt.ui.client.widget.LayoutContainer;
+import com.extjs.gxt.ui.client.widget.form.TextField;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.inject.Inject;
+
+public class BookmarkConfigViewImpl extends LayoutContainer implements BookmarkConfigView {
+	private Presenter presenter;
+	private TextField<String> linkTextField;
+	private TextField<String> bookmarkIdField;
+	
+	@Inject
+	public BookmarkConfigViewImpl() {
+	}
+	
+	@Override
+	public void initView() {
+		VerticalPanel vp = new VerticalPanel();
+		HorizontalPanel hp = new HorizontalPanel();
+		hp.setVerticalAlign(VerticalAlignment.MIDDLE);
+		linkTextField = new TextField<String>();
+		linkTextField.setAllowBlank(false);
+		Label linkTextLabel = new Label(DisplayConstants.LINK_TEXT_LABEL);
+		linkTextLabel.setWidth(70);
+		linkTextField.setWidth(270);
+		hp.add(linkTextLabel);
+		hp.add(linkTextField);
+		hp.addStyleName("margin-top-left-10");
+		vp.add(hp);
+		
+		hp = new HorizontalPanel();
+		hp.setVerticalAlign(VerticalAlignment.MIDDLE);
+		bookmarkIdField = new TextField<String>();
+		bookmarkIdField.setAllowBlank(false);
+		bookmarkIdField.setRegex(WebConstants.VALID_BOOKMARK_ID_REGEX);
+		bookmarkIdField.getMessages().setRegexText(DisplayConstants.ERROR_BOOKMARK_ID);
+		Label bookmarkIdLabel = new Label("Bookmark ID:");
+		bookmarkIdLabel.setWidth(70);
+		bookmarkIdField.setWidth(270);
+		hp.add(bookmarkIdLabel);
+		hp.add(bookmarkIdField);
+		hp.addStyleName("margin-top-left-10");
+		vp.add(hp);
+		
+		add(vp);
+	}
+
+	@Override
+	public int getDisplayHeight() {
+		return 60;
+	}
+
+	@Override
+	public int getAdditionalWidth() {
+		return 0;
+	}
+
+	@Override
+	public void checkParams() throws IllegalArgumentException {
+		if (!linkTextField.isValid()) {
+			throw new IllegalArgumentException(linkTextField.getErrorMessage());
+		} 
+		if (!bookmarkIdField.isValid()) {
+			throw new IllegalArgumentException(bookmarkIdField.getErrorMessage());
+		}
+	}
+
+	@Override
+	public void showLoading() {
+
+	}
+
+	@Override
+	public void showInfo(String title, String message) {
+		DisplayUtils.showInfo(title, message);
+	}
+
+	@Override
+	public void clear() {
+		if (linkTextField != null) {
+			linkTextField.setValue("");
+		}
+		if (bookmarkIdField != null) {
+			bookmarkIdField.setValue("");
+		}
+	}
+
+	@Override
+	public void setPresenter(Presenter presenter) {
+		this.presenter = presenter;
+	}
+
+	@Override
+	public void setLinkText(String linkText) {
+		linkTextField.setValue(linkText);
+	}
+
+	@Override
+	public String getLinkText() {
+		return linkTextField.getValue();
+	}
+
+	@Override
+	public void setTargetId(String targetId) {
+		bookmarkIdField.setValue(targetId);
+	}
+
+	@Override
+	public String getTargetId() {
+		return bookmarkIdField.getValue();
+	}
+
+	@Override
+	public void showErrorMessage(String message) {
+		DisplayUtils.showErrorMessage(message);
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/ButtonLinkConfigEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/ButtonLinkConfigEditor.java
@@ -39,7 +39,7 @@ public class ButtonLinkConfigEditor implements ButtonLinkConfigView.Presenter, W
 	public void updateDescriptorFromView() {
 		//update widget descriptor from the view
 		view.checkParams();
-		descriptor.put(WidgetConstants.BUTTON_LINK_TEXT_KEY, view.getName());
+		descriptor.put(WidgetConstants.TEXT_KEY, view.getName());
 		descriptor.put(WidgetConstants.BUTTON_LINK_URL_KEY, view.getLinkUrl());
 	}
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/ButtonLinkConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/ButtonLinkConfigViewImpl.java
@@ -63,7 +63,7 @@ public class ButtonLinkConfigViewImpl extends LayoutContainer implements ButtonL
 	
 	@Override
 	public void configure(WikiPageKey wikiKey, Map<String, String> descriptor) {
-		String text = descriptor.get(WidgetConstants.BUTTON_LINK_TEXT_KEY);
+		String text = descriptor.get(WidgetConstants.TEXT_KEY);
 		if (text != null)
 			nameField.setValue(text);
 		String url = descriptor.get(WidgetConstants.BUTTON_LINK_URL_KEY);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/LinkConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/LinkConfigViewImpl.java
@@ -46,7 +46,7 @@ public class LinkConfigViewImpl extends LayoutContainer implements LinkConfigVie
 		nameField.setName("Text");
 		nameField.setRegex(WebConstants.VALID_WIDGET_NAME_REGEX);
 		nameField.getMessages().setRegexText(DisplayConstants.ERROR_WIDGET_NAME_PATTERN_MISMATCH);
-		Label nameLabel = new Label("Link Text:");
+		Label nameLabel = new Label(DisplayConstants.LINK_TEXT_LABEL);
 		nameLabel.setWidth(60);
 		nameField.setWidth(270);
 		hp.add(nameLabel);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetConstants.java
@@ -4,6 +4,8 @@ package org.sagebionetworks.web.client.widget.entity.registration;
 public class WidgetConstants {
 	public static final String BOOKMARK_CONTENT_TYPE = "bookmark";
 	public static final String BOOKMARK_FRIENDLY_NAME = "Bookmark";
+	public static final String BOOKMARK_TARGET_CONTENT_TYPE = "bookmarktarget";
+	public static final String BOOKMARK_LINK_IDENTIFIER = "#Bookmark";
 	
 	public static final String YOUTUBE_CONTENT_TYPE = "youtube";
 	public static final String YOUTUBE_FRIENDLY_NAME = "YouTube";
@@ -100,7 +102,7 @@ public class WidgetConstants {
 	public static final int SHINYSITE_DEFAULT_HEIGHT_PX = 400;
 	
 	public static final String BUTTON_LINK_URL_KEY = "url";
-	public static final String BUTTON_LINK_TEXT_KEY = "text";
+	public static final String TEXT_KEY = "text";
 	
 	public static final String BOOKMARK_KEY = "bookmarkID";
 	public static final String REFERENCE_FOOTNOTE_KEY = "footnoteId";

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetConstants.java
@@ -2,6 +2,9 @@ package org.sagebionetworks.web.client.widget.entity.registration;
 
 
 public class WidgetConstants {
+	public static final String BOOKMARK_CONTENT_TYPE = "bookmark";
+	public static final String BOOKMARK_FRIENDLY_NAME = "Bookmark";
+	
 	public static final String YOUTUBE_CONTENT_TYPE = "youtube";
 	public static final String YOUTUBE_FRIENDLY_NAME = "YouTube";
 	
@@ -98,7 +101,9 @@ public class WidgetConstants {
 	
 	public static final String BUTTON_LINK_URL_KEY = "url";
 	public static final String BUTTON_LINK_TEXT_KEY = "text";
-		public static final String REFERENCE_FOOTNOTE_KEY = "footnoteId";
+	
+	public static final String BOOKMARK_KEY = "bookmarkID";
+	public static final String REFERENCE_FOOTNOTE_KEY = "footnoteId";
 	public static final String INLINE_WIDGET_KEY = "inlineWidget";	/**
 	 * API Table Column Renderers
 	 */

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
@@ -47,7 +47,9 @@ public class WidgetRegistrarImpl implements WidgetRegistrar {
 	public WidgetEditorPresenter getWidgetEditorForWidgetDescriptor(WikiPageKey wikiKey, String contentTypeKey, Map<String, String> model, boolean isWiki) { 
 		//use gin to create a new instance of the proper class.
 		WidgetEditorPresenter presenter = null;
-		if(contentTypeKey.equals(WidgetConstants.REFERENCE_CONTENT_TYPE)) {
+		if(contentTypeKey.equals(WidgetConstants.BOOKMARK_CONTENT_TYPE)) {
+			presenter = ginInjector.getBookmarkConfigEditor();
+		} else if(contentTypeKey.equals(WidgetConstants.REFERENCE_CONTENT_TYPE)) {
 			presenter = ginInjector.getReferenceConfigEditor();
 		} else if (contentTypeKey.equals(WidgetConstants.YOUTUBE_CONTENT_TYPE)) {
 			presenter = ginInjector.getYouTubeConfigEditor();

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/registration/WidgetRegistrarImpl.java
@@ -95,7 +95,9 @@ public class WidgetRegistrarImpl implements WidgetRegistrar {
 	public WidgetRendererPresenter getWidgetRendererForWidgetDescriptor(WikiPageKey wikiKey, String contentTypeKey, Map<String, String> model, boolean isWiki) { 
 		//use gin to create a new instance of the proper class.
 		WidgetRendererPresenter presenter = null;
-		if(contentTypeKey.equals(WidgetConstants.REFERENCE_CONTENT_TYPE)) {
+		if(contentTypeKey.equals(WidgetConstants.BOOKMARK_CONTENT_TYPE)) {
+			presenter = ginInjector.getBookmarkRenderer();
+		} else if(contentTypeKey.equals(WidgetConstants.REFERENCE_CONTENT_TYPE)) {
 			presenter = ginInjector.getReferenceRenderer();
 		} else if (contentTypeKey.equals(WidgetConstants.YOUTUBE_CONTENT_TYPE)) {
 			presenter = ginInjector.getYouTubeRenderer();
@@ -193,6 +195,7 @@ public class WidgetRegistrarImpl implements WidgetRegistrar {
 	}
 	
 	private void initWithKnownWidgets() {
+		registerWidget(WidgetConstants.BOOKMARK_CONTENT_TYPE, WidgetConstants.BOOKMARK_FRIENDLY_NAME);
 		registerWidget(WidgetConstants.REFERENCE_CONTENT_TYPE, WidgetConstants.REFERENCE_FRIENDLY_NAME);
 		registerWidget(WidgetConstants.YOUTUBE_CONTENT_TYPE, WidgetConstants.YOUTUBE_FRIENDLY_NAME);
 		registerWidget(WidgetConstants.PROVENANCE_CONTENT_TYPE, WidgetConstants.PROVENANCE_FRIENDLY_NAME);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidget.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.web.client.widget.entity.renderer;
+
+import java.util.Map;
+
+import org.sagebionetworks.web.client.widget.WidgetRendererPresenter;
+import org.sagebionetworks.web.client.widget.entity.registration.WidgetConstants;
+import org.sagebionetworks.web.shared.WikiPageKey;
+
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+
+public class BookmarkWidget implements BookmarkWidgetView.Presenter, WidgetRendererPresenter {
+	private BookmarkWidgetView view;
+	private Map<String, String> descriptor;
+	
+	@Override
+	public Widget asWidget() {
+		return view.asWidget();
+	}
+	
+	@Inject
+	public BookmarkWidget(BookmarkWidgetView view) {
+		this.view = view;
+		view.setPresenter(this);
+	}
+
+	@Override
+	public void configure(WikiPageKey wikiKey, Map<String, String> widgetDescriptor) {
+		descriptor = widgetDescriptor;
+		view.configure(descriptor.get(WidgetConstants.BOOKMARK_KEY), descriptor.get(WidgetConstants.BUTTON_LINK_TEXT_KEY));
+	}
+	
+	@SuppressWarnings("unchecked")
+	public void clearState() {
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidget.java
@@ -27,7 +27,7 @@ public class BookmarkWidget implements BookmarkWidgetView.Presenter, WidgetRende
 	@Override
 	public void configure(WikiPageKey wikiKey, Map<String, String> widgetDescriptor) {
 		descriptor = widgetDescriptor;
-		view.configure(descriptor.get(WidgetConstants.BOOKMARK_KEY), descriptor.get(WidgetConstants.BUTTON_LINK_TEXT_KEY));
+		view.configure(descriptor.get(WidgetConstants.BOOKMARK_KEY), descriptor.get(WidgetConstants.TEXT_KEY));
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidgetView.java
@@ -1,0 +1,19 @@
+package org.sagebionetworks.web.client.widget.entity.renderer;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface BookmarkWidgetView extends IsWidget {
+	/**
+	 * Set the presenter.
+	 * @param presenter
+	 */
+	public void setPresenter(Presenter presenter);
+	
+	public void configure(String bookmarkID, String bookmarkLinkText);
+	
+	/**
+	 * Presenter interface
+	 */
+	public interface Presenter {
+	}
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/BookmarkWidgetViewImpl.java
@@ -1,0 +1,59 @@
+package org.sagebionetworks.web.client.widget.entity.renderer;
+
+import org.sagebionetworks.web.shared.WebConstants;
+
+import com.extjs.gxt.ui.client.widget.LayoutContainer;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.inject.Inject;
+
+public class BookmarkWidgetViewImpl extends LayoutContainer implements BookmarkWidgetView {
+	private Presenter presenter;
+	private String bookmarkID;
+	private String bookmarkLinkText;
+	private boolean hasLoaded;
+	
+	@Inject
+	public BookmarkWidgetViewImpl() {
+	}
+	
+	@Override
+	public void setPresenter(Presenter presenter) {
+		this.presenter = presenter;		
+	}
+
+	@Override
+	public void configure(String bookmarkID, String bookmarkLinkText) {
+		this.removeAll();
+		this.bookmarkID = bookmarkID;
+		this.bookmarkLinkText = bookmarkLinkText;
+		hasLoaded = false;
+	}
+	
+	@Override
+	protected void onLoad() {
+		super.onLoad();
+		if(!hasLoaded) {
+			hasLoaded = true;
+			HTMLPanel parentPanel = (HTMLPanel)this.getParent();
+			Element heading = parentPanel.getElementById(bookmarkID);
+			final Element scrollToElement = heading;
+			Anchor a = new Anchor();
+			a.setHTML(bookmarkLinkText);
+			a.addStyleName("link");
+			a.addClickHandler(new ClickHandler() {
+				@Override
+				public void onClick(ClickEvent event) {
+					Window.scrollTo(0, scrollToElement.getOffsetTop());
+				}
+			});
+			add(a);
+			layout(true);		
+		}
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/ButtonLinkWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/ButtonLinkWidget.java
@@ -25,7 +25,7 @@ public class ButtonLinkWidget implements ButtonLinkWidgetView.Presenter, WidgetR
 	public void configure(final WikiPageKey wikiKey, final Map<String, String> widgetDescriptor) {
 		this.descriptor = widgetDescriptor;
 		String url = descriptor.get(WidgetConstants.BUTTON_LINK_URL_KEY);
-		String buttonText = descriptor.get(WidgetConstants.BUTTON_LINK_TEXT_KEY);
+		String buttonText = descriptor.get(WidgetConstants.TEXT_KEY);
 		view.configure(wikiKey, buttonText, url);
 		descriptor = widgetDescriptor;
 	}

--- a/src/main/java/org/sagebionetworks/web/server/ServerMarkdownUtils.java
+++ b/src/main/java/org/sagebionetworks/web/server/ServerMarkdownUtils.java
@@ -372,11 +372,15 @@ public class ServerMarkdownUtils {
 					StringBuilder sb = new StringBuilder();
 					int previousFoundIndex = 0;
 					boolean childFound = false;
+					boolean inlineWidget = false;
 					while (matcher.find()) {
 						childFound = true;
 						if (matcher.groupCount() == 2) {
 							sb.append(oldText.substring(previousFoundIndex, matcher.start()));
 							sb.append(SharedMarkdownUtils.getWidgetHTML(widgetsFound, suffix, matcher.group(2)));
+							if(matcher.group(2).contains("inlineWidget")) {
+								inlineWidget = true;
+							}
 							widgetsFound++;
 							previousFoundIndex = matcher.end(1);
 						}
@@ -385,7 +389,13 @@ public class ServerMarkdownUtils {
 						if (previousFoundIndex <= oldText.length() - 1)
 							// substring, go from the previously found index to the end
 							sb.append(oldText.substring(previousFoundIndex));
-						Element newElement = doc.createElement("div"); //wrap new html in a div, since it needs a container!					
+						//wrap new html in an appropriate tag, since it needs a container!
+						Element newElement;
+						if(inlineWidget) {
+							newElement = doc.createElement("span");
+						} else {
+							newElement = doc.createElement("div"); 					
+						}
 						newElement.html(sb.toString());
 						childNode.replaceWith(newElement);
 					}

--- a/src/main/java/org/sagebionetworks/web/server/SynapseMarkdownProcessor.java
+++ b/src/main/java/org/sagebionetworks/web/server/SynapseMarkdownProcessor.java
@@ -14,7 +14,7 @@ import org.jsoup.nodes.Document;
 import org.sagebionetworks.web.client.widget.entity.SharedMarkdownUtils;
 import org.sagebionetworks.web.server.markdownparser.BlockQuoteParser;
 import org.sagebionetworks.web.server.markdownparser.BoldParser;
-import org.sagebionetworks.web.server.markdownparser.BookmarkParser;
+import org.sagebionetworks.web.server.markdownparser.BookmarkTargetParser;
 import org.sagebionetworks.web.server.markdownparser.CodeParser;
 import org.sagebionetworks.web.server.markdownparser.CodeSpanParser;
 import org.sagebionetworks.web.server.markdownparser.HeadingParser;
@@ -57,8 +57,8 @@ public class SynapseMarkdownProcessor {
 	private void init() {
 		//initialize all markdown element parsers
 		allElementParsers.add(new BlockQuoteParser());
-		allElementParsers.add(new BoldParser());
-		allElementParsers.add(new BookmarkParser());		
+		allElementParsers.add(new BoldParser());	
+		allElementParsers.add(new BookmarkTargetParser());
 		codeParser = new CodeParser();
 		allElementParsers.add(codeParser);
 		allElementParsers.add(new CodeSpanParser());

--- a/src/main/java/org/sagebionetworks/web/server/SynapseMarkdownProcessor.java
+++ b/src/main/java/org/sagebionetworks/web/server/SynapseMarkdownProcessor.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.widget.entity.SharedMarkdownUtils;
 import org.sagebionetworks.web.server.markdownparser.BlockQuoteParser;
 import org.sagebionetworks.web.server.markdownparser.BoldParser;
+import org.sagebionetworks.web.server.markdownparser.BookmarkParser;
 import org.sagebionetworks.web.server.markdownparser.CodeParser;
 import org.sagebionetworks.web.server.markdownparser.CodeSpanParser;
 import org.sagebionetworks.web.server.markdownparser.HeadingParser;
@@ -48,6 +49,7 @@ public class SynapseMarkdownProcessor {
 		//initialize all markdown element parsers
 		allElementParsers.add(new BlockQuoteParser());
 		allElementParsers.add(new BoldParser());
+		allElementParsers.add(new BookmarkParser());
 		allElementParsers.add(new CodeParser());
 		allElementParsers.add(new CodeSpanParser());
 		allElementParsers.add(new HeadingParser());

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkParser.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkParser.java
@@ -1,0 +1,14 @@
+package org.sagebionetworks.web.server.markdownparser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BookmarkParser extends BasicMarkdownElementParser {
+	Pattern p1= Pattern.compile(MarkdownRegExConstants.BOOKMARK_REGEX);
+
+	@Override
+	public void processLine(MarkdownElements line) {
+		Matcher m = p1.matcher(line.getMarkdown());
+		line.updateMarkdown(m.replaceAll("<a id=\"$1\"></a>"));
+	}
+}

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkTargetParser.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkTargetParser.java
@@ -9,6 +9,6 @@ public class BookmarkTargetParser extends BasicMarkdownElementParser {
 	@Override
 	public void processLine(MarkdownElements line) {
 		Matcher m = p1.matcher(line.getMarkdown());
-		line.updateMarkdown(m.replaceAll("<a id=\"$1\"></a>"));
+		line.updateMarkdown(m.replaceAll("<p id=\"$1\"></p>"));
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkTargetParser.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/BookmarkTargetParser.java
@@ -3,8 +3,8 @@ package org.sagebionetworks.web.server.markdownparser;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class BookmarkParser extends BasicMarkdownElementParser {
-	Pattern p1= Pattern.compile(MarkdownRegExConstants.BOOKMARK_REGEX);
+public class BookmarkTargetParser extends BasicMarkdownElementParser {
+	Pattern p1= Pattern.compile(MarkdownRegExConstants.BOOKMARK_TARGET_REGEX);
 
 	@Override
 	public void processLine(MarkdownElements line) {

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/LinkParser.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/LinkParser.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.web.server.markdownparser;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.sagebionetworks.web.client.widget.entity.registration.WidgetConstants;
 
 public class LinkParser extends BasicMarkdownElementParser  {
@@ -10,7 +11,7 @@ public class LinkParser extends BasicMarkdownElementParser  {
 	@Override
 	public void processLine(MarkdownElements line) {
 		String input = line.getMarkdown();
-		String bookmarkTarget = "#Bookmark:";
+		String bookmarkTarget = WidgetConstants.BOOKMARK_LINK_IDENTIFIER + ":";
 		Matcher m = p1.matcher(input);
 		StringBuffer sb = new StringBuffer();
 		while(m.find()) {
@@ -21,8 +22,10 @@ public class LinkParser extends BasicMarkdownElementParser  {
 			//If the "url" targets a bookmarked element in the page, replace it with widget syntax 
 			//for the renderer to attach a handler
 			if(url.contains(bookmarkTarget)) {
-				updated = "${" + WidgetConstants.BOOKMARK_CONTENT_TYPE + "?text=" + text + "&" + WidgetConstants.INLINE_WIDGET_KEY + "=true&" +
-								WidgetConstants.BOOKMARK_KEY + "=" + url.substring(bookmarkTarget.length()) + "}";		
+				updated = WidgetConstants.WIDGET_START_MARKDOWN + WidgetConstants.BOOKMARK_CONTENT_TYPE + "?" + 
+				WidgetConstants.TEXT_KEY + "=" + text + "&" + WidgetConstants.INLINE_WIDGET_KEY + "=true&" + WidgetConstants.BOOKMARK_KEY + "=" +
+				url.substring(bookmarkTarget.length()) + WidgetConstants.WIDGET_END_MARKDOWN;			
+
 			} else {
 				updated = "<a class=\"link\" target=\"_blank\" href=\"" + url + "\">" + text + "</a>";
 			}

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/LinkParser.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/LinkParser.java
@@ -2,13 +2,36 @@ package org.sagebionetworks.web.server.markdownparser;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.sagebionetworks.web.client.widget.entity.registration.WidgetConstants;
 
 public class LinkParser extends BasicMarkdownElementParser  {
 	Pattern p1= Pattern.compile(MarkdownRegExConstants.LINK_REGEX, Pattern.DOTALL);
 
 	@Override
 	public void processLine(MarkdownElements line) {
-		Matcher m = p1.matcher(line.getMarkdown());
-		line.updateMarkdown(m.replaceAll("<a class=\"link\" target=\"_blank\" href=\"$3\">$2</a>"));
+		String input = line.getMarkdown();
+		String bookmarkTarget = "#Bookmark:";
+		Matcher m = p1.matcher(input);
+		StringBuffer sb = new StringBuffer();
+		while(m.find()) {
+			String text = input.substring(m.start(2), m.end(2));
+			String url = input.substring(m.start(3), m.end(3));
+			String updated;
+			
+			//If the "url" targets a bookmarked element in the page, replace it with widget syntax 
+			//for the renderer to attach a handler
+			if(url.contains(bookmarkTarget)) {
+				updated = "${" + WidgetConstants.BOOKMARK_CONTENT_TYPE + "?text=" + text + "&" + WidgetConstants.INLINE_WIDGET_KEY + "=true&" +
+								WidgetConstants.BOOKMARK_KEY + "=" + url.substring(bookmarkTarget.length()) + "}";		
+			} else {
+				updated = "<a class=\"link\" target=\"_blank\" href=\"" + url + "\">" + text + "</a>";
+			}
+			
+			//Escape the replacement string for appendReplacement
+			updated = Matcher.quoteReplacement(updated);
+			m.appendReplacement(sb, updated);
+		}
+		m.appendTail(sb);
+		line.updateMarkdown(sb.toString());
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/MarkdownRegExConstants.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/MarkdownRegExConstants.java
@@ -24,9 +24,9 @@ public class MarkdownRegExConstants {
 	
 	/**
 	 * Recognizes example input:
-	 * [bookmarkID=subject1] Subject 1
+	 * ${bookmarktarget?bookmarkID=subject1} Subject 1
 	 */
-	public static final String BOOKMARK_REGEX = "\\[bookmarkID=(.+?)\\]";
+	public static final String BOOKMARK_TARGET_REGEX = "\\$\\{bookmarktarget\\?bookmarkID=(.+?)\\}";
 	
 	/**
 	 * Recognized example input:
@@ -98,7 +98,7 @@ public class MarkdownRegExConstants {
 	
 	/**
 	 * Recognized example input:
-	 * -striked out text-
+	 * --striked out text--
 	 */
 	public static final String STRIKE_OUT_REGEX = "--(?=\\S)(.+?)(?<=\\S)--";
 	

--- a/src/main/java/org/sagebionetworks/web/server/markdownparser/MarkdownRegExConstants.java
+++ b/src/main/java/org/sagebionetworks/web/server/markdownparser/MarkdownRegExConstants.java
@@ -23,6 +23,12 @@ public class MarkdownRegExConstants {
 	public static final String BOLD_REGEX = "(\\*\\*|__)(?=\\S)(.+?[*_]*)(?<=\\S)\\1";
 	
 	/**
+	 * Recognizes example input:
+	 * [bookmarkID=subject1] Subject 1
+	 */
+	public static final String BOOKMARK_REGEX = "\\[bookmarkID=(.+?)\\]";
+	
+	/**
 	 * Recognized example input:
 	 * ``` <optional language>
 	 * This is a code block

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -74,8 +74,8 @@ public class WebConstants {
 	public static final String SYNAPSE_MARKDOWN_FORMATTING_TIPS_HTML = "<div style=\"margin-left:20px\"><br><br>" +
 			"<h3>Phrase Emphasis</h3><pre><code>*italic*   **bold**<br>_italic_   __bold__<br>--strike out--<br></code></pre><br>" +
 			"<h3>Subscript/Superscript</h3><pre><code>~subscript~  ^superscript^<br></code></pre><br>" +
-			"<h3>Links</h3><pre><code>http://sagebase.org - automatic!</code></pre><pre><code>syn12345 - automatic!</code></pre><pre><code>An [example](http://url.com/)</code></pre><pre><code>Custom Synapse ID link text:<br>[my text](#Synapse:syn12345)</code></pre><br>" +
-			"<h3>Tables</h3><pre><code>Row 1 Content Cell 1 | Row 1 Content Cell 2  | Row 1 Content Cell 3<br>Row 2 Content Cell 1  | Row 2 Content Cell 2  | Row 2 Content Cell 3</code></pre><br>" +
+			"<h3>Links</h3><pre><code>http://sagebase.org - automatic!</code></pre><pre><code>syn12345 - automatic!</code></pre><pre><code>An [example](http://url.com/)</code></pre><pre><code>Custom Synapse ID link text:<br>[my text](#Synapse:syn12345)</code></pre></pre><pre><code>Bookmarks within page<br>To create bookmark: [bookmarkID=yourID]<br>To link to bookmark: [my text](#Bookmark:yourID)</code></pre><br>" +
+			"<h3>Tables</h3><pre><code>Row 1 Content Cell 1 | Row 1 Content Cell 2  | Row 1 Content Cell 3<br>Row 2 Content Cell 1  | Row 2 Content Cell 2  | Row 2 Content Cell 3</code><br>" +
 			"<h3>Images</h3><pre><code>![alt text](http://path/to/img.jpg)</code></pre><br>" +
 			"<h3>Headers</h3><p><pre><code># Header 1<br>## Header 2<br>###### Header 6<br></code></pre></p><p>Exclude a header from the table of contents:<pre><code>#! Header 1 <br>##! Header 2<br>######! Header 6</code></pre></p><br>" +
 			"<h3>Lists</h3><p>Ordered, without paragraphs:<pre><code>1.  List item one<br>2.  List item two<br></code></pre></p><p>Unordered, with paragraphs:<pre><code>*   A list item.<br>    With multiple paragraphs.<br>*   Another list item<br></code></pre></p><p>You can nest them:<pre><code>*   Abacus<br>    * answer<br>*   Bubbles<br>    1.  bunk<br>    2.  bupkis<br>        * BELITTLER<br>    3. burper<br>*   Cunning<br></code></pre></p><br>" +

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -40,6 +40,7 @@ public class WebConstants {
 	public static final String VALID_WIDGET_NAME_REGEX = "^"+WIDGET_NAME_REGEX+"+";
 	public static final String VALID_ENTITY_ID_REGEX = "^[Ss]{1}[Yy]{1}[Nn]{1}\\d+";
 	public static final String VALID_POSITIVE_NUMBER_REGEX = "^[0-9]+";
+	public static final String VALID_BOOKMARK_ID_REGEX = "[_A-Za-z0-9-.[^\\s]]+";
 	
 	// OpenID related constants
 
@@ -74,7 +75,7 @@ public class WebConstants {
 	public static final String SYNAPSE_MARKDOWN_FORMATTING_TIPS_HTML = "<div style=\"margin-left:20px\"><br><br>" +
 			"<h3>Phrase Emphasis</h3><pre><code>*italic*   **bold**<br>_italic_   __bold__<br>--strike out--<br></code></pre><br>" +
 			"<h3>Subscript/Superscript</h3><pre><code>~subscript~  ^superscript^<br></code></pre><br>" +
-			"<h3>Links</h3><pre><code>http://sagebase.org - automatic!</code></pre><pre><code>syn12345 - automatic!</code></pre><pre><code>An [example](http://url.com/)</code></pre><pre><code>Custom Synapse ID link text:<br>[my text](#Synapse:syn12345)</code></pre></pre><pre><code>Bookmarks within page<br>To create bookmark: [bookmarkID=yourID]<br>To link to bookmark: [my text](#Bookmark:yourID)</code></pre><br>" +
+			"<h3>Links</h3><pre><code>http://sagebase.org - automatic!</code></pre><pre><code>syn12345 - automatic!</code></pre><pre><code>An [example](http://url.com/)</code></pre><pre><code>Custom Synapse ID link text:<br>[my text](#Synapse:syn12345)</code></pre></pre><pre><code>Bookmarks within page<br>To create bookmark target: ${bookmarktarget?bookmarkID=myid}<br>To link to bookmark: [my text](#Bookmark:myid)</code></pre><br>" +
 			"<h3>Tables</h3><pre><code>Row 1 Content Cell 1 | Row 1 Content Cell 2  | Row 1 Content Cell 3<br>Row 2 Content Cell 1  | Row 2 Content Cell 2  | Row 2 Content Cell 3</code><br>" +
 			"<h3>Images</h3><pre><code>![alt text](http://path/to/img.jpg)</code></pre><br>" +
 			"<h3>Headers</h3><p><pre><code># Header 1<br>## Header 2<br>###### Header 6<br></code></pre></p><p>Exclude a header from the table of contents:<pre><code>#! Header 1 <br>##! Header 2<br>######! Header 6</code></pre></p><br>" +

--- a/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/BookmarkTargetParserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/BookmarkTargetParserTest.java
@@ -1,0 +1,25 @@
+package org.sagebionetworks.web.unitserver.markdownparser;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sagebionetworks.web.server.markdownparser.BookmarkTargetParser;
+import org.sagebionetworks.web.server.markdownparser.MarkdownElements;
+
+public class BookmarkTargetParserTest {
+	BookmarkTargetParser parser;
+	
+	@Before
+	public void setup() {
+		parser = new BookmarkTargetParser();
+	}
+	
+	@Test
+	public void testBookmarkTarget() {
+		String text = "${bookmarktarget?bookmarkID=head2} Heading 2";
+		MarkdownElements elements = new MarkdownElements(text);
+		parser.processLine(elements);
+		assertTrue(elements.getHtml().contains("<a id=\"head2\"></a>"));
+	}
+}

--- a/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/BookmarkTargetParserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/BookmarkTargetParserTest.java
@@ -20,6 +20,6 @@ public class BookmarkTargetParserTest {
 		String text = "${bookmarktarget?bookmarkID=head2} Heading 2";
 		MarkdownElements elements = new MarkdownElements(text);
 		parser.processLine(elements);
-		assertTrue(elements.getHtml().contains("<a id=\"head2\"></a>"));
+		assertTrue(elements.getHtml().contains("<p id=\"head2\"></p>"));
 	}
 }

--- a/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/LinkParserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/markdownparser/LinkParserTest.java
@@ -16,7 +16,7 @@ public class LinkParserTest {
 	}
 	
 	@Test
-	public void testBold(){
+	public void testLink(){
 		String text = "This Is A Test";
 		String href = "http://example.com";
 		String line = "[" + text + "](" + href +")";
@@ -26,5 +26,15 @@ public class LinkParserTest {
 		assertTrue(result.contains("<a"));
 		assertTrue(result.contains("href=\"" + href));
 		assertTrue(result.contains(text));
+	}
+	
+	@Test
+	public void testBookmarkAndLink() {
+		String line = "I want to refer to [this](#Bookmark:subject1). To see official page, go [here](http://example.com).";
+		MarkdownElements elements = new MarkdownElements(line);
+		parser.processLine(elements);
+		String result = elements.getHtml();
+		assertTrue(result.contains("${bookmark?text=this&inlineWidget=true&bookmarkID=subject1}"));
+		assertTrue(result.contains("<a class=\"link\" target=\"_blank\" href=\"http://example.com\">here</a>"));
 	}
 }


### PR DESCRIPTION
Changed the container to a span for widgets that need to be inline because reference links/bookmark links would not properly inline when adjacent to other (inline) elements like links, bolded terms etc.
