### PR TITLE
set overflow to auto instead of scroll (scroll causes scroll bars to …

### DIFF
--- a/src/main/webapp/Portal.css
+++ b/src/main/webapp/Portal.css
@@ -956,7 +956,7 @@ a.shortBtn {
 
 .markdown {
 	word-wrap:break-word;
-	overflow: scroll;
+	overflow: auto;
 	text-align: justify;
 }
 


### PR DESCRIPTION
…always show up on Windows Chrome)
