### PR TITLE
SWC-3125: in query input widget, only expose the ability to edit if r…

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
@@ -184,11 +184,11 @@ public class TableEntityWidget implements IsWidget,
 	 */
 	private void setQuery(Query query, boolean isFromResults) {
 		this.currentQuery = query;
-		this.queryInputWidget.configure(query.getSql(), this, this.canEdit);
+		this.queryInputWidget.configure(query.getSql(), this, this.canEditResults);
 		this.view.setQueryResultsVisible(true);
 		this.view.setTableMessageVisible(false);
 		if(!isFromResults){
-			this.queryResultsWidget.configure(query, this.canEdit, this);
+			this.queryResultsWidget.configure(query, this.canEditResults, this);
 		}
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorWidget.java
@@ -222,7 +222,7 @@ public class QueryResultEditorWidget implements
 			doHideEditor();
 		}
 	}
-
+	
 	/**
 	 * Hide the modal editor.
 	 */

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TableEntityWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TableEntityWidgetTest.java
@@ -343,6 +343,22 @@ public class TableEntityWidgetTest {
 		expected.setOffset(TableEntityWidget.DEFAULT_OFFSET);
 		verify(mockQueryResultsWidget).configure(expected, canEdit, widget);
 	}
+
+	@Test
+	public void testOnExecuteViewQuery(){
+		configureBundleWithView();
+		boolean canEdit = true;
+		// Start with a query that is not on the first page
+		Query startQuery = new Query();
+		startQuery.setSql("select * from syn123");
+		startQuery.setLimit(100L);
+		startQuery.setOffset(101L);
+		when(mockQueryChangeHandler.getQueryString()).thenReturn(startQuery);
+		widget.configure(entityBundle, canEdit, mockQueryChangeHandler, mockActionMenu);
+		// Start query get passed to the results
+		boolean expectedCanEditResults = false;
+		verify(mockQueryResultsWidget).configure(startQuery, expectedCanEditResults, widget);
+	}
 	
 	@Test
 	public void testOnSchemaToggleShown(){
@@ -421,5 +437,23 @@ public class TableEntityWidgetTest {
 		verify(mockQueryInputWidget).configure(newQuery.getSql(), widget, canEdit);
 		// Should not be sent to the results as that is where it came from.
 		verify(mockQueryResultsWidget, never()).configure(any(Query.class), anyBoolean(), any(QueryResultsListener.class));
+	}
+	
+
+	@Test
+	public void testCanEditViewResults(){
+		configureBundleWithView();
+		//we can edit the view, but verify that the query input widget should be told that editing results is not possible
+		boolean canEdit = true;
+		// Start with a query that is not on the first page
+		Query startQuery = new Query();
+		startQuery.setSql("select * from syn123");
+		startQuery.setLimit(100L);
+		startQuery.setOffset(101L);
+		when(mockQueryChangeHandler.getQueryString()).thenReturn(startQuery);
+		widget.configure(entityBundle, canEdit, mockQueryChangeHandler, mockActionMenu);
+		
+		boolean expectedCanEditResults = false;
+		verify(mockQueryInputWidget).configure(startQuery.getSql(), widget, expectedCanEditResults);
 	}
 }


### PR DESCRIPTION
…esults are editable (today, editing results for a view is blocked)
