### PR TITLE
SWC-3095: when profile page is initialized, replace state instead of pushing new items onto the browser history

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -220,7 +220,7 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 	}
 	
 	public void updateArea(ProfileArea area, boolean pushState) {
-		if (area != null && !area.equals(place.getArea())) {
+		if (area != null && place != null && !area.equals(place.getArea())) {
 			place.setArea(area, filterType, filterTeamId);
 			if (pushState) {
 				globalApplicationState.pushCurrentPlace(place);	
@@ -237,7 +237,7 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		isOwner = authenticationController.isLoggedIn()
 				&& authenticationController.getCurrentUserPrincipalId().equals(
 						userId);
-		if (ProfileArea.SETTINGS.equals(currentArea) && !isOwner) {
+		if (currentArea == null || (ProfileArea.SETTINGS.equals(currentArea) && !isOwner)) {
 			currentArea = ProfileArea.PROJECTS;
 		}
 		this.currentProjectSort = SortOptionEnum.LATEST_ACTIVITY;
@@ -503,7 +503,8 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		}
 		this.filterType = filterType;
 		this.filterTeamId = filterTeamId;
-		place.setArea(ProfileArea.PROJECTS, filterType, filterTeamId);
+		if (place != null)
+			place.setArea(ProfileArea.PROJECTS, filterType, filterTeamId);
 		refreshProjects();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -58,6 +58,7 @@ import org.sagebionetworks.web.shared.ProjectPagedResults;
 import org.sagebionetworks.web.shared.exceptions.ConflictException;
 
 import com.google.gwt.activity.shared.AbstractActivity;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.place.shared.Place;
 import com.google.gwt.user.client.Window;
@@ -218,10 +219,14 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		globalApplicationState.getPlaceChanger().goTo(place);
 	}
 	
-	public void updateArea(ProfileArea area) {
+	public void updateArea(ProfileArea area, boolean pushState) {
 		if (area != null && !area.equals(place.getArea())) {
 			place.setArea(area, filterType, filterTeamId);
-			globalApplicationState.pushCurrentPlace(place);
+			if (pushState) {
+				globalApplicationState.pushCurrentPlace(place);	
+			} else {
+				globalApplicationState.replaceCurrentPlace(place);
+			}
 		}
 	}
 	
@@ -251,12 +256,14 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 				@Override
 				public void invoke() {
 					getUserProfile();
-					tabClicked(currentArea);
+					boolean pushState = false;
+					showTab(currentArea, pushState);
 				}
 			});
 		} else {
 			getUserProfile();
-			tabClicked(currentArea);
+			boolean pushState = false;
+			showTab(currentArea, pushState);
 		}
 	}
 	
@@ -497,7 +504,6 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		this.filterType = filterType;
 		this.filterTeamId = filterTeamId;
 		place.setArea(ProfileArea.PROJECTS, filterType, filterTeamId);
-		globalApplicationState.pushCurrentPlace(place);
 		refreshProjects();
 	}
 
@@ -979,6 +985,12 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		return isOwner;
 	}
 	
+	public void showTab(ProfileArea tab, boolean pushState) {
+		updateArea(tab, pushState);
+		refreshData(tab);
+		view.setTabSelected(tab);
+	}
+	
 	@Override
 	public void tabClicked(final ProfileArea tab) {
 		if (tab == null) {
@@ -990,18 +1002,16 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 			Callback yesCallback = new Callback() {
 				@Override
 				public void invoke() {
-					refreshData(tab);
-					view.setTabSelected(tab);
-					updateArea(tab);
+					boolean pushState = true;
+					showTab(tab, pushState);
 				}
 			};
 			view.showConfirmDialog("",
 					DisplayConstants.NAVIGATE_AWAY_CONFIRMATION_MESSAGE,
 					yesCallback);
 		} else {
-			refreshData(tab);
-			view.setTabSelected(tab);
-			updateArea(tab);
+			boolean pushState = true;
+			showTab(tab, pushState);
 		}
 	}
 	
@@ -1056,6 +1066,7 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 			filterTeamId = team.getId();
 		}
 		setProjectFilterAndRefresh(filterType, filterTeamId);
+		globalApplicationState.pushCurrentPlace(place);
 	}
 	
 	@Override

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -333,9 +333,6 @@ public class ProfilePresenterTest {
 		profilePresenter.setPlace(place);
 		verify(mockUserProfileClient).getUserBundle(anyLong(), anyInt(), any(AsyncCallback.class));
 		
-		verify(mockSynapseClient, never()).getTeamsForUser(anyString(), anyBoolean(), any(AsyncCallback.class));
-		profilePresenter.tabClicked(ProfileArea.TEAMS);
-		//also verify that it is asking for the correct teams
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		verify(mockSynapseClient).getTeamsForUser(captor.capture(), anyBoolean(), any(AsyncCallback.class));
 		
@@ -389,8 +386,6 @@ public class ProfilePresenterTest {
 		verify(mockUserProfileClient).getUserBundle(anyLong(), anyInt(), any(AsyncCallback.class));
 		
 		//also verify that it is asking for the correct teams
-		verify(mockSynapseClient, never()).getTeamsForUser(anyString(), anyBoolean(), any(AsyncCallback.class));
-		profilePresenter.tabClicked(ProfileArea.TEAMS);
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		verify(mockSynapseClient).getTeamsForUser(captor.capture(), anyBoolean(), any(AsyncCallback.class));
 		assertEquals(myPrincipalId, captor.getValue());

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -1289,15 +1289,26 @@ public class ProfilePresenterTest {
 	public void testUpdateArea() {
 		profilePresenter.setPlace(place);
 		when(place.getArea()).thenReturn(ProfileArea.PROJECTS);
-		profilePresenter.updateArea(ProfileArea.CHALLENGES);
+		boolean pushState = true;
+		profilePresenter.updateArea(ProfileArea.CHALLENGES, pushState);
 		verify(mockGlobalApplicationState).pushCurrentPlace(any(Profile.class));
+	}
+	
+	@Test
+	public void testUpdateAreaReplacestate() {
+		profilePresenter.setPlace(place);
+		when(place.getArea()).thenReturn(ProfileArea.PROJECTS);
+		boolean pushState = false;
+		profilePresenter.updateArea(ProfileArea.CHALLENGES, pushState);
+		verify(mockGlobalApplicationState).replaceCurrentPlace(any(Profile.class));
 	}
 
 	@Test
 	public void testUpdateAreaNoChange() {
 		profilePresenter.setPlace(place);
 		when(place.getArea()).thenReturn(ProfileArea.PROJECTS);
-		profilePresenter.updateArea(ProfileArea.PROJECTS);
+		boolean pushState = true;
+		profilePresenter.updateArea(ProfileArea.PROJECTS, false);
 		verify(mockPlaceChanger, never()).goTo(any(Profile.class));
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -671,6 +671,7 @@ public class ProfilePresenterTest {
 		profilePresenter.applyFilterClicked(ProjectFilterEnum.ALL, null);
 		verify(mockSynapseClient).getMyProjects(eq(ProjectListType.MY_PROJECTS), anyInt(), anyInt(), any(ProjectListSortColumn.class), any(SortDirection.class),  any(AsyncCallback.class));
 		verify(mockView).setProjectSortVisible(true);
+		verify(mockGlobalApplicationState).pushCurrentPlace(any(Place.class));
 	}
 	
 	@Test


### PR DESCRIPTION
on tab click (or project filter), push place into browser history.
