### PR TITLE
gwt 2.8 beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 
 		<synapse.version>143.0</synapse.version>
-		<gwtVersion>2.7.0</gwtVersion>
+		<gwtVersion>2.8.0-beta1</gwtVersion>
 		<org.springframework.version>4.0.2.RELEASE</org.springframework.version>
 		<guiceVersion>3.0</guiceVersion>
 		<ginVersion>2.1.2</ginVersion>


### PR DESCRIPTION
[gwt 2.8 has been in beta since December 3, 2015](http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_0_BETA1), let's use the latest version for the JDK emulation improvements.
