### PR TITLE
SWC-3075: do not pop up user selector unless whitespace precedes the …

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/GWTWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/GWTWrapper.java
@@ -43,4 +43,6 @@ public interface GWTWrapper {
 	String getFormattedDateString(Date date);
 	
 	void addDaysToDate(Date date, int days);
+	
+	boolean isWhitespace(String text);
 }

--- a/src/main/java/org/sagebionetworks/web/client/GWTWrapperImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GWTWrapperImpl.java
@@ -10,6 +10,7 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Random;
 import com.google.gwt.user.client.Timer;
@@ -20,6 +21,8 @@ import com.google.gwt.xhr.client.XMLHttpRequest;
 
 public class GWTWrapperImpl implements GWTWrapper {
 
+	private final static RegExp PATTERN_WHITE_SPACE = RegExp.compile("^\\s+$");
+	
 	@Override
 	public String getHostPageBaseURL() {
 		return GWT.getHostPageBaseURL();
@@ -120,5 +123,10 @@ public class GWTWrapperImpl implements GWTWrapper {
 	@Override
 	public void addDaysToDate(Date date, int days) {
 		CalendarUtil.addDaysToDate(date, days);
+	}
+	
+	@Override
+	public boolean isWhitespace(String text) {
+		return PATTERN_WHITE_SPACE.test(text);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
@@ -21,10 +21,12 @@ import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
+import com.google.gwt.core.shared.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -484,7 +486,12 @@ public class MarkdownEditorWidget implements MarkdownEditorWidgetView.Presenter,
 	@Override
 	public void onKeyPress(char c) {
 		if ('@' == c) {
-			insertUserLink();
+			// only insert a user link if this is the first character, or the character before it is whitespace
+			int pos = view.getCursorPos();
+			String md = view.getMarkdown();
+			if (pos < 1 || gwt.isWhitespace(md.substring(pos-1, pos))) {
+				insertUserLink();	
+			}
 		}
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
@@ -576,4 +576,23 @@ public class MarkdownEditorWidgetTest {
 		presenter.onKeyPress('@');
 		verify(mockUserSelector).show();
 	}
+
+	@Test
+	public void testOnKeyPressBeginningOfMarkdown() {
+		when(mockView.getCursorPos()).thenReturn(0);
+		when(mockView.getMarkdown()).thenReturn("");
+		when(mockGwt.isWhitespace(anyString())).thenReturn(false);
+		presenter.onKeyPress('@');
+		verify(mockUserSelector).show();
+	}
+	
+	@Test
+	public void testOnKeyPressNotWhitespace() {
+		// typing an @ at the end of the string 'email'
+		when(mockView.getCursorPos()).thenReturn(5);
+		when(mockView.getMarkdown()).thenReturn("email");
+		when(mockGwt.isWhitespace(anyString())).thenReturn(false);
+		presenter.onKeyPress('@');
+		verify(mockUserSelector, never()).show();
+	}
 }


### PR DESCRIPTION
…@ key event (or we're at the beginning of the md)
