### PR TITLE
fix tests, with the exception to SynapseClientImplTest.testGetFileEntity...

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
@@ -805,4 +805,12 @@ public class Uploader implements UploaderView.Presenter, SynapseWidgetPresenter,
 	public void setFileNames(String[] fileNames) {
 		this.fileNames = fileNames;
 	}
+	
+	/**
+	 * for testing purposes only
+	 * @param isDirectUploadSupported
+	 */
+	public void setDirectUploadSupported(boolean isDirectUploadSupported) {
+		this.isDirectUploadSupported = isDirectUploadSupported;
+	}
 }

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -2905,6 +2905,9 @@ public class SynapseClientImpl extends RemoteServiceServlet implements
 		String queryString =  	"select * from entity where parentId == '" + parentEntityId +
 								WebConstants.AND_NAME_EQUALS + fileName + WebConstants.LIMIT_ONE;
 		JSONObject query = query(queryString);
+		if (query == null) {
+			throw new SynapseClientException("Query service call returned null");
+		}
 		if(!query.has("totalNumberOfResults")){
 			throw new SynapseClientException("Query results did not have "+"totalNumberOfResults");
 		}


### PR DESCRIPTION
...IdWithSameName which no longer uses the getDescendants() call
