### PR TITLE
help widget: make more info link optional

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
@@ -3,6 +3,8 @@ package org.sagebionetworks.web.client.widget;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Popover;
 import org.gwtbootstrap3.client.ui.constants.Placement;
+import org.sagebionetworks.web.client.MarkdownIt;
+import org.sagebionetworks.web.client.MarkdownItImpl;
 
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.dom.client.SpanElement;
@@ -38,37 +40,30 @@ public class HelpWidget implements IsWidget {
 	@UiField
 	Popover helpPopover;
 	Widget widget;
+	private static MarkdownIt markdownIt = new MarkdownItImpl();
 	public interface Binder extends UiBinder<Widget, HelpWidget> {}
 	private static Binder uiBinder = GWT.create(Binder.class);
-	String text, basicHelpText, fullHelpHref;
+	String text="", basicHelpText="", moreHelpHTML="";
 	public HelpWidget() {
 		widget = uiBinder.createAndBindUi(this);
 	}
 
-	public void configure(String text, String basicHelpText, String fullHelpHref) {
-		this.text = text;
-		this.basicHelpText = basicHelpText;
-		this.fullHelpHref = fullHelpHref;
-	}
-	
 	public void setText(String text) {
-		moreInfoText.setInnerText(text);
+		this.text = text;
 	}
 	
-	public void setHelp(String basicHelpText) {
-		this.basicHelpText = basicHelpText;
+	public void setHelpMarkdown(String md) {
+		this.basicHelpText = markdownIt.markdown2Html(md, "");
 	}
 	
 	public void setHref(String fullHelpHref) {
-		this.fullHelpHref = fullHelpHref;
+		this.moreHelpHTML = "<div><a class=\"btn btn-primary btn-xs right\" target=\"_blank\" href=\"" + SafeHtmlUtils.htmlEscape(fullHelpHref) + "\" role=\"button\">More info</a></div>";
 	}
 	
 	@Override
 	public Widget asWidget() {
-		if (text != null) {
-			moreInfoText.setInnerText(text);
-		}
-		helpPopover.setContent(SafeHtmlUtils.htmlEscape(basicHelpText) + "<div><a class=\"btn btn-primary btn-xs right\" target=\"_blank\" href=\"" + SafeHtmlUtils.htmlEscape(fullHelpHref) + "\" role=\"button\">More info</a></div>");
+		moreInfoText.setInnerText(text);
+		helpPopover.setContent(basicHelpText + moreHelpHTML);
 		return widget;
 	}
 	

--- a/src/main/resources/org/sagebionetworks/web/client/view/ComingSoonViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ComingSoonViewImpl.ui.xml
@@ -17,8 +17,10 @@
 	<g:HTMLPanel>
 		<!-- HEADER -->
 		<g:SimplePanel ui:field="header" />
-		<w:HelpWidget text="Optional help link text" help="This contains concise but basic help." href="http://link/to/more/help" placement="BOTTOM" />
-		
+		<g:FlowPanel addStyleNames="margin-bottom-60 margin-top-100">
+			<w:HelpWidget text="Optional help link text" helpMarkdown="This contains basic help." href="http://link/to/more/help" placement="BOTTOM" />
+			<w:HelpWidget helpMarkdown="This contains **very basic** markdown, perhaps with a [link](http://www.jayhodgson.com)."/>
+		</g:FlowPanel>
 		<g:SimplePanel ui:field="fileHandleListContainer" />
 		
 		<h2>Coming Soon</h2>


### PR DESCRIPTION
and run the basic help text through the markdown processor.

<img width="332" alt="markdown help without link to more info" src="https://cloud.githubusercontent.com/assets/1864447/16429967/3bdd8fb8-3d2e-11e6-880b-883bf5245d05.png">
<img width="197" alt="basic help with link" src="https://cloud.githubusercontent.com/assets/1864447/16429966/3bdbf784-3d2e-11e6-9a41-2bb62004e1e7.png">
