### PR TITLE
SWC-3290: fix entity renderer when id does not contain the "syn" prefix

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/EntityIdCellRendererImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/EntityIdCellRendererImpl.java
@@ -7,7 +7,6 @@ import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.asynch.EntityHeaderAsyncHandler;
 import org.sagebionetworks.web.client.widget.lazyload.LazyLoadHelper;
 
-import com.google.gwt.core.shared.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -37,7 +36,9 @@ public class EntityIdCellRendererImpl implements EntityIdCellRenderer{
 	public void loadData() {
 		if (entityName == null && entityId != null) {
 			view.showLoadingIcon();
-			entityHeaderAsyncHandler.getEntityHeader(entityId, new AsyncCallback<EntityHeader>() {
+			String requestEntityId = entityId.toLowerCase().startsWith("syn") ? entityId : "syn"+entityId;
+			view.setLinkHref(Synapse.getHrefForDotVersion(requestEntityId));
+			entityHeaderAsyncHandler.getEntityHeader(requestEntityId, new AsyncCallback<EntityHeader>() {
 				@Override
 				public void onSuccess(EntityHeader entity) {
 					entityName = entity.getName();
@@ -65,7 +66,6 @@ public class EntityIdCellRendererImpl implements EntityIdCellRenderer{
 		this.entityId = value;
 		entityName = null;
 		lazyLoadHelper.setIsConfigured();
-		view.setLinkHref(Synapse.getHrefForDotVersion(entityId));
 	}
 
 	@Override

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EntityIdCellRendererImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EntityIdCellRendererImplTest.java
@@ -59,10 +59,9 @@ public class EntityIdCellRendererImplTest {
 	
 	@Test
 	public void testSetValue(){
-		String entityId = "syn987654";
+		String entityId = "987654";
 		renderer.setValue(entityId);
 		verify(mockLazyLoadHelper).setIsConfigured();
-		verify(mockView).setLinkHref("#!Synapse:syn987654");
 		verifyZeroInteractions(mockEntityHeaderAsyncHandler);
 		
 		simulateInView();
@@ -70,6 +69,7 @@ public class EntityIdCellRendererImplTest {
 		verify(mockEntityHeaderAsyncHandler).getEntityHeader(anyString(), any(AsyncCallback.class));
 		verify(mockView).setIcon(any(IconType.class));
 		verify(mockView).setLinkText(PROJECT_NAME);
+		verify(mockView).setLinkHref("#!Synapse:syn987654");
 		
 		//verify that attempting to load data again is a no-op
 		reset(mockEntityHeaderAsyncHandler);


### PR DESCRIPTION
The entity header service does not expect entity ids without the "syn"
