### PR TITLE
Fix java client documentation

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/view/HelpViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/HelpViewImpl.java
@@ -66,7 +66,6 @@ public class HelpViewImpl extends Composite implements HelpView {
 
 	@Override
 	public void showHelpPage(WikiPageKey wikiKey) {
-		
 		mainContainer.clear();
 		mainContainer.add(wikiPage.asWidget());
 		wikiPage.configure(wikiKey, false, new WikiPageWidget.Callback() {
@@ -76,7 +75,7 @@ public class HelpViewImpl extends Composite implements HelpView {
 			@Override
 			public void noWikiFound() {
 			}
-		}, false);
+		}, true);
 	}
 	
 	@Override

--- a/src/main/resources/org/sagebionetworks/web/client/view/HomeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/HomeViewImpl.ui.xml
@@ -115,7 +115,7 @@
 											<t:TableData>
 												<b:Heading size="H4" addStyleNames="font-weight-bolder" text="R client" />
 												<b:Anchor href="http://r-docs.synapse.org/" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
-												<b:Anchor href="https://www.synapse.org/#!Help:RClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
+												<b:Anchor href="#!Help:RClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
 											</t:TableData>
 										</t:TableRow>
 									</t:Table>
@@ -131,7 +131,7 @@
 											<t:TableData>
 												<b:Heading size="H4" addStyleNames="font-weight-bolder" text="Python client" />
 												<b:Anchor href="http://python-docs.synapse.org/" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
-												<b:Anchor href="https://www.synapse.org/#!Help:PythonClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
+												<b:Anchor href="#!Help:PythonClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
 											</t:TableData>
 										</t:TableRow>
 									</t:Table>
@@ -147,7 +147,7 @@
 											<t:TableData>
 												<b:Heading size="H4" addStyleNames="font-weight-bolder" text="Command line client" />
 												<b:Anchor href="http://python-docs.synapse.org/CommandLineClient.html" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
-												<b:Anchor href="https://www.synapse.org/#!Help:CommandLineClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
+												<b:Anchor href="#!Help:CommandLineClient" addStyleNames="displayBlock" target="_blank" text="Example code"/>
 											</t:TableData>
 										</t:TableRow>
 									</t:Table>
@@ -162,7 +162,7 @@
 											</t:TableData>
 											<t:TableData>
 												<b:Heading size="H4" addStyleNames="font-weight-bolder" text="Java client" />
-												<b:Anchor href="https://github.com/Sage-Bionetworks/Synapse-Repository-Services/blob/develop/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
+												<b:Anchor href="#!Help:JavaClient" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
 												<b:Anchor href="https://github.com/Sage-Bionetworks/SynapseWebClient/blob/develop/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java" addStyleNames="displayBlock" target="_blank" text="Example code"/>
 											</t:TableData>
 										</t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/view/HomeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/HomeViewImpl.ui.xml
@@ -162,7 +162,7 @@
 											</t:TableData>
 											<t:TableData>
 												<b:Heading size="H4" addStyleNames="font-weight-bolder" text="Java client" />
-												<b:Anchor href="#!Help:JavaClient" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
+												<b:Anchor href="#!StandaloneWiki:JavaClient" addStyleNames="displayBlock" target="_blank" text="API documentation"/>
 												<b:Anchor href="https://github.com/Sage-Bionetworks/SynapseWebClient/blob/develop/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java" addStyleNames="displayBlock" target="_blank" text="Example code"/>
 											</t:TableData>
 										</t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/CommandLineClientInstallWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/CommandLineClientInstallWidgetViewImpl.ui.xml
@@ -16,6 +16,6 @@ pip install synapseclient
 easy_install synapseclient</pre>
  	    <b:Anchor href="http://python-docs.synapse.org/CommandLineClient.html" addStyleNames="link" target="_blank" text="API Documentation"/>
 		<bh:Text text="and"/>
-		<b:Anchor href="https://www.synapse.org/#!Help:CommandLineClient" addStyleNames="link" target="_blank" text="Example Code"/>
+		<b:Anchor href="#!Help:CommandLineClient" addStyleNames="link" target="_blank" text="Example Code"/>
 	</g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/JavaClientInstallWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/JavaClientInstallWidgetViewImpl.ui.xml
@@ -24,7 +24,7 @@
 	&#60;artifactId&#62;synapseJavaClient&#60;/artifactId&#62;
 	&#60;version&#62;See Repository for newest Version&#60;/version&#62;
 &#60;/dependency&#62;</pre>
-	    <b:Anchor href="#!Help:JavaClient" addStyleNames="link" target="_blank" text="API Documentation"/>
+	    <b:Anchor href="#!StandaloneWiki:JavaClient" addStyleNames="link" target="_blank" text="API Documentation"/>
 		<bh:Text text="and"/>
 		<b:Anchor href="https://github.com/Sage-Bionetworks/SynapseWebClient/blob/develop/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java" addStyleNames="link" target="_blank" text="Example Code"/>
     </g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/JavaClientInstallWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/JavaClientInstallWidgetViewImpl.ui.xml
@@ -24,7 +24,7 @@
 	&#60;artifactId&#62;synapseJavaClient&#60;/artifactId&#62;
 	&#60;version&#62;See Repository for newest Version&#60;/version&#62;
 &#60;/dependency&#62;</pre>
-	    <b:Anchor href="https://github.com/Sage-Bionetworks/Synapse-Repository-Services/blob/develop/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java" addStyleNames="link" target="_blank" text="API Documentation"/>
+	    <b:Anchor href="#!Help:JavaClient" addStyleNames="link" target="_blank" text="API Documentation"/>
 		<bh:Text text="and"/>
 		<b:Anchor href="https://github.com/Sage-Bionetworks/SynapseWebClient/blob/develop/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java" addStyleNames="link" target="_blank" text="Example Code"/>
     </g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/PythonClientInstallWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/PythonClientInstallWidgetViewImpl.ui.xml
@@ -16,6 +16,6 @@ easy_install synapseclient</pre>
 		</g:HTMLPanel>
 		<b:Anchor href="http://python-docs.synapse.org/" addStyleNames="link" target="_blank" text="API Documentation"/>
 		<bh:Text text="and"/>
-		<b:Anchor href="https://www.synapse.org/#!Help:PythonClient" addStyleNames="link" target="_blank" text="Example Code"/>
+		<b:Anchor href="#!Help:PythonClient" addStyleNames="link" target="_blank" text="Example Code"/>
 	</g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/RClientInstallWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/RClientInstallWidgetViewImpl.ui.xml
@@ -15,7 +15,7 @@ source('http://depot.sagebase.org/CRAN.R')
 pkgInstall(c(&quot;synapseClient&quot;))</pre>
       	<b:Anchor href="http://r-docs.synapse.org/" addStyleNames="link" target="_blank" text="API Documentation"/>
 		<bh:Text text="and"/>
-		<b:Anchor href="https://www.synapse.org/#!Help:RClient" addStyleNames="link" target="_blank" text="Example Code"/>
+		<b:Anchor href="#!Help:RClient" addStyleNames="link" target="_blank" text="Example Code"/>
 	</g:HTMLPanel>
 
 </ui:UiBinder>

--- a/src/main/resources/portal.properties
+++ b/src/main/resources/portal.properties
@@ -6,6 +6,7 @@ org.sagebionetworks.portal.wikis.GettingStarted=syn2305384/61121
 org.sagebionetworks.portal.wikis.CreateProject=syn1669771/54547
 org.sagebionetworks.portal.wikis.RClient=syn1834618/55157
 org.sagebionetworks.portal.wikis.PythonClient=syn1768504/54750
+org.sagebionetworks.portal.wikis.JavaClient=syn3722562/390320
 org.sagebionetworks.portal.wikis.ChallengeParticipationInfo=syn2495968/64926
 org.sagebionetworks.portal.wikis.Governance=syn2502577/65109
 org.sagebionetworks.portal.wikis.CommandLineClient=syn1768504/54750


### PR DESCRIPTION
Fixes help link stack hopping issue, adds subpages to Help place, and adds reference to a newly created Java client help page.
https://www.synapse.org/#!Synapse:syn3722562/wiki/390320
