### PR TITLE
SWC-3188:  cross-browser solution

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidget.java
@@ -25,6 +25,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -267,7 +268,6 @@ public class MarkdownEditorWidget implements MarkdownEditorWidgetView.Presenter,
 			insertMarkdown(WidgetConstants.WIDGET_START_MARKDOWN + WidgetConstants.TOC_CONTENT_TYPE + WidgetConstants.WIDGET_END_MARKDOWN);
 			break;
 		case INSERT_USER_LINK:
-			insertMarkdown("@");
 			insertUserLink();
 			break;
 		case INSERT_USER_TEAM_BADGE:
@@ -504,13 +504,14 @@ public class MarkdownEditorWidget implements MarkdownEditorWidgetView.Presenter,
 	}
 	
 	@Override
-	public void onKeyPress(char c) {
-		if ('@' == c) {
+	public void onKeyPress(KeyPressEvent event) {
+		if ('@' == event.getCharCode()) {
 			// only insert a user link if this is the first character, or the character before it is whitespace
 			int pos = view.getCursorPos();
 			String md = view.getMarkdown();
 			if (pos < 1 || gwt.isWhitespace(md.substring(pos-1, pos))) {
-				view.setEditorEnabled(false);
+				event.preventDefault();
+				event.stopPropagation();
 				insertUserLink();	
 			}
 		}
@@ -518,6 +519,7 @@ public class MarkdownEditorWidget implements MarkdownEditorWidgetView.Presenter,
 	
 	public void insertUserLink() {
 		// pop up suggest box.  on selection, userSelector has been configured to add the username to the md.
+		insertMarkdown("@");
 		userSelector.show();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetView.java
@@ -5,6 +5,7 @@ import org.sagebionetworks.web.client.SynapseView;
 
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
@@ -41,7 +42,7 @@ public interface MarkdownEditorWidgetView extends IsWidget,SynapseView {
 	public interface Presenter {
 		void handleCommand(MarkdownEditorAction action);
 		void markdownEditorClicked();
-		void onKeyPress(char c);
+		void onKeyPress(KeyPressEvent event);
 	}
 	
 	void addTextAreaKeyUpHandler(KeyUpHandler keyUpHandler);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetViewImpl.java
@@ -263,7 +263,7 @@ public class MarkdownEditorWidgetViewImpl implements MarkdownEditorWidgetView {
 		markdownTextArea.addKeyPressHandler(new KeyPressHandler() {
 			@Override
 			public void onKeyPress(KeyPressEvent event) {
-				presenter.onKeyPress(event.getCharCode());
+				presenter.onKeyPress(event);
 			}
 		});
 		writeMarkdownButton.addClickHandler(new ClickHandler() {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
@@ -49,6 +49,7 @@ import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
+import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -75,6 +76,8 @@ public class MarkdownEditorWidgetTest {
 	String fileHandleId2 = "45";
 	@Mock
 	UserSelector mockUserSelector;
+	@Mock
+	KeyPressEvent mockKeyEvent;
 	@Before
 	public void before() throws JSONObjectAdapterException {
 		MockitoAnnotations.initMocks(this);
@@ -598,14 +601,18 @@ public class MarkdownEditorWidgetTest {
 	
 	@Test
 	public void testOnKeyPress() {
-		presenter.onKeyPress('1');
+		when(mockKeyEvent.getCharCode()).thenReturn('1');
+		presenter.onKeyPress(mockKeyEvent);
 		verify(mockUserSelector, never()).show();
-		presenter.onKeyPress('a');
+		when(mockKeyEvent.getCharCode()).thenReturn('a');
+		presenter.onKeyPress(mockKeyEvent);
 		verify(mockUserSelector, never()).show();
 		verify(mockView, never()).setEditorEnabled(anyBoolean());
-		presenter.onKeyPress('@');
+		when(mockKeyEvent.getCharCode()).thenReturn('@');
+		presenter.onKeyPress(mockKeyEvent);
 		verify(mockUserSelector).show();
-		verify(mockView).setEditorEnabled(false);
+		verify(mockKeyEvent).preventDefault();
+		verify(mockKeyEvent).stopPropagation();
 	}
 
 	@Test
@@ -613,7 +620,8 @@ public class MarkdownEditorWidgetTest {
 		when(mockView.getCursorPos()).thenReturn(0);
 		when(mockView.getMarkdown()).thenReturn("");
 		when(mockGwt.isWhitespace(anyString())).thenReturn(false);
-		presenter.onKeyPress('@');
+		when(mockKeyEvent.getCharCode()).thenReturn('@');
+		presenter.onKeyPress(mockKeyEvent);
 		verify(mockUserSelector).show();
 	}
 	
@@ -623,7 +631,8 @@ public class MarkdownEditorWidgetTest {
 		when(mockView.getCursorPos()).thenReturn(5);
 		when(mockView.getMarkdown()).thenReturn("email");
 		when(mockGwt.isWhitespace(anyString())).thenReturn(false);
-		presenter.onKeyPress('@');
+		when(mockKeyEvent.getCharCode()).thenReturn('@');
+		presenter.onKeyPress(mockKeyEvent);
 		verify(mockUserSelector, never()).show();
 	}
 	


### PR DESCRIPTION
Pass back the KeyPressEvent, and if '@' then prevent the default behavior (and propagation) and handle it all myself.  Tried with Edge 14, Safari, FF, and Chrome.  Seems to work ok on all.
