### PR TITLE
SWC-2918: autolink syn ids, and send most links to a new window by default.

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/MarkdownIt.java
+++ b/src/main/java/org/sagebionetworks/web/client/MarkdownIt.java
@@ -1,0 +1,6 @@
+package org.sagebionetworks.web.client;
+
+
+public interface MarkdownIt {
+	public String markdown2Html(String md, String uniqueSuffix);
+}

--- a/src/main/java/org/sagebionetworks/web/client/MarkdownItImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/MarkdownItImpl.java
@@ -1,0 +1,117 @@
+package org.sagebionetworks.web.client;
+
+
+public class MarkdownItImpl implements MarkdownIt {
+	@Override
+	public String markdown2Html(String md, String uniqueSuffix) {
+		return _markdown2Html(md, uniqueSuffix);
+	}
+	
+	private final static native String _markdown2Html(String md, String uniqueSuffix) /*-{
+		function sendLinksToNewWindow() {
+			var defaultRender = $wnd.markdownitSingleton.renderer.rules.link_open || function(tokens, idx, options, env, self) {
+			  return self.renderToken(tokens, idx, options);
+			};
+			
+			$wnd.markdownitSingleton.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+			  // If you are sure other plugins can't add `target` - drop check below
+			  var aIndex = tokens[idx].attrIndex('target');
+			  var hrefIndex = tokens[idx].attrIndex('href');
+			  if (aIndex < 0) {
+			  	if (hrefIndex < 0 || !tokens[idx].attrs[hrefIndex][1].startsWith('#!')) {
+			  		tokens[idx].attrPush(['target', '_blank']); // add new attribute
+			  	}
+			  } else {
+			    tokens[idx].attrs[aIndex][1] = '_blank';    // replace value of existing attr
+			  }
+			
+			  // pass token to default renderer.
+			  return defaultRender(tokens, idx, options, env, self);
+			};
+		}
+		
+		function initLinkify() {
+			$wnd.markdownitSingleton.linkify.add('@', {
+			  validate: function (text, pos, self) {
+			    var tail = text.slice(pos);
+			    if (!self.re.username) {
+			      self.re.username =  new RegExp(
+			        '^([a-zA-Z0-9_]){1,15}(?!_)(?=$|' + self.re.src_ZPCc + ')'
+			      );
+			    }
+			    if (self.re.username.test(tail)) {
+			      // Linkifier allows punctuation chars before prefix,
+			      // but we additionally disable `@` ("@@mention" is invalid)
+			      if (pos >= 2 && tail[pos - 2] === '@') {
+			        return false;
+			      }
+			      return tail.match(self.re.username)[0].length;
+			    }
+			    return 0;
+			  },
+			  normalize: function (match) {
+			    match.url = '#!Profile:' + match.url.replace(/^@/, '');
+			  }
+			});
+			
+			$wnd.markdownitSingleton.linkify.add('syn', {
+			  validate: function (text, pos, self) {
+			    var tail = text.slice(pos);
+			    if (!self.re.synapse) {
+			      self.re.synapse =  new RegExp(
+			        '^([0-9]+[.]?[0-9]*)+(?!_)(?=$|' + self.re.src_ZPCc + ')'
+			      );
+			    }
+			    if (self.re.synapse.test(tail)) {
+			      return tail.match(self.re.synapse)[0].length;
+			    }
+			    return 0;
+			  },
+			  normalize: function (match) {
+			    match.url = '#!Synapse:' + match.url.replace(/[.]/, '/version/');
+			  }
+			});
+		}
+		
+		function initMarkdownIt() {
+			$wnd.markdownitSingleton = $wnd.markdownit()
+				.set({ 
+					html: false, 
+					breaks: true,
+					linkify: true,
+					maxNesting: 100 });
+			$wnd.markdownitSingleton.disable([ 'heading' ]);
+			$wnd.markdownitSingleton
+				.use($wnd.markdownitSub)
+				.use($wnd.markdownitSup)
+				.use($wnd.markdownitCentertext)
+				.use($wnd.markdownitSynapseHeading)
+				;
+			
+			$wnd.markdownitSingleton
+				.set({
+				  highlight: function (str, lang) {
+				    if (lang && $wnd.hljs.getLanguage(lang)) {
+				      try {
+				      	return $wnd.hljs.highlight(lang, str).value;
+				      } catch (__) {}
+				    }
+				    return ''; // use external default escaping
+				  }
+				});
+			sendLinksToNewWindow();
+			initLinkify();
+		}
+		
+		if (!$wnd.markdownitSingleton) {
+			initMarkdownIt();
+		}
+		//load the plugin to recognize Synapse markdown widget syntax (with the uniqueSuffix parameter)
+		$wnd.markdownitSingleton
+			.use($wnd.markdownitSynapse, uniqueSuffix)
+			.use($wnd.markdownitMath, uniqueSuffix);
+		
+		return $wnd.markdownitSingleton.render(md);
+	}-*/;
+	
+}

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -1230,5 +1230,7 @@ public class PortalGinModule extends AbstractGinModule {
 		bind(RadioCellEditorView.class).to(RadioCellEditorViewImpl.class);
 		bind(BooleanFormCellEditor.class).to(BooleanFormCellEditorImpl.class);
 		bind(EnumFormCellEditor.class).to(EnumFormCellEditorImpl.class);
+		
+		bind(MarkdownIt.class).to(MarkdownItImpl.class);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
@@ -546,5 +546,7 @@ public interface SynapseClient extends RemoteService {
 			throws RestServiceException;
 
 	Entity moveEntity(String entityId, String newParentEntityId) throws RestServiceException;
+
+	String getUserIdFromUsername(String username) throws RestServiceException;
 	
 	}

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
@@ -442,4 +442,6 @@ public interface SynapseClientAsync {
 	
 	void setIsTeamAdmin(String currentUserId, String targetUserId,
 			String teamId, boolean isTeamAdmin, AsyncCallback<Void> callback);
+
+	void getUserIdFromUsername(String username, AsyncCallback<String> callback);
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtils.java
@@ -108,6 +108,4 @@ public interface SynapseJSNIUtils {
 	
 	public String getCurrentURL();
 	public String getCurrentHostName();
-	
-	public String markdown2Html(String md, String uniqueSuffix);
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJSNIUtilsImpl.java
@@ -578,44 +578,4 @@ public class SynapseJSNIUtilsImpl implements SynapseJSNIUtils {
 	public String getCurrentHostName() {
 		return Location.getHostName();
 	}
-	
-	@Override
-	public String markdown2Html(String md, String uniqueSuffix) {
-		return _markdown2Html(md, uniqueSuffix);
-	}
-	
-	private final static native String _markdown2Html(String md, String uniqueSuffix) /*-{
-		if (!$wnd.markdownitSingleton) {
-			$wnd.markdownitSingleton = $wnd.markdownit()
-				.set({ 
-					html: false, 
-					breaks: true,
-					maxNesting: 100 });
-			$wnd.markdownitSingleton.disable([ 'heading' ]);
-			$wnd.markdownitSingleton
-				.use($wnd.markdownitSub)
-				.use($wnd.markdownitSup)
-				.use($wnd.markdownitCentertext)
-				.use($wnd.markdownitSynapseHeading)
-				;
-			
-			$wnd.markdownitSingleton
-				.set({
-				  highlight: function (str, lang) {
-				    if (lang && $wnd.hljs.getLanguage(lang)) {
-				      try {
-				      	return $wnd.hljs.highlight(lang, str).value;
-				      } catch (__) {}
-				    }
-				    return ''; // use external default escaping
-				  }
-				});
-		}
-		//load the plugin to recognize Synapse markdown widget syntax (with the uniqueSuffix parameter)
-		$wnd.markdownitSingleton
-			.use($wnd.markdownitSynapse, uniqueSuffix)
-			.use($wnd.markdownitMath, uniqueSuffix);
-		
-		return $wnd.markdownitSingleton.render(md);
-	}-*/;
 }

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -884,18 +884,18 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 					Long.parseLong(place.getUserId());
 					updateProfileView(place.getUserId(), place.getArea());
 				} catch (NumberFormatException nfe) {
-					getUserIdAndGotoPlace(place.getUserId());
+					getUserIdFromUsername(token);
 				}
 			}
 		}
 	}
 	
-	public void getUserIdAndGotoPlace(String userName) {
+	public void getUserIdFromUsername(String userName) {
 		synapseClient.getUserIdFromUsername(userName, new AsyncCallback<String>() {
 			@Override
 			public void onSuccess(String userId) {
 				place.setUserId(userId);
-				globalApplicationState.getPlaceChanger().goTo(place);
+				updateProfileView(userId, place.getArea());
 			}
 			
 			@Override

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -879,10 +879,30 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 			} else if (Profile.EDIT_PROFILE_TOKEN.equals(token)) {
 				editMyProfile();
 			} else {
-				//otherwise, this is a user id
-				updateProfileView(place.getUserId(), place.getArea());
+				//if this is a number, then treat it as a a user id
+				try{
+					Long.parseLong(place.getUserId());
+					updateProfileView(place.getUserId(), place.getArea());
+				} catch (NumberFormatException nfe) {
+					getUserIdAndGotoPlace(place.getUserId());
+				}
 			}
 		}
+	}
+	
+	public void getUserIdAndGotoPlace(String userName) {
+		synapseClient.getUserIdFromUsername(userName, new AsyncCallback<String>() {
+			@Override
+			public void onSuccess(String userId) {
+				place.setUserId(userId);
+				globalApplicationState.getPlaceChanger().goTo(place);
+			}
+			
+			@Override
+			public void onFailure(Throwable caught) {
+				profileSynAlert.handleException(caught);
+			}
+		});
 	}
 	
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownWidget.java
@@ -10,6 +10,7 @@ import org.sagebionetworks.web.client.ClientProperties;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
+import org.sagebionetworks.web.client.MarkdownIt;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -42,6 +43,7 @@ import com.google.inject.Inject;
 public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 	
 	private SynapseClientAsync synapseClient;
+	private MarkdownIt markdownIt;
 	private SynapseJSNIUtils synapseJSNIUtils;
 	private WidgetRegistrar widgetRegistrar;
 	private CookieProvider cookies;
@@ -64,7 +66,8 @@ public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 			PortalGinInjector ginInjector,
 			MarkdownWidgetView view,
 			SynapseAlert synAlert,
-			SessionStorage sessionStorage) {
+			SessionStorage sessionStorage,
+			MarkdownIt markdownIt) {
 		super();
 		this.synapseClient = synapseClient;
 		this.synapseJSNIUtils = synapseJSNIUtils;
@@ -76,6 +79,7 @@ public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 		this.view = view;
 		this.synAlert = synAlert;
 		this.sessionStorage = sessionStorage;
+		this.markdownIt = markdownIt;
 		view.setSynAlertWidget(synAlert.asWidget());
 	}
 	
@@ -105,7 +109,7 @@ public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 					@Override
 					public void invoke() {
 						//save in cache
-						String result = synapseJSNIUtils.markdown2Html(md, uniqueSuffix);
+						String result = markdownIt.markdown2Html(md, uniqueSuffix);
 						sessionStorage.setItem(key, getValueToCache(uniqueSuffix, result));
 						loadHtml(uniqueSuffix, result);
 					}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -750,8 +750,8 @@ public class SynapseClientImpl extends SynapseClientBase implements
 	public String getUserIdFromUsername(String username) throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
-			//try to find it
-			UserGroupHeaderResponsePage responsePage = synapseClient.getUserGroupHeadersByPrefix(username, 1000, 0);
+			//try to find the user id based on the given username
+			UserGroupHeaderResponsePage responsePage = synapseClient.getUserGroupHeadersByPrefix(username);
 			for (UserGroupHeader header : responsePage.getChildren()) {
 				if (username.equals(header.getUserName())){
 					return header.getOwnerId();

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -77,6 +77,7 @@ import org.sagebionetworks.repo.model.Team;
 import org.sagebionetworks.repo.model.TeamMember;
 import org.sagebionetworks.repo.model.TeamMembershipStatus;
 import org.sagebionetworks.repo.model.TrashedEntity;
+import org.sagebionetworks.repo.model.UserGroupHeader;
 import org.sagebionetworks.repo.model.UserGroupHeaderResponsePage;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.VersionInfo;
@@ -745,6 +746,25 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		}
 	}
 
+	@Override
+	public String getUserIdFromUsername(String username) throws RestServiceException {
+		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
+		try {
+			//try to find it
+			UserGroupHeaderResponsePage responsePage = synapseClient.getUserGroupHeadersByPrefix(username, 1000, 0);
+			for (UserGroupHeader header : responsePage.getChildren()) {
+				if (username.equals(header.getUserName())){
+					return header.getOwnerId();
+				}
+			}
+			throw new NotFoundException(username + " not found");
+		} catch (SynapseException e) {
+			throw ExceptionUtil.convertSynapseException(e);
+		} catch (UnsupportedEncodingException e) {
+			throw new UnknownErrorException(e.getMessage());
+		}
+	}
+	
 	@Override
 	public void updateUserProfile(UserProfile profile)
 			throws RestServiceException {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
@@ -19,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
+import org.sagebionetworks.web.client.MarkdownIt;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -68,6 +69,9 @@ public class MarkdownWidgetTest {
 	MarkdownCacheKey mockMarkdownCacheKey;
 	@Mock
 	MarkdownCacheValue mockMarkdownCacheValue;
+	@Mock
+	MarkdownIt mockMarkdownIt;
+	
 	@Before
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
@@ -90,7 +94,7 @@ public class MarkdownWidgetTest {
 		when(mockElementWrapper.getAttribute("widgetParams")).thenReturn(elementContentType);
 		when(mockInjector.getMarkdownCacheKey()).thenReturn(mockMarkdownCacheKey);
 		when(mockInjector.getMarkdownCacheValue()).thenReturn(mockMarkdownCacheValue);
-		presenter = new MarkdownWidget(mockSynapseClient, mockSynapseJSNIUtils, mockWidgetRegistrar, mockCookies, mockResourceLoader, mockGwt, mockInjector, mockView, mockSynAlert, mockSessionStorage);
+		presenter = new MarkdownWidget(mockSynapseClient, mockSynapseJSNIUtils, mockWidgetRegistrar, mockCookies, mockResourceLoader, mockGwt, mockInjector, mockView, mockSynAlert, mockSessionStorage, mockMarkdownIt);
 	}
 	
 	@Test
@@ -199,7 +203,7 @@ public class MarkdownWidgetTest {
 	public void testMarkdownIt2Html() {
 		when(mockCookies.getCookie(eq(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))).thenReturn("true");
 		String sampleHTML = "<h1>heading</h1><p>foo baz bar</p>";
-		when(mockSynapseJSNIUtils.markdown2Html(anyString(), anyString())).thenReturn(sampleHTML);
+		when(mockMarkdownIt.markdown2Html(anyString(), anyString())).thenReturn(sampleHTML);
 		String markdown="input markdown that is transformed";
 		presenter.configure(markdown, mockWikiPageKey, 1L);
 		
@@ -207,7 +211,7 @@ public class MarkdownWidgetTest {
 		verify(mockView).callbackWhenAttached(callbackCaptor.capture());
 		callbackCaptor.getValue().invoke();
 		
-		verify(mockSynapseJSNIUtils).markdown2Html(anyString(),anyString());
+		verify(mockMarkdownIt).markdown2Html(anyString(),anyString());
 		verify(mockView).setMarkdown(sampleHTML);
 		//verify highlight code blocks never called (part of parsing)
 		verify(mockSynapseJSNIUtils, never()).highlightCodeBlocks();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/provenance/ProvUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/provenance/ProvUtilsTest.java
@@ -497,11 +497,6 @@ public class ProvUtilsTest {
 				// TODO Auto-generated method stub
 				return null;
 			}
-			@Override
-			public String markdown2Html(String md, String uniqueSuffix) {
-				// TODO Auto-generated method stub
-				return null;
-			}
 		};
 	}
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/provenance/ProvenanceWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/provenance/ProvenanceWidgetTest.java
@@ -548,11 +548,6 @@ public class ProvenanceWidgetTest {
 				// TODO Auto-generated method stub
 				return null;
 			}
-			@Override
-			public String markdown2Html(String md, String uniqueSuffix) {
-				// TODO Auto-generated method stub
-				return null;
-			}
 		};
 	}
 


### PR DESCRIPTION
Also includes a refactor (move this out of SynapseJSNIUtils), and support for \@username notation (will autolink to user profile page, where it attempts to resolve the username2userid).
