### PR TITLE
SWC-1879: body is being assigned modal-opeen, probably by the gwtbootstr...

### DIFF
--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -8,6 +8,10 @@
 	text-align: center;
 } */
 
+.overflow-y-scroll-imp {
+	overflow-y: scroll !important;
+}
+
 .sf-j-menu {
 	float: right !important;
 	margin-bottom: 1em;

--- a/src/main/webapp/Portal.html
+++ b/src/main/webapp/Portal.html
@@ -83,7 +83,7 @@
 		
 		</script>
 	</head>
-	<body>
+	<body class="overflow-y-scroll-imp">
 		<div>
 			<!-- GWT history support -->
 			<iframe src="javascript:''" id="__gwt_historyFrame" tabIndex='-1' style="position: absolute; width: 0; height: 0; border: 0"></iframe>


### PR DESCRIPTION
...ap lib (modal-open is a bootstrap class) which sets overflow to hidden.  override so that overflow-y is scroll
