### PR TITLE
Update Team Icon Drag & Drop Bug Fix (SWC-1734)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
@@ -13,7 +13,6 @@ import org.sagebionetworks.web.client.widget.provenance.nchart.NChartLayersArray
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.MetaElement;
@@ -24,7 +23,6 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Random;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.Location;
 import com.google.gwt.xhr.client.XMLHttpRequest;
 
@@ -303,12 +301,9 @@ public class SynapseJSNIUtilsImpl implements SynapseJSNIUtils {
 				if (event.target.id == @org.sagebionetworks.web.client.SynapseJSNIUtilsImpl::FILE_FIELD_ID) {
 					event.target.className = event.target.className.replace(dropStyleName, '');
   					var files = event.dataTransfer.files;
-					var fileNames = [];
-					for (var i = 0; i < files.length; i++) {
-						fileNames[i] = files[i].name;
-					}
-					// UPLOADER.uploadFiles(fileNames);
-					@org.sagebionetworks.web.client.SynapseJSNIUtilsImpl::UPLOADER.@org.sagebionetworks.web.client.widget.entity.download.Uploader::uploadFiles(Lcom/google/gwt/core/client/JsArrayString;)(fileNames);
+					$doc.getElementById(@org.sagebionetworks.web.client.SynapseJSNIUtilsImpl::FILE_FIELD_ID).files = files;
+					// UPLOADER.uploadFiles();
+					@org.sagebionetworks.web.client.SynapseJSNIUtilsImpl::UPLOADER.@org.sagebionetworks.web.client.widget.entity.download.Uploader::uploadFiles()();
 				}
 			}, false);
 		

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
@@ -39,11 +39,9 @@ import org.sagebionetworks.web.shared.exceptions.ConflictException;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 
-import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.xhr.client.ReadyStateChangeHandler;
@@ -169,19 +167,6 @@ public class Uploader implements UploaderView.Presenter, SynapseWidgetPresenter,
 	
 	public void uploadFiles() {
 		view.triggerUpload();
-	}
-	
-	/**
-	 * For uploading files from native JavaScript.
-	 * @param jsFileNames Array of file names to be uploaded.
-	 */
-	public void uploadFiles(JsArrayString jsFileNames) {
-		int length = jsFileNames.length();
-		fileNames = new String[length];
-		for (int i = 0; i < length; i++) {
-			fileNames[i] = jsFileNames.get(i);
-		}
-		uploadFiles();
 	}
 	
 	@Override


### PR DESCRIPTION
Quick fix to all drag & drop automatic start issues. Apparently you can assign the files array of the uploader
($doc.getElById(fileUplaodId).files = droppedFiles). This makes the
whole files-not-set-before-drop-event issue a... non-issue. So yeah.
