### PR TITLE
Open ID fixes

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/UserAccountService.java
+++ b/src/main/java/org/sagebionetworks/web/client/UserAccountService.java
@@ -39,4 +39,6 @@ public interface UserAccountService extends RemoteService {
 	public void changeEmailAddress(String changeEmailToken, String newPassword);
 	
 	public String getStorageUsage();
+	
+	public String acceptTermsOfUse(String sessionToken);
 }

--- a/src/main/java/org/sagebionetworks/web/client/UserAccountServiceAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/UserAccountServiceAsync.java
@@ -57,4 +57,9 @@ public interface UserAccountServiceAsync {
 	 * return the StorageUsageSummaryList json for the current user
 	 */
 	void getStorageUsage(AsyncCallback<String> callback);
+	
+	/**
+	 * Accepts the terms of use for a user, as identified by the session token
+	 */
+	void acceptTermsOfUse(String sessionToken, AsyncCallback<String> callback);
 }

--- a/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
@@ -1,9 +1,7 @@
 package org.sagebionetworks.web.client.presenter;
 
-import org.sagebionetworks.repo.model.ServiceConstants;
 import org.sagebionetworks.repo.model.UserSessionData;
 import org.sagebionetworks.web.client.ClientProperties;
-import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
@@ -17,7 +15,6 @@ import org.sagebionetworks.web.client.transform.NodeModelCreator;
 import org.sagebionetworks.web.client.view.LoginView;
 import org.sagebionetworks.web.client.widget.login.AcceptTermsOfUseCallback;
 import org.sagebionetworks.web.shared.WebConstants;
-import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.shared.exceptions.TermsOfUseException;
 
 import com.google.gwt.activity.shared.AbstractActivity;
@@ -111,7 +108,7 @@ public class LoginPresenter extends AbstractActivity implements LoginView.Presen
 			// parse token
 			view.showLoggingInLoader();
 			if(token != null) {
-				String sessionToken = token;	
+				final String sessionToken = token;	
 				authenticationController.loginUserSSO(sessionToken, new AsyncCallback<String>() {	
 					@Override
 					public void onSuccess(String result) {
@@ -130,7 +127,21 @@ public class LoginPresenter extends AbstractActivity implements LoginView.Presen
 								public void onSuccess(String termsOfUseContents) {
 									view.showTermsOfUse(termsOfUseContents, 
 											new AcceptTermsOfUseCallback() {
-												public void accepted() {showView(place);}
+												public void accepted() {
+													// Since this is an SSO request, to tell Repo that the terms have been accepted,
+													// the user can either redo the SSO-process or perform this call with the session token
+													authenticationController.acceptTermsOfUse(sessionToken, new AsyncCallback<String>() {
+														@Override
+														public void onSuccess(String result) {}
+														
+														@Override
+														public void onFailure(Throwable caught) {
+															if(!DisplayUtils.checkForRepoDown(caught, globalApplicationState.getPlaceChanger(), view)) 
+																view.showErrorMessage("An error occurred. Please try logging in again.");
+														}
+													}, true);
+													showView(place);
+												}
 											});		
 								}
 								public void onFailure(Throwable t) {

--- a/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
@@ -122,7 +122,7 @@ public class LoginPresenter extends AbstractActivity implements LoginView.Presen
 							view.showLogin(openIdActionUrl, openIdReturnUrl);
 							return;
 						}
-						if (caught instanceof TermsOfUseException) {
+						if (caught.getMessage().contains("Terms of use have not been signed")) {
 							authenticationController.getTermsOfUse(new AsyncCallback<String>() {
 								public void onSuccess(String termsOfUseContents) {
 									view.showTermsOfUse(termsOfUseContents, 

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationController.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.web.client.security;
 
 import org.sagebionetworks.repo.model.UserSessionData;
-import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
@@ -9,22 +8,16 @@ public interface AuthenticationController {
 		
 	/**
 	 * Login the user
-	 * @param username
-	 * @param password
-	 * @return
 	 */
 	public void loginUser(String username, String password, boolean explicitlyAcceptsTermsOfUse, AsyncCallback<String> callback);
 	
 	/**
 	 * Logs in the user represented by the token
-	 * @param token
 	 */
 	public void loginUser(String token, AsyncCallback<String> callback);
 	
 	/**
 	 * Sets the current user 
-	 * @param displayName
-	 * @param token
 	 */
 	public void loginUserSSO(String token, AsyncCallback<String> callback);
 	
@@ -33,34 +26,34 @@ public interface AuthenticationController {
 	 */
 	public void logoutUser();
 	
+	/**
+	 * Uses the session token to accept the terms of use
+	 */
+	public void acceptTermsOfUse(String token, AsyncCallback<String> callback,  boolean isSSO);
+	
 
 	/**
 	 * Is the user logged in?
-	 * @return
 	 */
 	public boolean isLoggedIn();
 	
 	/**
 	 * Get the OwnerId/Principal id out of the UserProfile / UserSessionData in a lightweight fashion
-	 * @return
 	 */
 	public String getCurrentUserPrincipalId();
 
 	/**
 	 * Get the current session token, if there is one
-	 * @return
 	 */
 	public String getCurrentUserSessionToken();
 	
 	/**
 	 * Get the current SSO status
-	 * @return
 	 */
 	public boolean getCurrentUserIsSSO();		
 	
 	/**
 	 * Get the UserSessionData object 
-	 * @return
 	 */
 	public UserSessionData getCurrentUserSessionData();
 

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -125,6 +125,35 @@ public class AuthenticationControllerImpl implements AuthenticationController {
 			}
 		});		
 	}
+	
+	@Override
+	public void acceptTermsOfUse(String token, final AsyncCallback<String> callback, final boolean isSSO) {
+		if (token == null) {
+			callback.onFailure(new IllegalArgumentException("Session token must be provided"));
+		}
+		
+		userAccountService.acceptTermsOfUse(token, new AsyncCallback<String>() {
+			@Override
+			public void onSuccess(String nothing) {
+				try {
+					UserSessionData userSessionData = new UserSessionData();
+					userSessionData.setIsSSO(isSSO);
+					JSONObjectAdapter usdAdapter = userSessionData.writeToJSONObject(adapterFactory.createNew());
+					Date tomorrow = getDayFromNow();
+					cookies.setCookie(CookieKeys.USER_LOGIN_DATA, usdAdapter.toJSONString(), tomorrow);
+					cookies.setCookie(CookieKeys.USER_LOGIN_TOKEN, userSessionData.getSessionToken(), tomorrow);
+					currentUser = userSessionData;
+				} catch (JSONObjectAdapterException e){
+					callback.onFailure(e);
+				}
+			}
+			
+			@Override
+			public void onFailure(Throwable caught) {
+				callback.onFailure(caught);
+			}
+		});
+	}
 
 	@Override
 	public void getTermsOfUse(AsyncCallback<String> callback) {

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -121,7 +121,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
 			
 			@Override
 			public void onFailure(Throwable caught) {
-				callback.onFailure(new AuthenticationException(AUTHENTICATION_MESSAGE));
+				callback.onFailure(caught);
 			}
 		});		
 	}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/UserAccountServiceImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/UserAccountServiceImpl.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.repo.model.PaginatedResults;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserSessionData;
+import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.schema.adapter.org.json.EntityFactory;
 import org.sagebionetworks.web.client.UserAccountService;
@@ -19,6 +20,7 @@ import org.sagebionetworks.web.client.security.AuthenticationException;
 import org.sagebionetworks.web.server.RestTemplateProvider;
 import org.sagebionetworks.web.shared.PublicPrincipalIds;
 import org.sagebionetworks.web.shared.exceptions.BadRequestException;
+import org.sagebionetworks.web.shared.exceptions.ExceptionUtil;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.shared.exceptions.TermsOfUseException;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
@@ -577,6 +579,19 @@ public class UserAccountServiceImpl extends RemoteServiceServlet implements User
 			}
 		}
 		return publicPrincipalIds;
+	}
+
+	@Override
+	public String acceptTermsOfUse(String sessionToken) {
+		SynapseClient anonymousClient = createAnonymousSynapseClient();
+		Session session = new Session();
+		session.setSessionToken(sessionToken);
+		try {
+			anonymousClient.acceptTermsOfUse(session);
+		} catch (SynapseException e) {
+			ExceptionUtil.convertSynapseException(e);
+		}
+		return null;
 	}
 	
 	public static void initPublicAndAuthenticatedPrincipalIds(SynapseClient synapseClient, String anonymousPrincipalId) {

--- a/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.web.server.servlet.openid;
 
-import static org.sagebionetworks.web.shared.WebConstants.OPEN_ID_PROVIDER_GOOGLE_VALUE;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -19,22 +17,12 @@ import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.web.shared.WebConstants;
 
 public class OpenIDUtils {
-	public static final String OPEN_ID_PROVIDER_GOOGLE_ENDPOINT = "https://www.google.com/accounts/o8/id";
 	public static final String OPENID_CALLBACK_URI = "/Portal/openidcallback";
 	
 	public static final String ACCEPTS_TERMS_OF_USE_COOKIE_NAME = "sagebionetworks.acceptsTermsOfUse";
 	public static final String RETURN_TO_URL_COOKIE_NAME = "sagebionetworks.returnToUrl";
 	public static final String REDIRECT_MODE_COOKIE_NAME = "sagebionetworks.redirectMode";
 	public static final int COOKIE_MAX_AGE_SECONDS = 60;
-	
-	/**
-	 * This maps allowed provider names to their OpenID endpoints
-	 * At this time only Google is supported
-	 */
-	private static String getOpenIdProviderURLforName(String name) {
-		if (name.equals(OPEN_ID_PROVIDER_GOOGLE_VALUE)) return OPEN_ID_PROVIDER_GOOGLE_ENDPOINT;
-		throw new IllegalArgumentException(name);
-	}
 	
 	/**
 	 * @param redirectEndpoint  this is the end point to which the OpenID provider should redirect
@@ -45,8 +33,6 @@ public class OpenIDUtils {
 			HttpServletRequest request, HttpServletResponse response,
 			String redirectEndpoint) throws IOException, ServletException,
 			OpenIDException, URISyntaxException {
-		
-		String openIdProvider = getOpenIdProviderURLforName(openIdProviderName);
 
 		// Stash info that the portal needs in cookies
 		Cookie cookie = new Cookie(RETURN_TO_URL_COOKIE_NAME, returnToURL);
@@ -65,7 +51,7 @@ public class OpenIDUtils {
 		
 		// Get the redirect
 		String openIDCallbackURL = redirectEndpoint + OPENID_CALLBACK_URI;
-		String redirectURL = OpenIDConsumerUtils.authRequest(openIdProvider, openIDCallbackURL);
+		String redirectURL = OpenIDConsumerUtils.authRequest(WebConstants.OPEN_ID_PROVIDER_GOOGLE_VALUE, openIDCallbackURL);
 		
 		// Send the user off to the next part of the handshake
 		response.sendRedirect(redirectURL);
@@ -137,6 +123,7 @@ public class OpenIDUtils {
 		
 		try {
 			// Send all the Open ID info to the repository services
+			System.out.println(URLDecoder.decode(request.getQueryString(), "UTF-8"));
 			Session session = synapse.passThroughOpenIDParameters(
 					URLDecoder.decode(request.getQueryString(), "UTF-8"), 
 					acceptsTermsOfUse);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
@@ -43,7 +43,7 @@ public class OpenIDUtils {
 		cookie.setMaxAge(COOKIE_MAX_AGE_SECONDS);
 		response.addCookie(cookie);
 		
-		if (redirectMode!=null) {
+		if (redirectMode != null) {
 			cookie = new Cookie(REDIRECT_MODE_COOKIE_NAME, redirectMode);
 			cookie.setMaxAge(COOKIE_MAX_AGE_SECONDS);
 			response.addCookie(cookie);
@@ -58,34 +58,29 @@ public class OpenIDUtils {
 	}
 	
 	public static String createRedirectURL(String returnToURL,
-			String sessionToken, boolean crowdAcceptsTermsOfUse,
+			String sessionToken, boolean acceptsTermsOfUse,
 			boolean isGWTMode) throws URISyntaxException {
-		String redirectUrl = null;
-		if (isGWTMode) {
-			redirectUrl = returnToURL+":";
-			if (crowdAcceptsTermsOfUse) {
-				redirectUrl += sessionToken;
-			} else {
-				redirectUrl += WebConstants.ACCEPTS_TERMS_OF_USE_REQUIRED_TOKEN;
-			}
-		} else {
-			if (crowdAcceptsTermsOfUse) {
+		String redirectUrl = returnToURL + ":" + sessionToken;
+		
+		if (!isGWTMode) {
+			if (acceptsTermsOfUse) {
 				redirectUrl = OpenIDConsumerUtils.addRequestParameter(returnToURL, "status=OK&sessionToken="+sessionToken);
 			} else {
 				redirectUrl = OpenIDConsumerUtils.addRequestParameter(returnToURL, "status=" + WebConstants.ACCEPTS_TERMS_OF_USE_REQUIRED_TOKEN);
 			}
 		}
+		
 		return redirectUrl;
 	}
 
 	public static String createErrorRedirectURL(String returnToURL,
 			boolean isGWTMode) throws URISyntaxException {
-		String redirectUrl = null;
-		if (isGWTMode) {
-			redirectUrl = returnToURL + ":" + WebConstants.OPEN_ID_ERROR_TOKEN;
-		} else {
+		String redirectUrl = returnToURL + ":" + WebConstants.OPEN_ID_ERROR_TOKEN;;
+
+		if (!isGWTMode) {
 			redirectUrl = OpenIDConsumerUtils.addRequestParameter(returnToURL, "status=" + WebConstants.OPEN_ID_ERROR_TOKEN);
 		}
+		
 		return redirectUrl;
 	}
 
@@ -123,7 +118,6 @@ public class OpenIDUtils {
 		
 		try {
 			// Send all the Open ID info to the repository services
-			System.out.println(URLDecoder.decode(request.getQueryString(), "UTF-8"));
 			Session session = synapse.passThroughOpenIDParameters(
 					URLDecoder.decode(request.getQueryString(), "UTF-8"), 
 					acceptsTermsOfUse);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/openid/OpenIDUtils.java
@@ -4,14 +4,15 @@ import static org.sagebionetworks.web.shared.WebConstants.OPEN_ID_PROVIDER_GOOGL
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.openid4java.OpenIDException;
 import org.sagebionetworks.authutil.OpenIDConsumerUtils;
-import org.sagebionetworks.authutil.OpenIDInfo;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.auth.Session;
@@ -20,6 +21,11 @@ import org.sagebionetworks.web.shared.WebConstants;
 public class OpenIDUtils {
 	public static final String OPEN_ID_PROVIDER_GOOGLE_ENDPOINT = "https://www.google.com/accounts/o8/id";
 	public static final String OPENID_CALLBACK_URI = "/Portal/openidcallback";
+	
+	public static final String ACCEPTS_TERMS_OF_USE_COOKIE_NAME = "sagebionetworks.acceptsTermsOfUse";
+	public static final String RETURN_TO_URL_COOKIE_NAME = "sagebionetworks.returnToUrl";
+	public static final String REDIRECT_MODE_COOKIE_NAME = "sagebionetworks.redirectMode";
+	public static final int COOKIE_MAX_AGE_SECONDS = 60;
 	
 	/**
 	 * This maps allowed provider names to their OpenID endpoints
@@ -41,18 +47,27 @@ public class OpenIDUtils {
 			OpenIDException, URISyntaxException {
 		
 		String openIdProvider = getOpenIdProviderURLforName(openIdProviderName);
+
+		// Stash info that the portal needs in cookies
+		Cookie cookie = new Cookie(RETURN_TO_URL_COOKIE_NAME, returnToURL);
+		cookie.setMaxAge(COOKIE_MAX_AGE_SECONDS);
+		response.addCookie(cookie);
 		
-		// Build up a return URL 
-		String openIDCallbackURL = redirectEndpoint + OPENID_CALLBACK_URI;
-		openIDCallbackURL = OpenIDConsumerUtils.addRequestParameter(returnToURL, OpenIDInfo.ACCEPTS_TERMS_OF_USE_PARAM_NAME + "=" + acceptsTermsOfUse);
-		if (redirectMode != null) {
-			openIDCallbackURL = OpenIDConsumerUtils.addRequestParameter(returnToURL, OpenIDInfo.REDIRECT_MODE_PARAM_NAME + "=" + redirectMode);
+		cookie = new Cookie(ACCEPTS_TERMS_OF_USE_COOKIE_NAME, ""+acceptsTermsOfUse);
+		cookie.setMaxAge(COOKIE_MAX_AGE_SECONDS);
+		response.addCookie(cookie);
+		
+		if (redirectMode!=null) {
+			cookie = new Cookie(REDIRECT_MODE_COOKIE_NAME, redirectMode);
+			cookie.setMaxAge(COOKIE_MAX_AGE_SECONDS);
+			response.addCookie(cookie);
 		}
 		
-		// Note: this must be the last parameter to be added
-		openIDCallbackURL = OpenIDConsumerUtils.addRequestParameter(returnToURL, OpenIDInfo.RETURN_TO_URL_PARAM_NAME + "=" + openIDCallbackURL);
-		
+		// Get the redirect
+		String openIDCallbackURL = redirectEndpoint + OPENID_CALLBACK_URI;
 		String redirectURL = OpenIDConsumerUtils.authRequest(openIdProvider, openIDCallbackURL);
+		
+		// Send the user off to the next part of the handshake
 		response.sendRedirect(redirectURL);
 	}
 	
@@ -100,9 +115,19 @@ public class OpenIDUtils {
 			SynapseUnauthorizedException {
 		Boolean isGWTMode = null;
 		
-		String returnToURL = request.getParameter(OpenIDInfo.RETURN_TO_URL_PARAM_NAME);
-		String redirectMode = request.getParameter(OpenIDInfo.REDIRECT_MODE_PARAM_NAME);
-		String acceptsTermsOfUse = request.getParameter(OpenIDInfo.ACCEPTS_TERMS_OF_USE_PARAM_NAME);
+		String returnToURL = null;
+		Boolean acceptsTermsOfUse = null;
+		String redirectMode = null;
+		Cookie[] cookies = request.getCookies();
+		for (Cookie c : cookies) {
+			if (RETURN_TO_URL_COOKIE_NAME.equals(c.getName())) {
+				returnToURL = c.getValue();
+			} else if (ACCEPTS_TERMS_OF_USE_COOKIE_NAME.equals(c.getName())) {
+				acceptsTermsOfUse = Boolean.parseBoolean(c.getValue());
+			} else if (REDIRECT_MODE_COOKIE_NAME.equals(c.getName())) {
+				redirectMode = c.getValue();
+			}
+		}
 		
 		if (returnToURL == null) {
 			throw new RuntimeException("Missing required return-to URL.");
@@ -112,11 +137,13 @@ public class OpenIDUtils {
 		
 		try {
 			// Send all the Open ID info to the repository services
-			Session session = synapse.passThroughOpenIDParameters(request.getQueryString());
+			Session session = synapse.passThroughOpenIDParameters(
+					URLDecoder.decode(request.getQueryString(), "UTF-8"), 
+					acceptsTermsOfUse);
 
 			// Redirect the user appropriately
 			String redirectUrl = createRedirectURL(returnToURL,
-					session.getSessionToken(), new Boolean(acceptsTermsOfUse), isGWTMode);
+					session.getSessionToken(), acceptsTermsOfUse, isGWTMode);
 			String location = response.encodeRedirectURL(redirectUrl);
 			response.sendRedirect(location);
 			

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -4,8 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;

--- a/src/test/java/org/sagebionetworks/web/unitserver/UserAccountServiceImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/UserAccountServiceImplTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.unitserver;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -8,15 +7,12 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-
-import net.oauth.OAuthException;
 
 import org.junit.After;
 import org.junit.AfterClass;


### PR DESCRIPTION
- Changes back to cookies for portal-side params (due to length limits on the URL)
- Moves endpoint resolution out of portal

Do _not_ pull this yet.  Still requires a pom change.  
