### PR TITLE
SWC-2957: only configure subscription list if visible.  And show erro…

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
@@ -261,12 +261,15 @@ public class SettingsPresenter implements SettingsView.Presenter {
 		notificationSynAlert.clear();
 		addressSynAlert.clear();
 		passwordSynAlert.clear();
-		view.setSubscriptionsVisible(DisplayUtils.isInTestWebsite(cookies));
+		boolean isSubscriptionsVisible = DisplayUtils.isInTestWebsite(cookies);
+		view.setSubscriptionsVisible(isSubscriptionsVisible);
 		if (authenticationController.isLoggedIn()) {
 			updateUserStorage();
 			getUserNotificationEmail();
 			view.updateNotificationCheckbox(authenticationController.getCurrentUserSessionData().getProfile());
-			subscriptionListWidget.configure();
+			if (isSubscriptionsVisible) {
+				subscriptionListWidget.configure();	
+			}
 		}
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/subscription/TopicWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/subscription/TopicWidget.java
@@ -61,7 +61,7 @@ public class TopicWidget implements TopicWidgetView.Presenter, SynapseWidgetPres
 			
 			@Override
 			public void onFailure(Throwable caught) {
-				synAlert.handleException(caught);
+				synAlert.showError(caught.getMessage());
 			}
 		});
 	}
@@ -71,7 +71,7 @@ public class TopicWidget implements TopicWidgetView.Presenter, SynapseWidgetPres
 		forumClient.getForumProject(forumId, new AsyncCallback<Project>() {
 			@Override
 			public void onFailure(Throwable caught) {
-				synAlert.handleException(caught);
+				synAlert.showError(caught.getMessage());
 			}
 			public void onSuccess(Project result) {
 				view.setTopicText(result.getName());

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.schema.adapter.AdapterFactory;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.schema.adapter.org.json.AdapterFactoryImpl;
 import org.sagebionetworks.web.client.DisplayConstants;
+import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
@@ -349,6 +350,16 @@ public class SettingsPresenterTest {
 		verify(mockSynAlert, times(5)).clear();
 		verify(mockView).clear();
 		verify(mockView).asWidget();
+		//TODO: remove "never()" once subscription list is out of alpha
+		verify(mockSubscriptionListWidget, never()).configure();
+		verify(mockView).setSubscriptionsVisible(false);
+	}
+	
+	@Test
+	public void testConfigureSubscriptionListInAlpha() {
+		when(mockCookieProvider.getCookie(eq(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))).thenReturn("true");
+		profilePresenter.asWidget();
+		verify(mockView).setSubscriptionsVisible(true);
 		verify(mockSubscriptionListWidget).configure();
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/subscription/TopicWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/subscription/TopicWidgetTest.java
@@ -85,14 +85,15 @@ public class TopicWidgetTest {
 	
 	@Test
 	public void testConfigureDiscussionThreadFailure() {
-		Exception ex = new Exception("error");
+		String errorMessage = "error";
+		Exception ex = new Exception(errorMessage);
 		AsyncMockStubber.callFailureWith(ex).when(mockForumClient)
 			.getThread(anyString(), any(AsyncCallback.class));
 		
 		widget.configure(SubscriptionObjectType.DISCUSSION_THREAD, TEST_OBJECT_ID);
 		verify(mockForumClient)
 			.getThread(anyString(), any(AsyncCallback.class));
-		verify(mockSynAlert).handleException(ex);
+		verify(mockSynAlert).showError(errorMessage);
 	}
 
 	@Test
@@ -111,12 +112,13 @@ public class TopicWidgetTest {
 
 	@Test
 	public void testConfigureForumFailure() {
-		Exception ex = new Exception("error");
+		String errorMessage = "error";
+		Exception ex = new Exception(errorMessage);
 		AsyncMockStubber.callFailureWith(ex).when(mockForumClient)
 			.getForumProject(anyString(), any(AsyncCallback.class));
 		
 		widget.configure(SubscriptionObjectType.FORUM, TEST_OBJECT_ID);
-		verify(mockSynAlert).handleException(ex);
+		verify(mockSynAlert).showError(errorMessage);
 	}
 
 	@Test


### PR DESCRIPTION
…r, instead of generic exception handling (if unknown error occurs, just show the message in an alert)
