### PR TITLE
SWC-2944: keep track of the original value

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellEditorImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellEditorImpl.java
@@ -13,6 +13,7 @@ import com.google.inject.Inject;
 public class DateCellEditorImpl implements DateCellEditor {
 	
 	private DateCellEditorView view;
+	private Long originalTime;
 	
 	@Inject
 	public DateCellEditorImpl(DateCellEditorView view) {
@@ -34,8 +35,10 @@ public class DateCellEditorImpl implements DateCellEditor {
 	public void setValue(String value) {
 		value = StringUtils.trimWithEmptyAsNull(value);
 		Date date = null;
+		originalTime = null;
 		if(value != null){
-			date = new Date(Long.parseLong(value));
+			originalTime = Long.parseLong(value);
+			date = new Date(originalTime);
 		}
 		view.setValue(date);
 	}
@@ -44,11 +47,19 @@ public class DateCellEditorImpl implements DateCellEditor {
 	public String getValue() {
 		Date date = view.getValue();
 		if(date != null){
-			return Long.toString(date.getTime());
+			Long time = date.getTime();
+			if (originalTime != null) {
+				double originalSeconds = Math.floor(originalTime / 1000);
+				double newSeconds = Math.floor(time / 1000);
+				if (originalSeconds == newSeconds) {
+					time = originalTime;
+				}
+			}
+			return Long.toString(time);
 		}
 		return null;
 	}
-
+	
 	@Override
 	public HandlerRegistration addKeyDownHandler(KeyDownHandler handler) {
 		return view.addKeyDownHandler(handler);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/DateCellEditorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/DateCellEditorImplTest.java
@@ -52,8 +52,33 @@ public class DateCellEditorImplTest {
 	
 	@Test
 	public void testGetValueReal(){
+		//get value from the editor, setValue is never called.
 		Date old = new Date(123);
 		when(mockView.getValue()).thenReturn(old);
 		assertEquals("123", editor.getValue());
 	}
+	
+	@Test
+	public void testSetValueMilliSecondLoss(){
+		//SWC-2944: Simulate precision loss by the view (Bootstrap extras DateTimePicker to be more specific).
+		String sValue = Long.toString(1457401179123L);
+		editor.setValue(sValue);
+		when(mockView.getValue()).thenReturn(new Date(1457401179000L));
+		
+		//the view has lost the milliseconds, should return the original value
+		assertEquals(sValue, editor.getValue());
+	}
+	
+	@Test
+	public void testSetValueViewHasDifferentDate(){
+		//SWC-2944
+		String sValue = Long.toString(1457401179123L);
+		editor.setValue(sValue);
+		Long newDate = 1457487584000L;
+		when(mockView.getValue()).thenReturn(new Date(newDate));
+		
+		//the user has selected a different value in the view, verify that it is not overwritten by the original value
+		assertEquals(Long.toString(newDate), editor.getValue());
+	}
+
 }


### PR DESCRIPTION
If the only thing that changes in the web client editor is the milliseconds, then return the original (revert the change).
