### PR TITLE
Non-generic java client methods

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -628,8 +628,12 @@ public class SynapseClientImpl extends RemoteServiceServlet implements
 	public String getUserProfile(String userId) throws RestServiceException {
 		try {
 			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
-			String targetUserId = userId == null ? "" : "/"+userId;
-			UserProfile profile = synapseClient.getUserProfile(targetUserId);
+			UserProfile profile;
+			if (userId == null) {
+				profile = synapseClient.getMyProfile();
+			} else {
+				profile = synapseClient.getUserProfile(userId);
+			}
 			return EntityFactory.createJSONStringForEntity(profile);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -629,10 +629,12 @@ public class SynapseClientImpl extends RemoteServiceServlet implements
 		try {
 			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 			String targetUserId = userId == null ? "" : "/"+userId;
-			JSONObject userProfile = synapseClient.getSynapseEntity(urlProvider.getRepositoryServiceUrl(), "/userProfile"+targetUserId);
-			return userProfile.toString();
+			UserProfile profile = synapseClient.getUserProfile(targetUserId);
+			return EntityFactory.createJSONStringForEntity(profile);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
+		} catch (JSONObjectAdapterException e) {
+			throw new UnknownErrorException(e.getMessage());
 		} 
 	}
 	
@@ -691,9 +693,8 @@ public class SynapseClientImpl extends RemoteServiceServlet implements
 					}
 				}
 			    profile.setPic(pic);
-				userProfileJSONObject = EntityFactory.createJSONObjectForEntity(profile);
 			}
-			synapseClient.putJSONObject("/userProfile", userProfileJSONObject, null);				
+			synapseClient.updateMyProfile(profile);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		} catch (JSONException e) {

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -496,7 +496,7 @@ public class SynapseClientImplTest {
 		String testRepoUrl = "http://mytestrepourl";
 		String testUserId = "myUserId";
 		when(mockUrlProvider.getRepositoryServiceUrl()).thenReturn(testRepoUrl);
-		when(mockSynapse.getUserProfile(testUserId)).thenReturn(testUserProfile);
+		when(mockSynapse.getUserProfile(eq(testUserId))).thenReturn(testUserProfile);
 		String userProfile = synapseClient.getUserProfile(testUserId);
 		assertEquals(userProfile, EntityFactory.createJSONStringForEntity(testUserProfile));
 	}

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -491,13 +491,14 @@ public class SynapseClientImplTest {
 	@Test
 	public void testGetUserProfile() throws Exception {
 		//verify call is directly calling the synapse client provider
-		JSONObject testUserJSONObject = new JSONObject("{ username: \"Test User\"}");
+		UserProfile testUserProfile = new UserProfile();
+		testUserProfile.setUserName("Test User");
 		String testRepoUrl = "http://mytestrepourl";
 		String testUserId = "myUserId";
 		when(mockUrlProvider.getRepositoryServiceUrl()).thenReturn(testRepoUrl);
-		when(mockSynapse.getSynapseEntity(testRepoUrl, "/userProfile/" + testUserId)).thenReturn(testUserJSONObject);
+		when(mockSynapse.getUserProfile(testUserId)).thenReturn(testUserProfile);
 		String userProfile = synapseClient.getUserProfile(testUserId);
-		assertEquals(userProfile, testUserJSONObject.toString());
+		assertEquals(userProfile, EntityFactory.createJSONStringForEntity(testUserProfile));
 	}
 	
 	@Test


### PR DESCRIPTION
Small correction for two methods that use generic calls even though non-generic calls are available.

Note: this pull request does _not_ require a change to the pom.
