### PR TITLE
set min height for main content on entity page.

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
@@ -228,6 +228,7 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 					view.clear();
 					synAlert.handleException(caught);
 				}
+				headerWidget.configure(false);
 			}			
 		};
 		if (versionNumber == null) {

--- a/src/main/resources/org/sagebionetworks/web/client/view/EntityViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/EntityViewImpl.ui.xml
@@ -11,12 +11,12 @@
 		<g:SimplePanel ui:field="headerPanel"/>
 		<g:Image ui:field="entityBackgroundImage" addStyleNames="entityBackgroundImage" />
 		<g:SimplePanel ui:field="synAlertContainer"/>
-		<g:HTMLPanel ui:field="loadingUI">
+		<g:HTMLPanel ui:field="loadingUI" addStyleNames="min-height-500">
 			<g:Image styleName="displayInline" resource='{sageImageBundle.loading16}' />
 			&nbsp;Loading...
 		</g:HTMLPanel>
 		
-		<g:SimplePanel ui:field="entityPageTopPanel"/>
+		<g:SimplePanel ui:field="entityPageTopPanel"  addStyleNames="min-height-500"/>
 		<b:Heading ui:field="accessDependentMessage"  size="H4" text="Access could be dependent upon membership in one of the following Teams"
 		     addStyleNames="margin-top-100 margin-left-15" visible="false"/>
 		<g:SimplePanel ui:field="openInvitesPanel" addStyleNames="margin-left-10 margin-bottom-10 margin-right-10" visible="false"/>

--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -1962,7 +1962,7 @@ iframe[seamless] {
 }
 
 h1, .h1, h2, .h2, h3, .h3 {
-	margin-top: 0px !important;
+	margin-top: 10px !important;
 }
 
 ul, ol {

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
@@ -234,6 +234,8 @@ public class EntityPresenterTest {
 		//verify synapse client call
 		verify(mockSynapseClient).getEntityBundle(eq(entityId), anyInt(), any(AsyncCallback.class));
 		verify(mockSynAlert).handleException(caught);
+		//header should be reconfigured to set back to Synapse
+		verify(mockHeaderWidget).configure(false);
 	}
 	
 	@Test


### PR DESCRIPTION
set margin-top for header elements.  and if there are any problems loading an entity, reconfigure the header widget (so that it shows Synapse instead of nothing)
