### PR TITLE
SWC-3253: support dot version notation in the entity list widget

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/DisplayUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayUtils.java
@@ -872,6 +872,10 @@ public class DisplayUtils {
 	}
 	public static Reference parseEntityVersionString(String entityVersion) {
 		String[] parts = entityVersion.split(WebConstants.ENTITY_VERSION_STRING);
+		if (parts.length == 1) {
+			// version may be using a dot delimiter:
+			parts = entityVersion.split("\\.");
+		}
 		Reference ref = null;
 		if(parts.length > 0) {
 			ref = new Reference();

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/EntityListUtil.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/EntityListUtil.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
+import org.sagebionetworks.web.client.presenter.EntityPresenter;
 import org.sagebionetworks.web.client.widget.entity.EntityGroupRecordDisplay;
 import org.sagebionetworks.web.client.widget.entity.registration.WidgetEncodingUtil;
 import org.sagebionetworks.web.shared.exceptions.ForbiddenException;
@@ -55,7 +56,10 @@ public class EntityListUtil {
 		if(record == null) return;
 		final Reference ref = record.getEntityReference();
 		if(ref == null) return;
-				
+		if (!EntityPresenter.isValidEntityId(ref.getTargetId()))  {
+			createFailureDisplay(new IllegalArgumentException(), ref, handler);
+			return;
+		}
 		AsyncCallback<EntityBundle> callback = new AsyncCallback<EntityBundle>() {
 			@Override
 			public void onSuccess(EntityBundle bundle) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/DisplayUtilsTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/DisplayUtilsTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mockito;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.Project;
+import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GlobalApplicationState;
@@ -369,6 +370,27 @@ public class DisplayUtilsTest {
 		versioned = DisplayUtils.createEntityVersionString("syn1234", 8888L);
 		assertTrue(versioned.contains("syn1234"));
 		assertTrue(versioned.contains("8888"));
+	}
+	
+	@Test
+	public void testParseEntityVersionString() {
+		String validSynId = "syn123";
+		Long validVersion = 3L;
+		
+		//verify ref without version
+		Reference expectedRef = new Reference();
+		expectedRef.setTargetId(validSynId);
+		Reference testRef;
+		testRef = DisplayUtils.parseEntityVersionString(validSynId);
+		assertEquals(expectedRef, testRef);
+		
+		//verify ref with version defined using dot notation
+		expectedRef.setTargetVersionNumber(validVersion);
+		testRef = DisplayUtils.parseEntityVersionString(validSynId + "." + validVersion);
+		assertEquals(expectedRef, testRef);
+		//verify ref with version defined using "/version/" notation
+		testRef = DisplayUtils.parseEntityVersionString(validSynId + WebConstants.ENTITY_VERSION_STRING + validVersion);
+		assertEquals(expectedRef, testRef);
 	}
 }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/EntityListUtilTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/EntityListUtilTest.java
@@ -1,18 +1,44 @@
 package org.sagebionetworks.web.unitclient.widget.entity.renderer;
 
 import static org.junit.Assert.*;
-
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.repo.model.EntityGroupRecord;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.Reference;
+import org.sagebionetworks.web.client.DisplayConstants;
+import org.sagebionetworks.web.client.SynapseClientAsync;
+import org.sagebionetworks.web.client.SynapseJSNIUtils;
+import org.sagebionetworks.web.client.widget.entity.EntityGroupRecordDisplay;
 import org.sagebionetworks.web.client.widget.entity.renderer.EntityListUtil;
+import org.sagebionetworks.web.client.widget.entity.renderer.EntityListUtil.RowLoadedHandler;
 
 public class EntityListUtilTest {
 
+	@Mock
+	SynapseClientAsync mockSynapseClient;
+	@Mock
+	SynapseJSNIUtils mockSynapseJSNIUtils;
+	@Mock
+	RowLoadedHandler mockHandler;
+	@Mock
+	EntityGroupRecord mockRecord;
+	@Mock
+	Reference mockReference;
+	
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		when(mockRecord.getEntityReference()).thenReturn(mockReference);
+	}
 	
 	@Test
 	public void testRecordsToStringRoundTrip() {
@@ -37,5 +63,25 @@ public class EntityListUtilTest {
 		String encoded = EntityListUtil.recordsToString(records);
 		List<EntityGroupRecord> clone = EntityListUtil.parseRecords(encoded);
 		assertEquals(records, clone);		
+	}
+	
+	@Test
+	public void testLoadIndividualRowDetails() {
+		List<EntityGroupRecord> records = new ArrayList<EntityGroupRecord>();
+		int rowIndex = 0;
+		String xsrfToken = "12222";
+		String invalidId = "invalidid";
+		boolean isLoggedIn = true;
+		records.add(mockRecord);
+		when(mockReference.getTargetId()).thenReturn(invalidId);
+		
+		EntityListUtil.loadIndividualRowDetails(mockSynapseClient, mockSynapseJSNIUtils, isLoggedIn, records, rowIndex, mockHandler, xsrfToken);
+		verifyZeroInteractions(mockSynapseClient);
+		ArgumentCaptor<EntityGroupRecordDisplay> captor = ArgumentCaptor.forClass(EntityGroupRecordDisplay.class);
+		verify(mockHandler).onLoaded(captor.capture());
+		EntityGroupRecordDisplay display = captor.getValue();
+		String textShown = display.getName().asString();
+		assertTrue(textShown.contains(DisplayConstants.ERROR_LOADING));
+		assertTrue(textShown.contains(invalidId));
 	}
 }


### PR DESCRIPTION
and catch invalid synapse ids before rpc
