### PR TITLE
SWC-1881 - Sharing Dialog: Clipping of Access Combo Box in Firefox.

### DIFF
--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -791,7 +791,7 @@ a.shortBtn {
 
 .input-xs, select.input-xs {
   height: 20px !important;
-  padding: 4px 8px !important;
+  padding: 0px 8px !important;
   font-size: 11px !important;
   border-radius: 3px !important;
 }


### PR DESCRIPTION
Took away the top padding in .input-xs in Portal.css. That gets rid of the clipping.
