### PR TITLE
SWC-3172: show login widget in Synapse Alert instead of button.

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -116,6 +116,7 @@ import org.sagebionetworks.web.client.widget.entity.renderer.VimeoWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.WikiFilesPreviewWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.WikiSubpagesWidget;
 import org.sagebionetworks.web.client.widget.entity.renderer.YouTubeWidget;
+import org.sagebionetworks.web.client.widget.login.LoginWidget;
 import org.sagebionetworks.web.client.widget.provenance.ProvenanceWidget;
 import org.sagebionetworks.web.client.widget.refresh.DiscussionThreadCountAlert;
 import org.sagebionetworks.web.client.widget.refresh.RefreshAlert;
@@ -399,4 +400,6 @@ public interface PortalGinInjector extends Ginjector {
 
 	// docker
 	public DockerRepoWidget createNewDockerRepoWidget();
+	
+	public LoginWidget getLoginWidget();
 }

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ErrorPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ErrorPresenter.java
@@ -56,7 +56,7 @@ public class ErrorPresenter extends AbstractActivity implements ErrorView.Presen
 				jsniUtils.consoleError(result.getMessage());
 				jsniUtils.consoleError(result.getStacktrace());
 				if (!synAlert.isUserLoggedIn()) {
-					synAlert.showSuggestLogin();
+					synAlert.showLogin();
 				}
 			}
 			

--- a/src/main/java/org/sagebionetworks/web/client/widget/biodalliance13/BiodallianceWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/biodalliance13/BiodallianceWidget.java
@@ -72,7 +72,7 @@ public class BiodallianceWidget implements BiodallianceWidgetView.Presenter, IsW
 			List<BiodallianceSource> sources) {
 		synAlert.clear();
 		if (!authenticationController.isLoggedIn()) {
-			synAlert.showMustLogin();
+			synAlert.showLogin();
 		} else {
 			this.initChr = initChr;
 		    this.initViewStart = initViewStart;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
@@ -138,7 +138,7 @@ public class PreviewWidget implements PreviewWidgetView.Presenter, WidgetRendere
 		//if not logged in, don't even try to load the preview.  Just direct user to log in.
 		if (!synapseAlert.isUserLoggedIn()) {
 			view.addSynapseAlertWidget(synapseAlert.asWidget());
-			synapseAlert.showMustLogin();
+			synapseAlert.showLogin();
 		} else if (bundle != null) {
 			if (!(bundle.getEntity() instanceof FileEntity)) {
 				//not a file!

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
@@ -216,7 +216,7 @@ public class PreviewWidget implements PreviewWidgetView.Presenter, WidgetRendere
 		synapseAlert.showError("Unable to load image preview");
 	}
 	
-	public void setHeight(String height) {
-		view.setHeight(height);
+	public void addStyleName(String style) {
+		view.addStyleName(style);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetView.java
@@ -14,7 +14,8 @@ public interface PreviewWidgetView extends IsWidget{
 	public void setImagePreview(String fullFileUrl, String previewUrl);
 	public void setCodePreview(String text);
 	public void setTextPreview(String text);
-	public void setHeight(String height);
+	void addStyleName(String style);
+	
 	/**
 	 * text must not be escaped (a regular expression will be used to split it into cells)
 	 * @param text

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetViewImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.client.widget.entity;
 
+import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.IconsImageBundle;
@@ -81,7 +82,10 @@ public class PreviewWidgetViewImpl extends FlowPanel implements PreviewWidgetVie
 				presenter.imagePreviewLoadFailed(event);
 		    }
 		});
-		add(image);
+		Div div = new Div();
+		div.setHeight("200px");
+		div.add(image);
+		add(div);
 		image.setUrl(previewUrl);
 		
 		currentPopupPreviewWidget = new Image(previewUrl);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlert.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlert.java
@@ -58,7 +58,7 @@ public class StuAlert implements StuAlertView.Presenter  {
 		show403();
 		this.entityId = entityId;
 		if (!authController.isLoggedIn()) {
-			synAlert.showMustLogin();
+			synAlert.showLogin();
 		} else {
 			view.showRequestAccessUI();	
 		}
@@ -97,7 +97,7 @@ public class StuAlert implements StuAlertView.Presenter  {
 		//if it's something that Stu recognizes, then he should handle it.
 		if(ex instanceof ForbiddenException) {			
 			if(!authController.isLoggedIn()) {
-				synAlert.showMustLogin();
+				synAlert.showLogin();
 			} else {
 				view.show403();
 			}
@@ -115,15 +115,9 @@ public class StuAlert implements StuAlertView.Presenter  {
 		view.setVisible(true);
 	}
 	
-	public void showMustLogin() {
+	public void showLogin() {
 		clear();
-		synAlert.showMustLogin();
-		view.setVisible(true);
-	}
-	
-	public void showSuggestLogin() {
-		clear();
-		synAlert.showSuggestLogin();
+		synAlert.showLogin();
 		view.setVisible(true);
 	}
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlert.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlert.java
@@ -22,13 +22,7 @@ public interface SynapseAlert extends IsWidget {
 	 * Called to instruct the widget to ask the user to login to access the resource (with a link to the login page).
 	 * Can be called when you know that the user must be logged in in order to use the widget. 
 	 */
-	void showMustLogin();
-	
-	/**
-	 * Called to instruct the widget to let the user decide if logging in might help solve a shown error.
-	 * 
-	 */
-	void showSuggestLogin();
+	void showLogin();
 	
 	/**
 	 * Convenience method to answer if the user is currently logged in.

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertImpl.java
@@ -2,13 +2,17 @@ package org.sagebionetworks.web.client.widget.entity.controller;
 
 import static org.sagebionetworks.web.client.ClientProperties.DEFAULT_PLACE_TOKEN;
 
+import org.sagebionetworks.repo.model.UserSessionData;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
+import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.place.Down;
 import org.sagebionetworks.web.client.place.LoginPlace;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.widget.entity.JiraURLHelper;
+import org.sagebionetworks.web.client.widget.login.LoginWidget;
+import org.sagebionetworks.web.client.widget.login.UserListener;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.exceptions.ForbiddenException;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
@@ -25,20 +29,30 @@ public class SynapseAlertImpl implements SynapseAlert, SynapseAlertView.Presente
 	GlobalApplicationState globalApplicationState;
 	AuthenticationController authController;
 	SynapseAlertView view;
+	PortalGinInjector ginInjector;
 	Throwable ex;
-	
+	UserListener reloadOnLoginListener;
 	@Inject
 	public SynapseAlertImpl(
 			SynapseAlertView view,
 			GlobalApplicationState globalApplicationState,
 			AuthenticationController authController,
-			GWTWrapper gwt
+			GWTWrapper gwt,
+			PortalGinInjector ginInjector
 			) {
 		this.view = view;
 		this.globalApplicationState = globalApplicationState;
 		this.authController = authController;
+		this.ginInjector = ginInjector;
 		view.setPresenter(this);
 		view.clearState();
+		
+		reloadOnLoginListener = new UserListener() {
+			@Override
+			public void userChanged(UserSessionData newUser) {
+				SynapseAlertImpl.this.view.reload();
+			}
+		};
 	}
 
 	@Override
@@ -55,7 +69,7 @@ public class SynapseAlertImpl implements SynapseAlert, SynapseAlertView.Presente
 			globalApplicationState.getPlaceChanger().goTo(new LoginPlace(LoginPlace.LOGIN_TOKEN));
 		} else if(ex instanceof ForbiddenException) {			
 			if(!isLoggedIn) {
-				view.showLoginAlert();
+				showLogin();
 			} else {
 				view.showError(DisplayConstants.ERROR_FAILURE_PRIVLEDGES + " " + ex.getMessage());
 			}
@@ -116,11 +130,6 @@ public class SynapseAlertImpl implements SynapseAlert, SynapseAlertView.Presente
 	}
 	
 	@Override
-	public void onLoginClicked() {
-		globalApplicationState.getPlaceChanger().goTo(new LoginPlace(LoginPlace.LOGIN_TOKEN));	
-	}
-	
-	@Override
 	public boolean isUserLoggedIn() {
 		return authController.isLoggedIn();
 	}
@@ -128,7 +137,11 @@ public class SynapseAlertImpl implements SynapseAlert, SynapseAlertView.Presente
 	@Override
 	public void showLogin() {
 		clear();
-		view.showLoginAlert();
+		// lazy inject login widget
+		LoginWidget loginWidget = ginInjector.getLoginWidget();
+		loginWidget.setUserListener(reloadOnLoginListener);
+		view.setLoginWidget(loginWidget.asWidget());
+		view.showLogin();
 	}
 	
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertImpl.java
@@ -126,18 +126,10 @@ public class SynapseAlertImpl implements SynapseAlert, SynapseAlertView.Presente
 	}
 	
 	@Override
-	public void showMustLogin() {
+	public void showLogin() {
 		clear();
 		view.showLoginAlert();
 	}
-	
-	@Override
-	public void showSuggestLogin() {
-		clear();
-		view.showSuggestLoginAlert();
-	}
-	
-	
 	
 	@Override
 	public void clear() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertView.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.client.widget.entity.controller;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 /**
  * Abstraction for the view 
  *
@@ -47,12 +48,14 @@ public interface SynapseAlertView extends IsWidget {
 	 */
 	void showLogin();
 	void setPresenter(Presenter p);
-
+	void setLoginWidget(Widget w);
+	
+	void reload();
+	
 	/**
 	 * Presenter interface
 	 */
 	public interface Presenter {
 		void onCreateJiraIssue(String userReport);
-		void onLoginClicked();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertView.java
@@ -45,11 +45,7 @@ public interface SynapseAlertView extends IsWidget {
 	/**
 	 * Show a special login alert, that includes a link to the login page.
 	 */
-	void showLoginAlert();
-	/**
-	 * Show a special login alert to let the user decide if logging in might help. Includes a link to the login page.
-	 */
-	void showSuggestLoginAlert();
+	void showLogin();
 	void setPresenter(Presenter p);
 
 	/**

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.java
@@ -4,6 +4,7 @@ import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.TextArea;
+import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Strong;
 import org.gwtbootstrap3.extras.bootbox.client.Bootbox;
 import org.sagebionetworks.web.client.DisplayUtils;
@@ -12,6 +13,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
@@ -38,14 +40,10 @@ public class SynapseAlertViewImpl implements
 	@UiField
 	Alert alert;
 	@UiField
-	Alert loginAlert;
-	@UiField
-	Alert suggestLoginAlert;
-	@UiField
-	Button loginButton;
-	@UiField
-	Button loginButton2;
+	Div loginAlert;
 	Presenter presenter;
+	@UiField
+	Div loginWidgetContainer;
 	
 	@Inject
 	public SynapseAlertViewImpl(Binder binder){
@@ -60,18 +58,6 @@ public class SynapseAlertViewImpl implements
 			@Override
 			public void onClick(ClickEvent event) {
 				jiraDialog.hide();
-			}
-		});
-		loginButton.addClickHandler(new ClickHandler() {
-			@Override
-			public void onClick(ClickEvent event) {
-				presenter.onLoginClicked();
-			}
-		});
-		loginButton2.addClickHandler(new ClickHandler() {
-			@Override
-			public void onClick(ClickEvent event) {
-				presenter.onLoginClicked();
 			}
 		});
 	}
@@ -107,20 +93,13 @@ public class SynapseAlertViewImpl implements
 		alert.setVisible(false);
 		alertText.setText("");
 		loginAlert.setVisible(false);
-		suggestLoginAlert.setVisible(false);
 		widget.setVisible(false);
 	}
 	
 	@Override
-	public void showLoginAlert() {
+	public void showLogin() {
 		widget.setVisible(true);
 		loginAlert.setVisible(true);	
-	}
-	
-	@Override
-	public void showSuggestLoginAlert() {
-		widget.setVisible(true);
-		suggestLoginAlert.setVisible(true);	
 	}
 	
 	@Override
@@ -133,5 +112,16 @@ public class SynapseAlertViewImpl implements
 	@Override
 	public void showJiraIssueOpen(String key, String url) {
 		Bootbox.alert("The new report <a target=\"_blank\" href=\"" + url + "\">"+key+"</a> has been sent. Thank you for submitting!");
+	}
+	
+	@Override
+	public void setLoginWidget(Widget w) {
+		loginWidgetContainer.clear();
+		loginWidgetContainer.add(w);
+	}
+	
+	@Override
+	public void reload() {
+		Window.Location.reload();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/SynapseTableFormWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/SynapseTableFormWidget.java
@@ -75,7 +75,7 @@ public class SynapseTableFormWidget implements SynapseTableFormWidgetView.Presen
 		descriptor = widgetDescriptor;
 		clear();
 		if (!synAlert.isUserLoggedIn()) {
-			synAlert.showMustLogin();
+			synAlert.showLogin();
 			return;
 		}
 		view.setSubmitButtonLoading(false);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
@@ -120,7 +120,7 @@ public class FilesTab implements FilesTabView.Presenter{
 		this.modifiedCreatedBy = modifiedCreatedBy;
 		view.setPresenter(this);
 		
-		previewWidget.setHeight(WIDGET_HEIGHT_PX + "px");
+		previewWidget.addStyleName("min-height-200");
 		view.setFileTitlebar(fileTitleBar.asWidget());
 		view.setFolderTitlebar(folderTitleBar.asWidget());
 		view.setBreadcrumb(breadcrumb.asWidget());

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
@@ -72,7 +72,7 @@ public class TableQueryResultWidget implements TableQueryResultView.Presenter, I
 		this.queryListener = listener;
 		if (!synapseAlert.isUserLoggedIn()) {
 			setupErrorState();
-			synapseAlert.showMustLogin();
+			synapseAlert.showLogin();
 		} else {
 			runQuery();
 		}

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
@@ -10,10 +10,10 @@
  	
   	<bh:Div visible="false" addStyleNames="margin-top-10 margin-left-15 margin-right-15">
   		<bh:Div ui:field="loginAlert">
-	  		<b:Alert type="INFO">
-	  			<bh:Strong text="Please login to access this resource." />
-	  		</b:Alert>
 	  		<bh:Div addStyleNames="well col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">
+		  		<b:Alert type="INFO">
+		  			<bh:Strong text="Please login to access this resource." />
+		  		</b:Alert>
 	  			<bh:Div ui:field="loginWidgetContainer" />
 	  		</bh:Div>
   		</bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
@@ -10,12 +10,10 @@
  	
   	<bh:Div visible="false" addStyleNames="margin-top-10 margin-left-15 margin-right-15">
   		<bh:Div ui:field="loginAlert">
-	  		<bh:Div addStyleNames="well col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">
-		  		<b:Alert type="INFO">
-		  			<bh:Strong text="Please login to access this resource." />
-		  		</b:Alert>
-	  			<bh:Div ui:field="loginWidgetContainer" />
-	  		</bh:Div>
+  			<b:Alert type="INFO">
+	  			<bh:Strong text="Please login to access this resource." />
+	  		</b:Alert>
+  			<bh:Div ui:field="loginWidgetContainer" />
   		</bh:Div>
   		
   		<b:Alert ui:field="alert" type="DANGER" addStyleNames="margin-bottom-0-imp">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
@@ -9,19 +9,15 @@
   <ui:with field='sageImageBundle' type='org.sagebionetworks.web.client.SageImageBundle'/>
  	
   	<bh:Div visible="false" addStyleNames="margin-top-10 margin-left-15 margin-right-15">
-  		<b:Alert ui:field="loginAlert" type="INFO">
-  			<bh:Strong text="Please login to access this resource." />
-  			<b:Button ui:field="loginButton" icon="SIGN_IN" addStyleNames="margin-left-10">Log in</b:Button>
-  			<bh:Div addStyleNames="margin-top-5 font-italic">
-  				<bh:Text>New to Synapse?</bh:Text>
-  				<b:Anchor text="Register" href="#!RegisterAccount:0" addStyleNames="underline margin-left-5 margin-right-5"/>
-  				<bh:Text>for a free account today!</bh:Text>
-  			</bh:Div>
-  		</b:Alert>
-  		<b:Alert ui:field="suggestLoginAlert" type="INFO">
-  			<bh:Strong text="If you feel this is due to anonymous browsing, please " />
-  			<b:Button ui:field="loginButton2" icon="SIGN_IN" addStyleNames="margin-left-10">Log in</b:Button>
-  		</b:Alert>
+  		<bh:Div ui:field="loginAlert">
+	  		<b:Alert type="INFO">
+	  			<bh:Strong text="Please login to access this resource." />
+	  		</b:Alert>
+	  		<bh:Div addStyleNames="well col-md-offset-3 col-md-6 col-sm-offset-2 col-sm-8">
+	  			<bh:Div ui:field="loginWidgetContainer" />
+	  		</bh:Div>
+  		</bh:Div>
+  		
   		<b:Alert ui:field="alert" type="DANGER" addStyleNames="margin-bottom-0-imp">
   			<bh:Strong ui:field="alertText"></bh:Strong>
   		</b:Alert>

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ErrorPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ErrorPresenterTest.java
@@ -2,9 +2,11 @@ package org.sagebionetworks.web.unitclient.presenter;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +64,7 @@ public class ErrorPresenterTest {
 		verify(mockSynAlert).clear();
 		verify(mockView).setEntry(mockLogEntry);
 		verify(mockJsniUtils, times(3)).consoleError(anyString());
-		verify(mockSynAlert).showSuggestLogin();
+		verify(mockSynAlert).showLogin();
 	}
 	@Test
 	public void testShowLogEntryLoggedIn() throws RestServiceException {
@@ -73,7 +75,7 @@ public class ErrorPresenterTest {
 		verify(mockSynAlert).clear();
 		verify(mockView).setEntry(mockLogEntry);
 		verify(mockJsniUtils, times(3)).consoleError(anyString());
-		verify(mockSynAlert, never()).showSuggestLogin();
+		verify(mockSynAlert, never()).showLogin();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/biodalliance13/BiodallianceWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/biodalliance13/BiodallianceWidgetTest.java
@@ -78,7 +78,7 @@ public class BiodallianceWidgetTest {
 		Callback widgetRefreshRequired = null;
 		widget.configure(key, descriptor, widgetRefreshRequired, wikiVersionInView);
 		//verify that view does not try to show
-		verify(mockSynAlert).showMustLogin();
+		verify(mockSynAlert).showLogin();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StuAlertTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StuAlertTest.java
@@ -73,7 +73,7 @@ public class StuAlertTest {
 		when(mockAuthenticationController.isLoggedIn()).thenReturn(false);
 		widget.handleException(new ForbiddenException());
 		verify(mockView).clearState();
-		verify(mockSynapseAlert).showMustLogin();
+		verify(mockSynapseAlert).showLogin();
 		verify(mockView).setVisible(true);
 	}
 	
@@ -103,9 +103,9 @@ public class StuAlertTest {
 	
 	@Test
 	public void testShowMustLogin() {
-		widget.showMustLogin();
+		widget.showLogin();
 		verify(mockView).clearState();
-		verify(mockSynapseAlert).showMustLogin();
+		verify(mockSynapseAlert).showLogin();
 		verify(mockView).setVisible(true);
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StuAlertTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StuAlertTest.java
@@ -119,14 +119,6 @@ public class StuAlertTest {
 	}
 	
 	@Test
-	public void testShowSuggestLogin() {
-		widget.showSuggestLogin();
-		verify(mockView).clearState();
-		verify(mockSynapseAlert).showSuggestLogin();
-		verify(mockView).setVisible(true);
-	}
-	
-	@Test
 	public void testShowEntity403() {
 		String entityId = "syn123";
 		widget.show403(entityId);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/SynapseAlertImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/SynapseAlertImplTest.java
@@ -211,7 +211,7 @@ public class SynapseAlertImplTest {
 	
 	@Test
 	public void testShowMustLogin() {
-		widget.showMustLogin();
+		widget.showLogin();
 		verify(mockView, times(2)).clearState();
 		verify(mockView).showLoginAlert();
 	}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/SynapseAlertImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/SynapseAlertImplTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.web.unitclient.widget.entity.controller;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -12,20 +12,22 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserSessionData;
 import org.sagebionetworks.web.client.DisplayConstants;
-import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
-import org.sagebionetworks.web.client.SynapseClientAsync;
+import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.place.Down;
 import org.sagebionetworks.web.client.place.LoginPlace;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.widget.entity.JiraURLHelper;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlertImpl;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlertView;
+import org.sagebionetworks.web.client.widget.login.LoginWidget;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.exceptions.ForbiddenException;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
@@ -36,16 +38,27 @@ import org.sagebionetworks.web.shared.exceptions.UnknownErrorException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Widget;
 
 public class SynapseAlertImplTest {
-
+	@Mock
 	SynapseAlertView mockView;
+	@Mock
 	GlobalApplicationState mockGlobalApplicationState;
+	@Mock
 	AuthenticationController mockAuthenticationController;
 	SynapseAlertImpl widget;
+	@Mock
 	PlaceChanger mockPlaceChanger;
+	@Mock
 	JiraURLHelper mockJiraClient;
+	@Mock
+	PortalGinInjector mockPortalGinInjector;
+	@Mock
 	GWTWrapper mockGWT;
+	@Mock
+	LoginWidget mockLoginWidget;
+	
 	// a new jira odyssey
 	String newJiraKey = "SWC-2001";
 	
@@ -53,13 +66,8 @@ public class SynapseAlertImplTest {
 	public static final String JIRA_ENDPOINT_URL="http://foo.bar.com/";
 	@Before
 	public void before(){
-		mockAuthenticationController = mock(AuthenticationController.class);
-		mockGlobalApplicationState = mock(GlobalApplicationState.class);
-		mockPlaceChanger = mock(PlaceChanger.class);
-		mockJiraClient = mock(JiraURLHelper.class);
-		mockView = mock(SynapseAlertView.class);
-		mockGWT = mock(GWTWrapper.class);
-		widget = new SynapseAlertImpl(mockView, mockGlobalApplicationState, mockAuthenticationController, mockGWT);
+		MockitoAnnotations.initMocks(this);
+		widget = new SynapseAlertImpl(mockView, mockGlobalApplicationState, mockAuthenticationController, mockGWT, mockPortalGinInjector);
 		UserSessionData mockUSD = mock(UserSessionData.class);
 		when(mockAuthenticationController.getCurrentUserSessionData()).thenReturn(mockUSD);
 		UserProfile mockProfile = mock(UserProfile.class);
@@ -74,6 +82,7 @@ public class SynapseAlertImplTest {
 		
 		when(mockAuthenticationController.isLoggedIn()).thenReturn(true);
 		verify(mockView).setPresenter(widget);
+		when(mockPortalGinInjector.getLoginWidget()).thenReturn(mockLoginWidget);
 	}
 	
 	@Test
@@ -103,8 +112,10 @@ public class SynapseAlertImplTest {
 	public void testHandleServiceExceptionForbiddenNotLoggedIn() {
 		when(mockAuthenticationController.isLoggedIn()).thenReturn(false);
 		widget.handleException(new ForbiddenException());
-		verify(mockView, times(2)).clearState();
-		verify(mockView).showLoginAlert();
+		verify(mockView, atLeastOnce()).clearState();
+		verify(mockPortalGinInjector).getLoginWidget();
+		verify(mockView).setLoginWidget(any(Widget.class));
+		verify(mockView).showLogin();
 	}
 	
 	@Test
@@ -198,12 +209,6 @@ public class SynapseAlertImplTest {
 	}
 	
 	@Test
-	public void testOnLoginClicked() {
-		widget.onLoginClicked();
-		verify(mockPlaceChanger).goTo(any(LoginPlace.class));
-	}
-
-	@Test
 	public void testIsUserLoggedIn() {
 		widget.isUserLoggedIn();
 		verify(mockAuthenticationController).isLoggedIn();
@@ -213,7 +218,9 @@ public class SynapseAlertImplTest {
 	public void testShowMustLogin() {
 		widget.showLogin();
 		verify(mockView, times(2)).clearState();
-		verify(mockView).showLoginAlert();
+		verify(mockPortalGinInjector).getLoginWidget();
+		verify(mockView).setLoginWidget(any(Widget.class));
+		verify(mockView).showLogin();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SynapseTableFormWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SynapseTableFormWidgetTest.java
@@ -112,7 +112,7 @@ public class SynapseTableFormWidgetTest {
 		verify(mockView).setFormUIVisible(false);
 		verify(mockView).setSuccessMessageVisible(false);
 		
-		verify(mockSynAlert).showMustLogin();
+		verify(mockSynAlert).showLogin();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
@@ -124,7 +124,7 @@ public class TableQueryResultWidgetTest {
 		verify(mockView).setProgressWidgetVisible(false);
 		verify(mockView).setErrorVisible(true);
 		verify(mockView).setSynapseAlertWidget(any(Widget.class));
-		verify(mockSynapseAlert).showMustLogin();
+		verify(mockSynapseAlert).showLogin();
 	}
 	
 	@Test


### PR DESCRIPTION
Has lazy construction (via gin injector) of LoginWidget, since the SynapseAlert only needs it when showLogin() is called.
