### PR TITLE
SWC-2084: if the column name is not found in the response, then return a...

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererDate.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererDate.java
@@ -39,11 +39,6 @@ public class APITableColumnRendererDate implements APITableColumnRenderer {
 		outputColumnData = new HashMap<String, List<String>>();
 		String inputColumnName = APITableWidget.getSingleInputColumnName(config);
 		List<String> colValues = APITableWidget.getColumnValues(inputColumnName, columnData);
-		if (colValues == null) {
-			//user defined an input column that doesn't exist in the service output
-			callback.onFailure(new IllegalArgumentException(DisplayConstants.ERROR_API_TABLE_RENDERER_MISSING_INPUT_COLUMN + inputColumnName));
-			return;
-		}
 		List<String> outputValues = new ArrayList<String>();
 		//assume dates are long values.  if parse exception occurs, then switch to standard formatter parsing (and don't try to parse as long again)
 		boolean isMsFromEpoch = true;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererLink.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererLink.java
@@ -34,11 +34,6 @@ public class APITableColumnRendererLink implements APITableColumnRenderer {
 		outputColumnData = new HashMap<String, List<String>>();
 		String inputColumnName = APITableWidget.getSingleInputColumnName(config);
 		List<String> colValues = APITableWidget.getColumnValues(inputColumnName, columnData);
-		if (colValues == null) {
-			//user defined an input column that doesn't exist in the service output
-			callback.onFailure(new IllegalArgumentException(DisplayConstants.ERROR_API_TABLE_RENDERER_MISSING_INPUT_COLUMN + inputColumnName));
-			return;
-		}
 		List<String> outputValues = new ArrayList<String>();
 		for (String colValue : colValues) {
 			if (colValue == null) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererSynapseID.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererSynapseID.java
@@ -32,11 +32,6 @@ public class APITableColumnRendererSynapseID implements APITableColumnRenderer {
 		outputColumnData = new HashMap<String, List<String>>();
 		String inputColumnName = APITableWidget.getSingleInputColumnName(config);
 		List<String> colValues = APITableWidget.getColumnValues(inputColumnName, columnData);
-		if (colValues == null) {
-			//user defined an input column that doesn't exist in the service output
-			callback.onFailure(new IllegalArgumentException(DisplayConstants.ERROR_API_TABLE_RENDERER_MISSING_INPUT_COLUMN + inputColumnName));
-			return;
-		}
 		List<String> outputValues = new ArrayList<String>();
 		
 		for (String colValue : colValues) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererUserId.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableColumnRendererUserId.java
@@ -48,11 +48,6 @@ public class APITableColumnRendererUserId implements APITableColumnRenderer {
 		userId2html = new HashMap<String, String>();
 		//get unique user ids, then ask for the user group headers
 		inputUserIds = APITableWidget.getColumnValues(inputColumnName, columnData);
-		if (inputUserIds == null) {
-			//user defined an input column that doesn't exist in the service output
-			callback.onFailure(new IllegalArgumentException(DisplayConstants.ERROR_API_TABLE_RENDERER_MISSING_INPUT_COLUMN + inputColumnName));
-			return;
-		}
 		
 		for (String userId : inputUserIds) {
 			if (userId != null)

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
@@ -385,6 +385,7 @@ public class APITableWidget implements APITableWidgetView.Presenter, WidgetRende
 					tableColumnRendererInit(columnData, columnNames, renderers, initializedRenderers, currentIndex+1);
 			}
 		};
+
 		APITableColumnConfig config = tableConfig.getColumnConfigs().get(currentIndex);
 		renderers[currentIndex].init(columnData, config, callback);
 	}
@@ -512,6 +513,16 @@ public class APITableWidget implements APITableWidgetView.Presenter, WidgetRende
 		if (colValues == null) {
 			//try to find using the fixed column value
 			colValues = columnData.get(removeFirstToken(inputColumnName));
+		}
+		if (colValues == null) {
+			//column not found in the data.  return an empty column
+			if (!columnData.values().isEmpty()) {
+				colValues = new ArrayList<String>();
+				List<String> aColumn = columnData.values().iterator().next();
+				for (int i = 0; i < aColumn.size(); i++) {
+					colValues.add(null);
+				}
+			}
 		}
 		return colValues;
 	}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererDateTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererDateTest.java
@@ -80,13 +80,5 @@ public class APITableColumnRendererDateTest {
 		//null value should be rendered as an empty string
 		assertEquals("", initializedRenderer.getColumnData().get(inputColumnName).get(0));
 	}
-
-	@Test
-	public void testInputError() {
-		HashSet<String> inputColumnNames = new HashSet<String>();
-		inputColumnNames.add("missing_column");
-		config.setInputColumnNames(inputColumnNames);
-		renderer.init(columnData, config, mockCallback);
-		verify(mockCallback).onFailure(any(IllegalArgumentException.class));
-	}
+	//Callback.onFailure is never called.  An empty column is shown if the data are unavailable for the specified column.
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererLinkTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererLinkTest.java
@@ -66,13 +66,5 @@ public class APITableColumnRendererLinkTest {
 		//null value should be rendered as an empty string
 		assertEquals("", initializedRenderer.getColumnData().get(inputColumnName).get(0));
 	}
-
-	@Test
-	public void testInputError() {
-		HashSet<String> inputColumnNames = new HashSet<String>();
-		inputColumnNames.add("missing_column");
-		config.setInputColumnNames(inputColumnNames);
-		renderer.init(columnData, config, mockCallback);
-		verify(mockCallback).onFailure(any(IllegalArgumentException.class));
-	}
+	//Callback.onFailure is never called.  An empty column is shown if the data are unavailable for the specified column.
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererNoneTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererNoneTest.java
@@ -61,15 +61,7 @@ public class APITableColumnRendererNoneTest {
 		//null value should be rendered as an empty string
 		assertEquals("", initializedRenderer.getColumnData().get(inputColumnName).get(0));
 	}
-	
-	@Test
-	public void testInputError() {
-		HashSet<String> inputColumnNames = new HashSet<String>();
-		inputColumnNames.add("missing_column");
-		config.setInputColumnNames(inputColumnNames);
-		renderer.init(columnData, config, mockCallback);
-		verify(mockCallback).onFailure(any(IllegalArgumentException.class));
-	}
+	//Callback.onFailure is never called.  An empty column is shown if the data are unavailable for the specified column.
 	
 	/**  NumberFormat is gwt client specific, so testDecimalNumberFormat and testGetColumnValue are in GwtTestSuite **/
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererSynapseIDTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererSynapseIDTest.java
@@ -64,13 +64,5 @@ public class APITableColumnRendererSynapseIDTest {
 		//null value should be rendered as an empty string
 		assertEquals("", initializedRenderer.getColumnData().get(inputColumnName).get(0));
 	}
-	
-	@Test
-	public void testInputError() {
-		HashSet<String> inputColumnNames = new HashSet<String>();
-		inputColumnNames.add("missing_column");
-		config.setInputColumnNames(inputColumnNames);
-		renderer.init(columnData, config, mockCallback);
-		verify(mockCallback).onFailure(any(IllegalArgumentException.class));
-	}
+	//Callback.onFailure is never called.  An empty column is shown if the data are unavailable for the specified column.
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererUserIDTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableColumnRendererUserIDTest.java
@@ -106,13 +106,5 @@ public class APITableColumnRendererUserIDTest {
 		renderer.init(columnData, config, mockCallback);
 		verify(mockCallback).onFailure(eq(thrownException));
 	}
-	
-	@Test
-	public void testInputError() {
-		HashSet<String> inputColumnNames = new HashSet<String>();
-		inputColumnNames.add("missing_column");
-		config.setInputColumnNames(inputColumnNames);
-		renderer.init(columnData, config, mockCallback);
-		verify(mockCallback).onFailure(any(IllegalArgumentException.class));
-	}
+	//Callback.onFailure is never called.  An empty column is shown if the data are unavailable for the specified column.
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableWidgetTest.java
@@ -68,7 +68,7 @@ public class APITableWidgetTest {
 	WikiPageKey testWikiKey = new WikiPageKey("", ObjectType.ENTITY.toString(), null);
 	String col1Name ="column 1";
 	String col2Name ="column 2";
-	
+	public static final int COLUMN_ROW_COUNT = 10;
 	@Before
 	public void setup() throws JSONObjectAdapterException{
 		mockView = mock(APITableWidgetView.class);
@@ -266,7 +266,7 @@ public class APITableWidgetTest {
 	}
 	private List<String> getTestColumnValues(String columnName) {
 		List<String> testColumnValues = new ArrayList<String>();
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < COLUMN_ROW_COUNT; i++) {
 			testColumnValues.add(columnName + " data item " + i);
 		}
 		return testColumnValues;
@@ -495,6 +495,10 @@ public class APITableWidgetTest {
 		assertNotNull(APITableWidget.getColumnValues(column1, columnData));
 		//previous table column definitions will be looking for the type. This should also work
 		assertNotNull(APITableWidget.getColumnValues("project."+column1, columnData));
-		assertNull(APITableWidget.getColumnValues("absent", columnData));
+		//absent column should not be null, and should have the item count 
+		List<String> absentColumn = APITableWidget.getColumnValues("absent", columnData);
+		assertNotNull(absentColumn);
+		assertEquals(COLUMN_ROW_COUNT, absentColumn.size());
+		assertNull(absentColumn.get(0));
 	}
 }


### PR DESCRIPTION
...n empty column (column full of nulls of the expected size)
