### PR TITLE
if default query, do not set the area token (to avoid adding the same…

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
@@ -63,8 +63,8 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 	SynapseClientAsync synapseClient;
 	PortalGinInjector ginInjector;
 	ModifiedCreatedByWidget modifiedCreatedBy;
-	
 	CallbackP<Boolean> showProjectInfoCallack;
+	TableEntityWidget v2TableWidget;
 	@Inject
 	public TablesTab(
 			TablesTabView view,
@@ -124,7 +124,6 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 				String entityId = synapse.getEntityId();
 				if (entityId.equals(projectEntityId)) {
 				    showProjectLevelUI();
-				    tab.showTab();
 				} else {
 				    getTargetBundleAndDisplay(entityId);
 				}
@@ -169,6 +168,7 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 			showError(projectBundleLoadError);
 		}
 		tab.setEntityNameAndPlace(title, new Synapse(projectEntityId, null, EntityArea.TABLES, null));
+		tab.showTab(true);
 	}
 	
 	public void resetView() {
@@ -207,7 +207,7 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 			modifiedCreatedBy.configure(entity.getCreatedOn(), entity.getCreatedBy(), entity.getModifiedOn(), entity.getModifiedBy());
 			ActionMenuWidget actionMenu = initActionMenu(bundle);
 			
-			TableEntityWidget v2TableWidget = ginInjector.createNewTableEntityWidget();
+			v2TableWidget = ginInjector.createNewTableEntityWidget();
 			view.setTableEntityWidget(v2TableWidget.asWidget());
 			v2TableWidget.configure(bundle, bundle.getPermissions().getCanCertifiedUserEdit(), this, actionMenu);
 		} else if (isProject) {
@@ -241,16 +241,17 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 		AsyncCallback<EntityBundle> callback = new AsyncCallback<EntityBundle>() {
 			@Override
 			public void onSuccess(EntityBundle bundle) {
-				tab.setEntityNameAndPlace(bundle.getEntity().getName(), new Synapse(entityId, null, null, null));
+				tab.setEntityNameAndPlace(bundle.getEntity().getName(), new Synapse(entityId, null, EntityArea.TABLES, null));
 				setTargetBundle(bundle);
-				tab.showTab();
+				// note: let TableEntityWidget query control browser history.  when the query is run, push url into the stack. 
+				tab.showTab(false);
 			}
 			
 			@Override
 			public void onFailure(Throwable caught) {
-				tab.setEntityNameAndPlace(entityId, new Synapse(entityId, null, null, null));
+				tab.setEntityNameAndPlace(entityId, new Synapse(entityId, null, EntityArea.TABLES, null));
 				showError(caught);
-				tab.showTab();
+				tab.showTab(false);
 			}			
 		};
 		
@@ -262,14 +263,15 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 	}
 	
 	public void onQueryChange(Query newQuery) {
-		if(newQuery != null){
+		if(newQuery != null) {
 			String token = queryTokenProvider.queryToToken(newQuery);
-			if(token != null){
+			if(token != null && !newQuery.equals(v2TableWidget.getDefaultQuery())){
 				areaToken = TABLE_QUERY_PREFIX + token;
-				tab.setEntityNameAndPlace(entity.getName(), new Synapse(entity.getId(), null, EntityArea.TABLES, areaToken));
-				// replace state if configuring table query widget, push history state after configuration.
-				tab.showTab(false);
+			} else {
+				areaToken = "";
 			}
+			tab.setEntityNameAndPlace(entity.getName(), new Synapse(entity.getId(), null, EntityArea.TABLES, areaToken));
+			tab.showTab(true);
 		}
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -226,7 +226,7 @@ public class TablesTabTest {
 		Synapse place = (Synapse)captor.getValue();
 		assertEquals(tableEntityId, place.getEntityId());
 		assertNull(place.getVersionNumber());
-		assertNull(place.getArea());
+		assertEquals(EntityArea.TABLES, place.getArea());
 		assertNull(place.getAreaToken());
 	}
 	
@@ -283,17 +283,18 @@ public class TablesTabTest {
 		tab.configure(mockTableEntity, mockEntityUpdatedHandler, null);
 		
 		reset(mockTab);
-		String queryToken = queryTokenProvider.queryToToken(query);
+		when(mockTableEntityWidget.getDefaultQuery()).thenReturn(query);
 		tab.onQueryChange(query);
 		
 		Synapse place = getNewPlace(tableName);
 		assertEquals(EntityArea.TABLES, place.getArea());
-		assertTrue(place.getAreaToken().contains(queryToken));
+		assertTrue(place.getAreaToken().isEmpty());
 	}
 	
 	@Test
 	public void testSetTableQueryWithToken() {
 		query.setOffset(1L);
+		when(mockTableEntityWidget.getDefaultQuery()).thenReturn(new Query());
 		String startToken = queryTokenProvider.queryToToken(query);
 		// Start with a token.
 		


### PR DESCRIPTION
… content to the browser stack twice), but push the page to the browser stack when a new query is executed
