### PR TITLE
SWC-3025: ignore list detection in preprocessing if line could be a table

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/MarkdownItImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/MarkdownItImpl.java
@@ -180,10 +180,10 @@ public class MarkdownItImpl implements MarkdownIt {
 				$wnd.md.utils.doiRE = new RegExp('^doi:10[.]{1}[0-9]+[/]{1}[a-zA-Z0-9_.]+$');
 			}
 			if (!$wnd.md.utils.ulMarkerRE) {
-				$wnd.md.utils.ulMarkerRE = new RegExp("^\\s*[*-+>]{1}.*$");
+				$wnd.md.utils.ulMarkerRE = new RegExp("^\\s*[*-+>]{1}[^|]*$");
 			}
 			if (!$wnd.md.utils.olMarkerRE) {
-				$wnd.md.utils.olMarkerRE = new RegExp("^\\s*\\d+\\s*[.)]{1}.*$");
+				$wnd.md.utils.olMarkerRE = new RegExp("^\\s*\\d+\\s*[.)]{1}[^|]*$");
 			}
 			if (!$wnd.md.utils.spacesRE) {
 				$wnd.md.utils.spacesRE = new RegExp("[ ]{7}", 'g');

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownWidget.java
@@ -103,8 +103,8 @@ public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 		final String key = getKey(md, hostPrefix, isInTestWebsite);
 		
 		//avoid cache for new md processor until it is in good shape.
-		final MarkdownCacheValue cachedValue = getValueFromCache(key);
-		if(cachedValue == null) {
+//		final MarkdownCacheValue cachedValue = getValueFromCache(key);
+//		if(cachedValue == null) {
 			view.callbackWhenAttached(new Callback() {
 				@Override
 				public void invoke() {
@@ -118,15 +118,15 @@ public class MarkdownWidget implements MarkdownWidgetView.Presenter, IsWidget {
 					}
 				}
 			});
-		} else {
-			//used cached value
-			view.callbackWhenAttached(new Callback() {
-				@Override
-				public void invoke() {
-					loadHtml(cachedValue.getUniqueSuffix(), cachedValue.getHtml());
-				}
-			});
-		}
+//		} else {
+//			//used cached value
+//			view.callbackWhenAttached(new Callback() {
+//				@Override
+//				public void invoke() {
+//					loadHtml(cachedValue.getUniqueSuffix(), cachedValue.getHtml());
+//				}
+//			});
+//		}
 	}
 	
 	public String getKey(String md, String hostPrefix, boolean isInTestWebsite) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -218,6 +219,7 @@ public class MarkdownWidgetTest {
 		verify(mockSynAlert).showError(anyString());
 	}
 	
+	@Ignore
 	@Test
 	public void testMdCache() {
 		//simulate value is found in the cache.


### PR DESCRIPTION
and turn off md2html cache for now.
