### PR TITLE
SWC-3264: set default column ids to null when adding new columns

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -2501,7 +2501,12 @@ public class SynapseClientImpl extends SynapseClientBase implements
 	public List<ColumnModel> getDefaultColumnsForView(ViewType type) throws RestServiceException {
 		try {
 			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
-			return synapseClient.getDefaultColumnsForView(type);
+			List<ColumnModel> defaultColumns = synapseClient.getDefaultColumnsForView(type);
+			// SWC-3264: in order for these to look like new columns in the TableUpdateTransactionRequest change set, set column ids to null
+			for (ColumnModel cm : defaultColumns) {
+				cm.setId(null);
+			}
+			return defaultColumns;
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -132,6 +132,7 @@ import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.TableSchemaChangeRequest;
 import org.sagebionetworks.repo.model.table.TableUpdateRequest;
 import org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest;
+import org.sagebionetworks.repo.model.table.ViewType;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHistorySnapshot;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiOrderHint;
@@ -2375,5 +2376,20 @@ public class SynapseClientImplTest {
 		// colD should be new
 		columnChange = getColumnChange(null, changes);
 		assertEquals("5", columnChange.getNewColumnId());
+	}
+	
+	@Test
+	public void testGetDefaultColumnsForView()  throws RestServiceException, SynapseException{
+		ColumnModel colA, colB;
+		colA = getColumnModel("1", ColumnType.STRING);
+		colB = getColumnModel("2", ColumnType.STRING);
+		
+		List<ColumnModel> defaultColumns = Arrays.asList(colA, colB);
+		when(mockSynapse.getDefaultColumnsForView(any(ViewType.class))).thenReturn(defaultColumns);
+		List<ColumnModel> returnedColumns = synapseClient.getDefaultColumnsForView(ViewType.file);
+		
+		assertEquals(2, returnedColumns.size());
+		assertNull(returnedColumns.get(0).getId());
+		assertNull(returnedColumns.get(1).getId());
 	}
 }


### PR DESCRIPTION
so the request recognizes them as new columns (to be associated with the view)
