### PR TITLE
SWC-2874: simplify markdown html5 video config editor

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
@@ -563,7 +563,7 @@ public class DisplayConstants {
 	public static final String FIND_IMAGE_ENTITY = "Find Image File Entity";
 	public static final String ERROR_ENTER_AT_LEAST_ONE_ENTITY = "Please enter at least one entity";
 	public static final String ERROR_ENTER_DEPTH = "Please enter a valid depth";
-	public static final String ERROR_ENTER_AT_LEAST_ONE_VIDEO_FILE = "Please set at least one video file format";
+	public static final String ERROR_SELECT_VIDEO_FILE = "Please select a video file";
 	public static final String FIND_ENTITIES = "Find Entities";
 	public static final String FIND_ENTITY = "Find Entity";
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigEditor.java
@@ -1,22 +1,41 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
+import static org.sagebionetworks.repo.model.EntityBundle.FILE_NAME;
+
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.sagebionetworks.repo.model.EntityBundle;
+import org.sagebionetworks.repo.model.Reference;
+import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.widget.WidgetEditorPresenter;
 import org.sagebionetworks.web.client.widget.entity.dialog.DialogCallback;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEditorPresenter {
 	
 	private VideoConfigView view;
 	private Map<String, String> descriptor;
+	private SynapseClientAsync synapseClient;
+	public static enum VIDEO_TYPE { MP4, OGG, WEBM }
+	
+	private static final String[] MP4_EXTENSIONS = new String[] {".mp4", ".m4a", ".m4p", ".m4b", ".m4r", ".m4v"};
+	private static final HashSet<String> MP4_EXTENSIONS_SET = new HashSet<String>(Arrays.asList(MP4_EXTENSIONS));
+	
+	private static final String[] OGG_EXTENSIONS = new String[] {".ogv", ".ogg"};
+	private static final HashSet<String> OGG_EXTENSIONS_SET = new HashSet<String>(Arrays.asList(OGG_EXTENSIONS));
+	VIDEO_TYPE currentType;
+	
 	@Inject
-	public VideoConfigEditor(VideoConfigView view) {
+	public VideoConfigEditor(VideoConfigView view, SynapseClientAsync synapseClient) {
 		this.view = view;
+		this.synapseClient = synapseClient;
 		view.setPresenter(this);
 		view.initView();
 	}		
@@ -24,14 +43,15 @@ public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEdito
 	@Override
 	public void configure(WikiPageKey wikiKey, Map<String, String> widgetDescriptor, DialogCallback dialogCallback) {
 		descriptor = widgetDescriptor;		
-		if (descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY) != null)
-			view.setMp4Entity(descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY));
-		
-		if (descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY) != null){
-			view.setOggEntity(descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY));
-		}
-		if (descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY) != null){
-			view.setWebMEntity(descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY));
+		if (descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY) != null) {
+			currentType = VIDEO_TYPE.MP4;
+			view.setEntity(descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY));
+		} else if (descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY) != null){
+			currentType = VIDEO_TYPE.OGG;
+			view.setEntity(descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY));
+		} else if (descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY) != null){
+			currentType = VIDEO_TYPE.WEBM;
+			view.setEntity(descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY));
 		}
 	}
 	
@@ -44,17 +64,93 @@ public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEdito
 	public Widget asWidget() {
 		return view.asWidget();
 	}
+	@Override
+	public void validateSelection(final Reference ref) {
+		//determine what video type this is
+		view.setVideoFormatWarningVisible(false);
+		final String entityId = ref.getTargetId();
+		int mask = FILE_NAME;
+		AsyncCallback<EntityBundle> ebCallback = new AsyncCallback<EntityBundle> () {
+			@Override
+			public void onFailure(Throwable caught) {
+				view.showFinderError(caught.getMessage());
+			}
+
+			@Override
+			public void onSuccess(EntityBundle result) {
+				currentType = null;
+				String fileName = result.getFileName();
+				if (isRecognizedMP4FileName(fileName)) {
+					currentType = VIDEO_TYPE.MP4;
+					
+				} else {
+					view.setVideoFormatWarningVisible(true);
+					if (isRecognizedOggFileName(fileName)) {
+						currentType = VIDEO_TYPE.OGG;
+					} else if (isRecognizedWebMFileName(fileName)) {
+						currentType = VIDEO_TYPE.WEBM;
+					} else {
+						view.showFinderError("Unrecognized video format");
+					}
+				}
+				if (currentType != null) {
+					view.setEntity(entityId);
+					view.hideFinder();
+				}
+			}
+			
+		};
+		synapseClient.getEntityBundle(ref.getTargetId(), mask, ebCallback);
+	}
+	
+	public static boolean isRecognizedMP4FileName(String fileName) {
+		String extension = getExtension(fileName);
+		if (extension != null) {
+			return MP4_EXTENSIONS_SET.contains(extension);
+		}
+		return false;
+	}
+	
+	public static boolean isRecognizedWebMFileName(String fileName) {
+		String extension = getExtension(fileName);
+		if (extension != null) {
+			return ".webm".equals(extension);
+		}
+		return false;
+	}
+	
+	public static boolean isRecognizedOggFileName(String fileName) {
+		String extension = getExtension(fileName);
+		if (extension != null) {
+			return OGG_EXTENSIONS_SET.contains(extension);
+		}
+		return false;
+	}
+	
+	private static String getExtension(String fileName) {
+		if (fileName != null) {
+			int lastDot = fileName.lastIndexOf(".");
+			if (lastDot > -1) {
+				return fileName.substring(lastDot).toLowerCase();
+			}
+		}
+		return null;
+	}
+	
 	
 	@Override
 	public void updateDescriptorFromView() {
 		//update widget descriptor from the view
 		view.checkParams();
-		if (!"".equals(view.getMp4Entity()))
-			descriptor.put(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY, view.getMp4Entity());
-		if (!"".equals(view.getOggEntity()))
-			descriptor.put(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY, view.getOggEntity());
-		if (!"".equals(view.getWebMEntity()))
-			descriptor.put(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY, view.getWebMEntity());
+		String entityId = view.getEntity();
+		descriptor.clear();
+		if (VIDEO_TYPE.MP4.equals(currentType)) {
+			descriptor.put(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY, entityId);
+		} else if (VIDEO_TYPE.OGG.equals(currentType)) {
+			descriptor.put(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY, entityId);
+		} else if (VIDEO_TYPE.WEBM.equals(currentType)) {
+			descriptor.put(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY, entityId);
+		}
 	}
 	
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigEditor.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEditorPresenter {
 	
+	public static final String UNRECOGNIZED_VIDEO_FORMAT_MESSAGE = "Unrecognized video format";
 	private VideoConfigView view;
 	private Map<String, String> descriptor;
 	private SynapseClientAsync synapseClient;
@@ -55,7 +56,6 @@ public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEdito
 		}
 	}
 	
-	@SuppressWarnings("unchecked")
 	public void clearState() {
 		view.clear();
 	}
@@ -90,7 +90,7 @@ public class VideoConfigEditor implements VideoConfigView.Presenter, WidgetEdito
 					} else if (isRecognizedWebMFileName(fileName)) {
 						currentType = VIDEO_TYPE.WEBM;
 					} else {
-						view.showFinderError("Unrecognized video format");
+						view.showFinderError(UNRECOGNIZED_VIDEO_FORMAT_MESSAGE);
 					}
 				}
 				if (currentType != null) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigView.java
@@ -4,7 +4,6 @@ import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.widget.WidgetEditorView;
 
 import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 
 public interface VideoConfigView extends IsWidget, WidgetEditorView {
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigView.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
+import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.widget.WidgetEditorView;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 
 public interface VideoConfigView extends IsWidget, WidgetEditorView {
 
@@ -12,19 +14,16 @@ public interface VideoConfigView extends IsWidget, WidgetEditorView {
 	 */
 	void setPresenter(Presenter presenter);
 	
-	void setMp4Entity(String mp4Entity);
-	String getMp4Entity();
-	void setOggEntity(String mp4Entity);
-	String getOggEntity();
-	
-	void setWebMEntity(String mp4Entity);
-	String getWebMEntity();
-	
+	void setEntity(String entity);
+	String getEntity();
+	void hideFinder();
+	void setVideoFormatWarningVisible(boolean visible);
+	void showFinderError(String error);
 	/**
 	 * Presenter interface
 	 */
 	public interface Presenter {
-
+		void validateSelection(Reference ref);
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.java
@@ -1,10 +1,11 @@
 package org.sagebionetworks.web.client.widget.entity.editor;
 
-import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.Column;
+import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.repo.model.Reference;
-import org.sagebionetworks.web.client.ClientProperties;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.DisplayUtils.SelectedHandler;
@@ -22,20 +23,11 @@ public class VideoConfigViewImpl implements VideoConfigView {
 	public interface VideoConfigViewImplUiBinder extends UiBinder<Widget, VideoConfigViewImpl> {}
 	private Presenter presenter;
 	@UiField
-	TextBox mp4Entity;
+	TextBox entity;
 	@UiField
-	TextBox oggEntity;
+	Button button;
 	@UiField
-	TextBox webmEntity;
-	@UiField
-	Button mp4Button;
-	@UiField
-	Button oggButton;
-	@UiField
-	Button webmButton;
-	@UiField
-	Anchor moreInfoLink;
-	
+	Heading videoFormatWarning;
 	EntityFinder entityFinder;
 	
 	Widget widget;
@@ -45,15 +37,7 @@ public class VideoConfigViewImpl implements VideoConfigView {
 			EntityFinder entityFinder) {
 		widget = binder.createAndBindUi(this);
 		this.entityFinder = entityFinder;
-		mp4Button.addClickHandler(getClickHandler(mp4Entity));
-		oggButton.addClickHandler(getClickHandler(oggEntity));
-		webmButton.addClickHandler(getClickHandler(webmEntity));
-		moreInfoLink.addClickHandler(new ClickHandler() {
-			@Override
-			public void onClick(ClickEvent event) {
-				DisplayUtils.newWindow(ClientProperties.VIDEO_HTML5_BROWSER_LINK, "", "");
-			}
-		});
+		button.addClickHandler(getClickHandler(entity));
 	}
 	
 	@Override
@@ -67,8 +51,7 @@ public class VideoConfigViewImpl implements VideoConfigView {
 				entityFinder.configure(EntityFilter.FILE, false, new SelectedHandler<Reference>() {					
 					@Override
 					public void onSelected(Reference selected) {
-						textBox.setValue(selected.getTargetId());
-						entityFinder.hide();
+						presenter.validateSelection(selected);
 					}
 				});
 				entityFinder.show();
@@ -77,9 +60,14 @@ public class VideoConfigViewImpl implements VideoConfigView {
 	}
 	
 	@Override
+	public void hideFinder() {
+		entityFinder.hide();
+	}
+	
+	@Override
 	public void checkParams() throws IllegalArgumentException {
-		if ("".equals(mp4Entity.getValue()) && "".equals(oggEntity.getValue()) && "".equals(webmEntity.getValue()))
-			throw new IllegalArgumentException(DisplayConstants.ERROR_ENTER_AT_LEAST_ONE_VIDEO_FILE);
+		if ("".equals(entity.getValue()))
+			throw new IllegalArgumentException(DisplayConstants.ERROR_SELECT_VIDEO_FILE);
 	}
 
 	@Override
@@ -107,40 +95,26 @@ public class VideoConfigViewImpl implements VideoConfigView {
 	}
 	
 	@Override
-	public String getMp4Entity() {
-		return mp4Entity.getValue();
+	public String getEntity() {
+		return entity.getValue();
 	}
 	
 	@Override
-	public void setMp4Entity(String mp4EntityString) {
-		mp4Entity.setValue(mp4EntityString);
-	}
-	
-	@Override
-	public String getOggEntity() {
-		return oggEntity.getValue();
-	}
-	
-	@Override
-	public void setOggEntity(String oggEntityString) {
-		oggEntity.setValue(oggEntityString);
-	}
-	
-	@Override
-	public String getWebMEntity() {
-		return webmEntity.getValue();
-	}
-	
-	@Override
-	public void setWebMEntity(String webMEntityString) {
-		webmEntity.setValue(webMEntityString);
+	public void setEntity(String entityString) {
+		entity.setValue(entityString);
 	}
 	
 	@Override
 	public void clear() {
-		mp4Entity.setValue("");
-		oggEntity.setValue("");
-		webmEntity.setValue("");
+		entity.setValue("");
+		setVideoFormatWarningVisible(false);
 	}
-	
+	@Override
+	public void setVideoFormatWarningVisible(boolean visible) {
+		videoFormatWarning.setVisible(visible);
+	}
+	@Override
+	public void showFinderError(String error) {
+		entityFinder.showError(error);
+	}
 }

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.ui.xml
@@ -5,48 +5,21 @@
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	
 	<bh:Div>
-		<g:FlowPanel addStyleNames="margin-10">
-			<b:Heading size="H5" text="The browser viewing the video will use the first format that it recognizes." addStyleNames="displayInline" />
-			<b:Anchor ui:field="moreInfoLink" addStyleNames="margin-left-5" text="more information" />
-		</g:FlowPanel>
 		<b:Row addStyleNames="margin-10">
-			<b:Column size="XS_6">
-				<b:Tooltip title="MPEG 4 files with H264 video codec and AAC audio codec">
-					<b:InputGroup>
-						<b:TextBox ui:field="mp4Entity" autoComplete="false" enabled="false" />
-						<b:InputGroupButton>
-							<b:Button text="Find MP4" ui:field="mp4Button" icon="SEARCH" width="120px"/>
-						</b:InputGroupButton>
-					</b:InputGroup>
-				</b:Tooltip>
+			<b:Column size="XS_12">
+				<b:InputGroup>
+					<b:TextBox ui:field="entity" autoComplete="false" enabled="false" />
+					<b:InputGroupButton>
+						<b:Button text="Find video file" ui:field="button" icon="SEARCH" width="140px"/>
+					</b:InputGroupButton>
+				</b:InputGroup>
 			</b:Column>
-			<b:Column size="XS_6" />
-		</b:Row>
-		<b:Row addStyleNames="margin-10">
-			<b:Column size="XS_6">
-				<b:Tooltip title="Ogg files with Theora video codec and Vorbis audio codec">
-					<b:InputGroup>
-						<b:TextBox ui:field="oggEntity" autoComplete="false" enabled="false" />
-						<b:InputGroupButton>
-							<b:Button text="Find Ogg" ui:field="oggButton" icon="SEARCH" width="120px"/>
-						</b:InputGroupButton>
-					</b:InputGroup>
-				</b:Tooltip>
+			<b:Column size="XS_12" >
+				<b:Heading size="H5" ui:field="videoFormatWarning" visible="false">
+					<bh:Text>We recommend using the mp4 video format for</bh:Text>
+					<b:Anchor ui:field="moreInfoLink" target="_blank" addStyleNames="margin-left-5" text="cross-browser compatability" href="http://en.wikipedia.org/wiki/HTML5_video#Browser_support"/>
+				</b:Heading>
 			</b:Column>
-			<b:Column size="XS_6" />
-		</b:Row>
-		<b:Row addStyleNames="margin-10">
-			<b:Column size="XS_6">
-				<b:Tooltip title="WebM files with VP8 video codec and Vorbis audio codec">
-					<b:InputGroup>
-						<b:TextBox ui:field="webmEntity" autoComplete="false" enabled="false" />
-						<b:InputGroupButton>
-							<b:Button text="Find WebM" ui:field="webmButton" icon="SEARCH" width="120px"/>
-						</b:InputGroupButton>
-					</b:InputGroup>
-				</b:Tooltip>
-			</b:Column>
-			<b:Column size="XS_6" />
 		</b:Row>
 	</bh:Div>
 </ui:UiBinder>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/VideoConfigEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/VideoConfigEditorTest.java
@@ -1,9 +1,11 @@
 package org.sagebionetworks.web.unitclient.widget.entity.editor;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -11,22 +13,40 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.sagebionetworks.repo.model.EntityBundle;
 import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.Reference;
+import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.widget.entity.editor.VideoConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.VideoConfigView;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
+import org.sagebionetworks.web.test.helper.AsyncMockStubber;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public class VideoConfigEditorTest {
 		
 	VideoConfigEditor editor;
 	VideoConfigView mockView;
 	WikiPageKey wikiKey = new WikiPageKey("", ObjectType.ENTITY.toString(), null);
-	
+	@Mock
+	SynapseClientAsync mockSynapseClient;
+	@Mock
+	EntityBundle mockBundle;
+	@Mock
+	Reference mockSelectedEntityReference;
+	String selectedEntityId = "syn9347";
 	@Before
 	public void setup(){
+		MockitoAnnotations.initMocks(this);
 		mockView = mock(VideoConfigView.class);
-		editor = new VideoConfigEditor(mockView);
+		editor = new VideoConfigEditor(mockView, mockSynapseClient);
+		
+		AsyncMockStubber.callSuccessWith(mockBundle).when(mockSynapseClient).getEntityBundle(anyString(), anyInt(), any(AsyncCallback.class));
+		when(mockSelectedEntityReference.getTargetId()).thenReturn(selectedEntityId);
 	}
 	
 	@Test
@@ -47,33 +67,124 @@ public class VideoConfigEditorTest {
 		descriptor.put(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY, oggVideoId);
 		
 		editor.configure(wikiKey, descriptor, null);
-		verify(mockView).setMp4Entity(eq(mp4VideoId));
-		verify(mockView).setWebMEntity(eq(webMVideoId));
-		verify(mockView).setOggEntity(eq(oggVideoId));
-		
+		verify(mockView).setEntity(eq(mp4VideoId));
 	}
 	
+	@Test
 	public void testUpdateDescriptorFromView() {
 		String mp4VideoId = "syn123";
-		String webMVideoId = "syn456";
-		String oggVideoId = "syn789";
-
-		when(mockView.getMp4Entity()).thenReturn(mp4VideoId);
-		when(mockView.getWebMEntity()).thenReturn(webMVideoId);
-		when(mockView.getOggEntity()).thenReturn(oggVideoId);
-
+		when(mockView.getEntity()).thenReturn(mp4VideoId);
 		Map<String, String> descriptor = new HashMap<String, String>();
+		descriptor.put(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY, mp4VideoId);
 		editor.configure(wikiKey, descriptor, null);
-		
 		editor.updateDescriptorFromView();
 		verify(mockView).checkParams();
-		verify(mockView).getMp4Entity();
-		verify(mockView).getWebMEntity();
-		verify(mockView).getOggEntity();
-
+		verify(mockView).getEntity();
 		//verify descriptor has the expected values
 		assertEquals(mp4VideoId, descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY));
-		assertEquals(webMVideoId, descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY));
-		assertEquals(oggVideoId, descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY));
+	}
+	
+
+	@Test
+	public void testValidateSelectionMP4() {
+		String fileName = "video.Mp4";
+		when(mockBundle.getFileName()).thenReturn(fileName);
+		
+		Map<String, String> descriptor = new HashMap<String, String>();
+		editor.configure(wikiKey, descriptor, null);
+		editor.validateSelection(mockSelectedEntityReference);
+		
+		verify(mockSynapseClient).getEntityBundle(eq(selectedEntityId), anyInt(), any(AsyncCallback.class));
+		verify(mockView, never()).setVideoFormatWarningVisible(true);
+		verify(mockView).setEntity(selectedEntityId);
+		verify(mockView).hideFinder();
+		
+		when(mockView.getEntity()).thenReturn(selectedEntityId);
+		editor.updateDescriptorFromView();
+		assertEquals(selectedEntityId, descriptor.get(WidgetConstants.VIDEO_WIDGET_MP4_SYNAPSE_ID_KEY));
+	}
+	
+	@Test
+	public void testValidateSelectionOgg() {
+		String fileName = "video.Ogg";
+		when(mockBundle.getFileName()).thenReturn(fileName);
+		
+		Map<String, String> descriptor = new HashMap<String, String>();
+		editor.configure(wikiKey, descriptor, null);
+		editor.validateSelection(mockSelectedEntityReference);
+		
+		verify(mockSynapseClient).getEntityBundle(eq(selectedEntityId), anyInt(), any(AsyncCallback.class));
+		verify(mockView).setVideoFormatWarningVisible(true);
+		verify(mockView).setEntity(selectedEntityId);
+		verify(mockView).hideFinder();
+		
+		when(mockView.getEntity()).thenReturn(selectedEntityId);
+		editor.updateDescriptorFromView();
+		assertEquals(selectedEntityId, descriptor.get(WidgetConstants.VIDEO_WIDGET_OGG_SYNAPSE_ID_KEY));
+	}
+	
+	@Test
+	public void testValidateSelectionWebm() {
+		String fileName = "video.WebM";
+		when(mockBundle.getFileName()).thenReturn(fileName);
+		
+		Map<String, String> descriptor = new HashMap<String, String>();
+		editor.configure(wikiKey, descriptor, null);
+		editor.validateSelection(mockSelectedEntityReference);
+		
+		verify(mockSynapseClient).getEntityBundle(eq(selectedEntityId), anyInt(), any(AsyncCallback.class));
+		verify(mockView).setVideoFormatWarningVisible(true);
+		verify(mockView).setEntity(selectedEntityId);
+		verify(mockView).hideFinder();
+		
+		when(mockView.getEntity()).thenReturn(selectedEntityId);
+		editor.updateDescriptorFromView();
+		assertEquals(selectedEntityId, descriptor.get(WidgetConstants.VIDEO_WIDGET_WEBM_SYNAPSE_ID_KEY));
+	}
+	
+	@Test
+	public void testValidateSelectionInvalidType() {
+		String fileName = "video.not.recognized";
+		when(mockBundle.getFileName()).thenReturn(fileName);
+		
+		editor.validateSelection(mockSelectedEntityReference);
+		
+		verify(mockSynapseClient).getEntityBundle(eq(selectedEntityId), anyInt(), any(AsyncCallback.class));
+		verify(mockView).setVideoFormatWarningVisible(true);
+		verify(mockView).showFinderError(VideoConfigEditor.UNRECOGNIZED_VIDEO_FORMAT_MESSAGE);
+		verify(mockView, never()).setEntity(selectedEntityId);
+		verify(mockView, never()).hideFinder();
+	}
+	
+	@Test
+	public void testValidateSelectionRPCError() {
+		Exception ex = new Exception("error seeking file name");
+		AsyncMockStubber.callFailureWith(ex).when(mockSynapseClient).getEntityBundle(anyString(), anyInt(), any(AsyncCallback.class));
+		editor.validateSelection(mockSelectedEntityReference);
+		
+		verify(mockSynapseClient).getEntityBundle(eq(selectedEntityId), anyInt(), any(AsyncCallback.class));
+		verify(mockView).showFinderError(ex.getMessage());
+	}
+	
+	
+
+	@Test
+	public void testRecognizedFiletype() {
+		assertTrue(VideoConfigEditor.isRecognizedMP4FileName("video.mp4"));
+		assertTrue(VideoConfigEditor.isRecognizedMP4FileName("video.1.m4a"));
+		assertTrue(VideoConfigEditor.isRecognizedMP4FileName("video.m4R"));
+		assertTrue(VideoConfigEditor.isRecognizedMP4FileName("video.2.M4V"));
+		assertTrue(VideoConfigEditor.isRecognizedMP4FileName("video.m4R"));
+		assertFalse(VideoConfigEditor.isRecognizedMP4FileName("video.m44"));
+		assertFalse(VideoConfigEditor.isRecognizedMP4FileName("video.OGG"));
+		
+		assertTrue(VideoConfigEditor.isRecognizedOggFileName("video.1.ogg"));
+		assertTrue(VideoConfigEditor.isRecognizedOggFileName("video.OGV"));
+		assertFalse(VideoConfigEditor.isRecognizedOggFileName("video.webm"));
+		assertFalse(VideoConfigEditor.isRecognizedOggFileName("video.mp4"));
+		
+		assertTrue(VideoConfigEditor.isRecognizedWebMFileName("video.1.webm"));
+		assertFalse(VideoConfigEditor.isRecognizedWebMFileName("video.1.mp4"));
+		assertFalse(VideoConfigEditor.isRecognizedWebMFileName("video.1.ogg"));
 	}
 }


### PR DESCRIPTION
Single entity selection.  Warn about format if not mp4 (with link to browser compatibility table), and don't allow selection unless it's a recognized extension.  More specifically, we're now looking for a file with an extension:
".mp4", ".m4a", ".m4p", ".m4b", ".m4r", ".m4v", ".ogv", ".ogg", or "webm"
