### PR TITLE
SWC-1903: Parent in trash restore message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 
- 		<synapse.version>develop-SNAPSHOT</synapse.version>
+ 		<synapse.version>2014-11-25-1512-e7ba178</synapse.version>
 		<gwtVersion>2.5.1</gwtVersion>
 		<org.springframework.version>4.0.2.RELEASE</org.springframework.version>
 		<guiceVersion>3.0-rc2</guiceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 
- 		<synapse.version>2014-11-25-1512-e7ba178</synapse.version>
+ 		<synapse.version>develop-SNAPSHOT</synapse.version>
 		<gwtVersion>2.5.1</gwtVersion>
 		<org.springframework.version>4.0.2.RELEASE</org.springframework.version>
 		<guiceVersion>3.0-rc2</guiceVersion>

--- a/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
@@ -173,7 +173,7 @@ public class DisplayConstants {
 	public static final String ERROR_API_TABLE_RENDERER_MISSING_INPUT_COLUMN = "Specified input column is missing from the service response: ";
 	public static final String ERROR_GETTING_PERMISSIONS_TEXT = "READ ONLY MODE. Reason: An error occurred in retrieving your level of access.";	
 	public static final String ERROR_ACL_RETRIEVAL_FAILED = "Retrieval of sharing settings failed. Please try again.";
-	public static final String ERROR_RESTORING_TRASH_PARENT_NOT_FOUND = "Sorry, you cannot restore this item.";
+	public static final String ERROR_RESTORING_TRASH_PARENT_NOT_FOUND = "Sorry, an error occurred while restoring this item.";
 	public static final String ERROR_LOCAL_ACL_CREATION_FAILED = "Creation of local sharing settings failed. Please try again.";
 	public static final String ERROR_FAILED_PERSIST_AGREEMENT_TEXT = "Your license acceptance was not saved. You will need to sign it again in the future.";
 	public static final String FORGOT_PASSWORD_MESSAGE = "If you have forgotten your password, please click the \"Forgot Password\" button on the login page.";

--- a/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
@@ -172,7 +172,7 @@ public class TrashPresenter extends AbstractActivity implements TrashView.Presen
 				if (caught instanceof ForbiddenException) {
 					// Show to view, as handleServiceException call in createFailureDisplay
 					// will show message about insufficient privileges.
-					view.displayFailureMessage(DisplayConstants.ERROR_RESTORING_TRASH_PARENT_NOT_FOUND, caught.getMessage());
+					view.showErrorMessage(caught.getMessage());
 				} else {
 					createFailureDisplay(ERROR_RESTORING_ENTITY_TITLE, caught);
 				}

--- a/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
@@ -172,7 +172,7 @@ public class TrashPresenter extends AbstractActivity implements TrashView.Presen
 				if (caught instanceof ForbiddenException) {
 					// Show to view, as handleServiceException call in createFailureDisplay
 					// will show message about insufficient privileges.
-					view.showErrorMessage(caught.getMessage());
+					view.showErrorMessage(DisplayConstants.ERROR_RESTORING_TRASH_PARENT_NOT_FOUND + " " + caught.getMessage());
 				} else {
 					createFailureDisplay(ERROR_RESTORING_ENTITY_TITLE, caught);
 				}

--- a/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
@@ -170,7 +170,9 @@ public class TrashPresenter extends AbstractActivity implements TrashView.Presen
 			@Override
 			public void onFailure(Throwable caught) {
 				if (caught instanceof ForbiddenException) {
-					createFailureDisplay(DisplayConstants.ERROR_RESTORING_TRASH_PARENT_NOT_FOUND, caught);
+					// Show to view, as handleServiceException call in createFailureDisplay
+					// will show message about insufficient privileges.
+					view.displayFailureMessage(DisplayConstants.ERROR_RESTORING_TRASH_PARENT_NOT_FOUND, caught.getMessage());
 				} else {
 					createFailureDisplay(ERROR_RESTORING_ENTITY_TITLE, caught);
 				}


### PR DESCRIPTION
Changed message when restoring to parent that is in trash. I no longer call handleServiceException, which will prepend a message about insufficient privileges to the error message.
