### PR TITLE
SWC-3493: getEntityVersions now 0-based index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 gwt-unitCache/
 war/
 .DS_Store
+extras/

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 
-		<synapse.version>167.0</synapse.version>
+		<synapse.version>2017-02-23-2525-02e7ac5</synapse.version>
 		<gwtVersion>2.8.0-beta1</gwtVersion>
 		<org.springframework.version>4.3.3.RELEASE</org.springframework.version>
 		<guiceVersion>3.0</guiceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
 
-		<synapse.version>167.0</synapse.version>
+		<synapse.version>169.0-2-g7480acf</synapse.version>
 		<gwtVersion>2.8.0-beta1</gwtVersion>
 		<org.springframework.version>4.3.3.RELEASE</org.springframework.version>
 		<guiceVersion>3.0</guiceVersion>

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
@@ -66,7 +66,6 @@ import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHistorySnapshot;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiOrderHint;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiPage;
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
 import org.sagebionetworks.web.client.view.TeamRequestBundle;
 import org.sagebionetworks.web.shared.AccessRequirementsTransport;
@@ -297,9 +296,6 @@ public interface SynapseClient extends XsrfProtectedService {
 	public String getJSONEntity(String repoUri) throws RestServiceException;
 	
 	public String getRootWikiId(String ownerId, String ownerType) throws RestServiceException;
-	//wiki crud
-	public PaginatedResults<WikiHeader> getWikiHeaderTree(String ownerId, String ownerType) throws RestServiceException;
-	
 	public FileHandleResults getWikiAttachmentHandles(WikiPageKey key) throws RestServiceException;
 	
 	 // V2 Wiki crud
@@ -309,7 +305,7 @@ public interface SynapseClient extends XsrfProtectedService {
     public V2WikiPage updateV2WikiPage(String ownerId, String ownerType, V2WikiPage wikiPag) throws RestServiceException;
     public V2WikiPage restoreV2WikiPage(String ownerId, String ownerType, String wikiId, Long versionToUpdate) throws RestServiceException;
     public void deleteV2WikiPage(WikiPageKey key) throws RestServiceException;
-    public PaginatedResults<V2WikiHeader> getV2WikiHeaderTree(String ownerId, String ownerType) throws RestServiceException;
+    public List<V2WikiHeader> getV2WikiHeaderTree(String ownerId, String ownerType) throws RestServiceException;
 	public V2WikiOrderHint getV2WikiOrderHint(WikiPageKey key) throws RestServiceException;
 	public V2WikiOrderHint updateV2WikiOrderHint(V2WikiOrderHint toUpdate) throws RestServiceException;
     public FileHandleResults getV2WikiAttachmentHandles(WikiPageKey key) throws RestServiceException;
@@ -544,7 +540,6 @@ public interface SynapseClient extends XsrfProtectedService {
 	BatchFileResult getFileHandleAndUrlBatch(BatchFileRequest request) throws RestServiceException;
 	
 	void deleteAccessApproval(Long approvalId) throws RestServiceException;
-	PaginatedResults<AccessApproval> getEntityAccessApproval(String entityId) throws RestServiceException;
 	void deleteAccessApprovals(String accessRequirement, String accessorId) throws RestServiceException;
 
 	String generateSqlWithFacets(String basicSql, List<org.sagebionetworks.repo.model.table.FacetColumnRequest> selectedFacets, List<ColumnModel> schema) throws RestServiceException;

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
@@ -43,8 +43,6 @@ import org.sagebionetworks.repo.model.file.BatchFileResult;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.file.FileHandleCopyRequest;
 import org.sagebionetworks.repo.model.file.FileHandleResults;
-import org.sagebionetworks.repo.model.file.S3FileHandle;
-import org.sagebionetworks.repo.model.file.UploadDaemonStatus;
 import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.project.StorageLocationSetting;
 import org.sagebionetworks.repo.model.provenance.Activity;
@@ -67,7 +65,6 @@ import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHistorySnapshot;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiOrderHint;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiPage;
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
 import org.sagebionetworks.web.client.view.TeamRequestBundle;
 import org.sagebionetworks.web.shared.AccessRequirementsTransport;
@@ -212,8 +209,6 @@ public interface SynapseClientAsync {
 	public void getJSONEntity(String repoUri, AsyncCallback<String> callback);
 	
 	public void getRootWikiId(String ownerId, String ownerType, AsyncCallback<String> callback);
-	void getWikiHeaderTree(String ownerId, String ownerType,
-			AsyncCallback<PaginatedResults<WikiHeader>> callback);
 	public void getWikiAttachmentHandles(WikiPageKey key, AsyncCallback<FileHandleResults> callback);
 	public void getFileEndpoint(AsyncCallback<String> callback);
 
@@ -228,7 +223,7 @@ public interface SynapseClientAsync {
 			Long versionToUpdate, AsyncCallback<V2WikiPage> callback);
     public void deleteV2WikiPage(WikiPageKey key, AsyncCallback<Void> callback);
     void getV2WikiHeaderTree(String ownerId, String ownerType,
-			AsyncCallback<PaginatedResults<V2WikiHeader>> callback);
+			AsyncCallback<List<V2WikiHeader>> callback);
     public void getV2WikiOrderHint(WikiPageKey key, AsyncCallback<V2WikiOrderHint> callback);
     public void updateV2WikiOrderHint(V2WikiOrderHint toUpdate, AsyncCallback<V2WikiOrderHint> callback);
     void getV2WikiAttachmentHandles(WikiPageKey key,
@@ -458,7 +453,6 @@ public interface SynapseClientAsync {
 	void getFileHandleAndUrlBatch(BatchFileRequest request, AsyncCallback<BatchFileResult> asyncCallback);
 	
 	void deleteAccessApproval(Long approvalId, AsyncCallback<Void> callback);
-	void getEntityAccessApproval(String entityId, AsyncCallback<PaginatedResults<AccessApproval>> callback);
 
 	void deleteAccessApprovals(String accessRequirement, String accessorId, AsyncCallback<Void> asyncCallback);
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizard.java
@@ -7,11 +7,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.repo.model.wiki.WikiHeader;
 import org.sagebionetworks.schema.adapter.JSONEntity;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.widget.WidgetRendererPresenter;
-import org.sagebionetworks.web.shared.PaginatedResults;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
@@ -68,15 +68,13 @@ public class TutorialWizard implements TutorialWizardView.Presenter, WidgetRende
 	 */
 	public void configure(final String entityId, Callback callback) {
 		this.callback = callback;
-		synapseClient.getWikiHeaderTree(entityId, ObjectType.ENTITY.toString(), new AsyncCallback<PaginatedResults<WikiHeader>>() {
+		synapseClient.getV2WikiHeaderTree(entityId, ObjectType.ENTITY.toString(), new AsyncCallback<List<V2WikiHeader>>() {
 			@Override
-			public void onSuccess(PaginatedResults<WikiHeader> results) {
-				PaginatedResults<WikiHeader> wikiHeaders = results;
+			public void onSuccess(List<V2WikiHeader> wikiHeaders) {
 				
 				//sort them so that they are always in a predictable order for the wizard.
-				List<WikiHeader> sortedHeaders= new ArrayList<WikiHeader>();
-				for (JSONEntity headerEntity : wikiHeaders.getResults()) {
-					WikiHeader header = (WikiHeader) headerEntity;
+				List<V2WikiHeader> sortedHeaders= new ArrayList<V2WikiHeader>();
+				for (V2WikiHeader header : wikiHeaders) {
 					//ignore root page to simplify setup
 					if (header.getParentId() != null)
 						sortedHeaders.add(header);
@@ -85,9 +83,9 @@ public class TutorialWizard implements TutorialWizardView.Presenter, WidgetRende
 					onFailure(new NotFoundException("Wiki subpages not found for tutorial: " + entityId));
 					return;
 				}
-				Collections.sort(sortedHeaders, new Comparator<WikiHeader>() {
+				Collections.sort(sortedHeaders, new Comparator<V2WikiHeader>() {
 				    @Override
-			        public int compare(WikiHeader o1, WikiHeader o2) {
+			        public int compare(V2WikiHeader o1, V2WikiHeader o2) {
 			        	return o1.getTitle().compareTo(o2.getTitle());
 			        }
 				});

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizardView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizardView.java
@@ -2,14 +2,14 @@ package org.sagebionetworks.web.client.widget.entity;
 
 import java.util.List;
 
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
+import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.web.client.SynapseView;
 
 import com.google.gwt.user.client.ui.Widget;
 
 public interface TutorialWizardView extends SynapseView {
 
-	void showWizard(String ownerObjectId, List<WikiHeader> headers);
+	void showWizard(String ownerObjectId, List<V2WikiHeader> headers);
 	Widget getTutorialLink(String buttonText);
 	
 	/**

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizardViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/TutorialWizardViewImpl.java
@@ -10,7 +10,7 @@ import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.ModalSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.sagebionetworks.repo.model.ObjectType;
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
+import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.shared.WikiPageKey;
@@ -29,7 +29,7 @@ public class TutorialWizardViewImpl implements TutorialWizardView {
 	private Presenter presenter;
 	private PortalGinInjector ginInjector;
 	private List<MarkdownWidget> pageContents;
-	private List<WikiHeader> wikiHeaders;
+	private List<V2WikiHeader> wikiHeaders;
 	private int currentPageIndex;
 	@Inject
 	public TutorialWizardViewImpl(PortalGinInjector ginInjector) {
@@ -42,7 +42,7 @@ public class TutorialWizardViewImpl implements TutorialWizardView {
 	}
 	
 	@Override
-	public void showWizard(String ownerObjectId, List<WikiHeader> headers) {
+	public void showWizard(String ownerObjectId, List<V2WikiHeader> headers) {
 		this.wikiHeaders = headers;
 		final Modal dialog = new Modal();
 		dialog.setSize(ModalSize.LARGE);
@@ -122,8 +122,8 @@ public class TutorialWizardViewImpl implements TutorialWizardView {
  		dialog.setTitle(wikiHeaders.get(currentPageIndex).getTitle());
 	}
 	
-	public void loadAllPageContents(String ownerObjectId, List<WikiHeader> headers){
-		for (WikiHeader header : headers) {
+	public void loadAllPageContents(String ownerObjectId, List<V2WikiHeader> headers){
+		for (V2WikiHeader header : headers) {
 			MarkdownWidget step = ginInjector.getMarkdownWidget();
 			step.loadMarkdownFromWikiPage(new WikiPageKey(ownerObjectId, ObjectType.ENTITY.toString(), header.getId()), false);
 			pageContents.add(step);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
@@ -323,7 +323,7 @@ public class APITableWidget implements APITableWidgetView.Presenter, WidgetRende
 		boolean isNodeQueryService = isNodeQueryService(uri);
 		if (isSubmissionQueryService || isNodeQueryService) {
 			//the node query service's first element is at index 1! (submission query service first element is at index 0)
-			Long firstIndex = isSubmissionQueryService ? ServiceConstants.DEFAULT_PAGINATION_OFFSET : ServiceConstants.DEFAULT_PAGINATION_OFFSET_NO_OFFSET_EQUALS_ONE;
+			Long firstIndex =  ServiceConstants.DEFAULT_PAGINATION_OFFSET;
 			return uri + "+limit+"+tableConfig.getPageSize()+"+offset+"+(tableConfig.getOffset()+firstIndex);
 		} else {
 			String firstCharacter = uri.contains("?") ? "&" : "?";

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/APITableWidget.java
@@ -323,7 +323,7 @@ public class APITableWidget implements APITableWidgetView.Presenter, WidgetRende
 		boolean isNodeQueryService = isNodeQueryService(uri);
 		if (isSubmissionQueryService || isNodeQueryService) {
 			//the node query service's first element is at index 1! (submission query service first element is at index 0)
-			Long firstIndex =  ServiceConstants.DEFAULT_PAGINATION_OFFSET;
+			Long firstIndex = isSubmissionQueryService ? ServiceConstants.DEFAULT_PAGINATION_OFFSET : 1;
 			return uri + "+limit+"+tableConfig.getPageSize()+"+offset+"+(tableConfig.getOffset()+firstIndex);
 		} else {
 			String firstCharacter = uri.contains("?") ? "&" : "?";

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/WikiSubpagesWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/WikiSubpagesWidget.java
@@ -104,25 +104,24 @@ public class WikiSubpagesWidget implements WikiSubpagesView.Presenter, IsWidget 
 	public void refreshTableOfContents() {
 		view.clear();
 		
-		synapseClient.getV2WikiHeaderTree(wikiKey.getOwnerObjectId(), wikiKey.getOwnerObjectType(), new AsyncCallback<PaginatedResults<V2WikiHeader>>() {
+		synapseClient.getV2WikiHeaderTree(wikiKey.getOwnerObjectId(), wikiKey.getOwnerObjectType(), new AsyncCallback<List<V2WikiHeader>>() {
 			@Override
-			public void onSuccess(PaginatedResults<V2WikiHeader> results) {
-				final PaginatedResults<V2WikiHeader> wikiHeaders = results;
+			public void onSuccess(final List<V2WikiHeader> wikiHeaders) {
 				
 				synapseClient.getV2WikiOrderHint(wikiKey, new AsyncCallback<V2WikiOrderHint>() {
 					@Override
 					public void onSuccess(V2WikiOrderHint result) {
 						// "Sort" stuff'
 						subpageOrderHint = result;
-						WikiOrderHintUtils.sortHeadersByOrderHint(wikiHeaders.getResults(), subpageOrderHint);
-						view.configure(wikiHeaders.getResults(), wikiSubpagesContainer, wikiPageContainer, ownerObjectName,
+						WikiOrderHintUtils.sortHeadersByOrderHint(wikiHeaders, subpageOrderHint);
+						view.configure(wikiHeaders, wikiSubpagesContainer, wikiPageContainer, ownerObjectName,
 										ownerObjectLink, wikiKey, isEmbeddedInOwnerPage, getUpdateOrderHintCallback(), reloadWikiPageCallback);
 						view.setEditOrderButtonVisible(canEdit);
 					}
 					@Override
 					public void onFailure(Throwable caught) {
 						// Failed to get order hint. Just ignore it.
-						view.configure(wikiHeaders.getResults(), wikiSubpagesContainer, wikiPageContainer, ownerObjectName,
+						view.configure(wikiHeaders, wikiSubpagesContainer, wikiPageContainer, ownerObjectName,
 								ownerObjectLink, wikiKey, isEmbeddedInOwnerPage, getUpdateOrderHintCallback(), reloadWikiPageCallback);
 						view.setEditOrderButtonVisible(canEdit);
 					}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -1461,9 +1461,11 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
 			boolean isMore = true;
+			long limit = 50L;
+			long offset = 0L;
 			org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> results = new org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader>();
 			while (isMore) {
-				org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> headerTreePage = synapseClient.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType));
+				org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> headerTreePage = synapseClient.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType), limit, offset);
 				if (results.getResults() == null) {
 					results.setResults(headerTreePage.getResults());
 				} else {
@@ -1472,6 +1474,7 @@ public class SynapseClientImpl extends SynapseClientBase implements
 				if (headerTreePage.getResults().isEmpty() || headerTreePage.getTotalNumberOfResults() <= headerTreePage.getResults().size()) {
 					isMore = false;
 				}
+				offset += limit;
 			}
 			results.setTotalNumberOfResults(results.getResults().size());
 			return convertPaginated(results);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -1464,13 +1464,10 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			long limit = 50L;
 			long offset = 0L;
 			org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> results = new org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader>();
+			results.setResults(new LinkedList<V2WikiHeader>());
 			while (isMore) {
 				org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> headerTreePage = synapseClient.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType), limit, offset);
-				if (results.getResults() == null) {
-					results.setResults(headerTreePage.getResults());
-				} else {
-					results.getResults().addAll(headerTreePage.getResults());
-				}
+				results.getResults().addAll(headerTreePage.getResults());
 				if (headerTreePage.getResults().isEmpty() || headerTreePage.getTotalNumberOfResults() <= headerTreePage.getResults().size()) {
 					isMore = false;
 				}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -1460,8 +1460,21 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
-			return convertPaginated(synapseClient
-					.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType)));
+			boolean isMore = true;
+			org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> results = new org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader>();
+			while (isMore) {
+				org.sagebionetworks.reflection.model.PaginatedResults<V2WikiHeader> headerTreePage = synapseClient.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType));
+				if (results.getResults() == null) {
+					results.setResults(headerTreePage.getResults());
+				} else {
+					results.getResults().addAll(headerTreePage.getResults());
+				}
+				if (headerTreePage.getResults().isEmpty() || headerTreePage.getTotalNumberOfResults() <= headerTreePage.getResults().size()) {
+					isMore = false;
+				}
+			}
+			results.setTotalNumberOfResults(results.getResults().size());
+			return convertPaginated(results);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -130,7 +130,6 @@ import org.sagebionetworks.repo.model.v2.wiki.V2WikiHistorySnapshot;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiOrderHint;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiPage;
 import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
 import org.sagebionetworks.schema.adapter.AdapterFactory;
 import org.sagebionetworks.schema.adapter.JSONArrayAdapter;
@@ -182,7 +181,7 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		SynapseClient, TokenProvider {
 	
 	private static final Integer MAX_LIMIT = 300;
-	private static final Integer ZERO_OFFSET = 0;
+	public static final Integer ZERO_OFFSET = 0;
 
 	public static final String DEFAULT_STORAGE_ID_PROPERTY_KEY = "org.sagebionetworks.portal.synapse_storage_id";
 	public static final String HTML_TEAM_ID_PROPERTY_KEY = "org.sagebionetworks.portal.html_team_id";
@@ -195,7 +194,7 @@ public class SynapseClientImpl extends SynapseClientBase implements
 	public static final ContentType PLAIN_MESSAGE_CONTENT_TYPE = ContentType
 			.create("text/plain", MESSAGE_CHARSET);
 
-	private static final long LIMIT_50 = 50;
+	public static final long LIMIT_50 = 50;
 	static private Log log = LogFactory.getLog(SynapseClientImpl.class);
 
 	private static StackTraceDeobfuscator deobfuscator = null;
@@ -328,7 +327,7 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			Entity en = synapseClient.getEntityById(entityId);
 			if (en instanceof Versionable) {
 				// Get the correct version, now that we now it's Versionable
-				Long latestVersionNumber =  synapseClient.getEntityVersions(entityId, 1, 1)
+				Long latestVersionNumber =  synapseClient.getEntityVersions(entityId, ZERO_OFFSET, 1)
 						.getResults().get(0).getVersionNumber();
 				if (versionNumber == null || latestVersionNumber.equals(versionNumber)) {
 					versionNumber = latestVersionNumber;
@@ -992,13 +991,11 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			RestrictableObjectDescriptor subjectId = new RestrictableObjectDescriptor();
 			subjectId.setId(entityId);
 			subjectId.setType(RestrictableObjectType.ENTITY);
-
-			org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> accessRequirements = synapseClient
-					.getUnmetAccessRequirements(subjectId, accessType);
+			boolean unmetOnly = true;
+			List<AccessRequirement> accessRequirements = getAllAccessRequirements(unmetOnly, subjectId, accessType, synapseClient);
 			AccessRequirementsTransport transport = new AccessRequirementsTransport();
 			transport.setAccessRequirements(new PaginatedResults<AccessRequirement>(
-							accessRequirements.getResults(), accessRequirements
-									.getTotalNumberOfResults()));
+					accessRequirements, accessRequirements.size()));
 			Entity e = synapseClient.getEntityById(entityId);
 			transport.setEntity(e);
 			UserProfile profile = getUserProfile();
@@ -1007,6 +1004,37 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}
+	}
+	
+	private List<AccessRequirement> getAllAccessRequirements(boolean unmetOnly, RestrictableObjectDescriptor subjectId, ACCESS_TYPE accessType, org.sagebionetworks.client.SynapseClient synapseClient) throws SynapseException {
+		List<AccessRequirement> allAccessRequirements = new ArrayList<AccessRequirement>();
+		long offset = ZERO_OFFSET;
+		boolean isDone = false;
+		while (!isDone) {
+			List<AccessRequirement> accessRequirments;
+			if (unmetOnly) {
+				accessRequirments = synapseClient.getUnmetAccessRequirements(subjectId, accessType, LIMIT_50, offset).getResults();
+			} else {
+				accessRequirments = synapseClient.getAccessRequirements(subjectId, LIMIT_50, offset).getResults();
+			}
+			isDone = accessRequirments.size() < LIMIT_50;
+			allAccessRequirements.addAll(accessRequirments);
+			offset += LIMIT_50;
+		}
+		return allAccessRequirements;
+	}
+	
+	private List<V2WikiHeader> getAllWikiHeaderTree(String ownerId,	ObjectType ownerType, org.sagebionetworks.client.SynapseClient synapseClient) throws SynapseException {
+		List<V2WikiHeader> allHeaders = new ArrayList<V2WikiHeader>();
+		long offset = ZERO_OFFSET;
+		boolean isDone = false;
+		while (!isDone) {
+			List<V2WikiHeader> headers = synapseClient.getV2WikiHeaderTree(ownerId, ownerType, LIMIT_50, offset).getResults();
+			isDone = headers.size() < LIMIT_50;
+			allHeaders.addAll(headers);
+			offset += LIMIT_50;
+		}
+		return allHeaders;
 	}
 
 	@Override
@@ -1022,14 +1050,9 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			RestrictableObjectDescriptor subjectId = new RestrictableObjectDescriptor();
 			subjectId.setId(teamId);
 			subjectId.setType(RestrictableObjectType.TEAM);
-			org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> accessRequirements;
-			if (unmetOnly)
-				accessRequirements = synapseClient
-						.getUnmetAccessRequirements(subjectId, ACCESS_TYPE.PARTICIPATE);
-			else
-				accessRequirements = synapseClient
-						.getAccessRequirements(subjectId);
-			return accessRequirements.getResults();
+			List<AccessRequirement> accessRequirements = getAllAccessRequirements(unmetOnly, subjectId, ACCESS_TYPE.PARTICIPATE, synapseClient);
+				
+			return accessRequirements;
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}
@@ -1049,23 +1072,15 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			RestrictableObjectDescriptor subjectId = new RestrictableObjectDescriptor();
 			subjectId.setId(entityId);
 			subjectId.setType(RestrictableObjectType.ENTITY);
-			org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> accessRequirements;
-			if (unmetOnly)
-				accessRequirements = synapseClient
-						.getUnmetAccessRequirements(subjectId, targetAccessType);
-			else
-				accessRequirements = synapseClient
-						.getAccessRequirements(subjectId);
+			List<AccessRequirement> accessRequirements = getAllAccessRequirements(unmetOnly, subjectId, targetAccessType, synapseClient);
+			
 			// filter to the targetAccessType
 			if (targetAccessType != null) {
-				List<AccessRequirement> filteredResults = AccessRequirementUtils.filterAccessRequirements(
-						accessRequirements.getResults(), targetAccessType);
-				accessRequirements.setResults(filteredResults);
-				accessRequirements.setTotalNumberOfResults(filteredResults
-						.size());
+				accessRequirements = AccessRequirementUtils.filterAccessRequirements(
+						accessRequirements, targetAccessType);
 			}
 
-			return new PaginatedResults<AccessRequirement>(accessRequirements.getResults(), accessRequirements.getTotalNumberOfResults());
+			return new PaginatedResults<AccessRequirement>(accessRequirements, accessRequirements.size());
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		} 
@@ -1104,17 +1119,6 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		}
 	}
 	
-	@Override
-	public PaginatedResults<AccessApproval> getEntityAccessApproval(String entityId) 
-			throws RestServiceException {
-		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
-		try {
-			return convertPaginated(synapseClient.getEntityAccessApproval(entityId));
-		} catch (SynapseException e) {
-			throw ExceptionUtil.convertSynapseException(e);
-		}
-	}
-
 	@Override
 	public Entity updateExternalFile(String entityId, String externalUrl, String name, String contentType, Long fileSize, String md5, Long storageLocationId) throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
@@ -1284,25 +1288,6 @@ public class SynapseClientImpl extends SynapseClientBase implements
 		}
 	}
 
-	
-	@Override
-	public PaginatedResults<WikiHeader> getWikiHeaderTree(String ownerId, String ownerType)
-			throws RestServiceException {
-		return getWikiHeaderTree(ownerId,
-				ObjectType.valueOf(ownerType));
-	}
-
-	private PaginatedResults<WikiHeader> getWikiHeaderTree(String ownerId,
-			ObjectType ownerType) throws RestServiceException {
-		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
-		try {
-			return convertPaginated(synapseClient
-					.getWikiHeaderTree(ownerId, ownerType));
-		} catch (SynapseException e) {
-			throw ExceptionUtil.convertSynapseException(e);
-		}
-	}
-
 	private String getRootWikiId(
 			org.sagebionetworks.client.SynapseClient synapseClient,
 			String ownerId, ObjectType ownerType) throws RestServiceException {
@@ -1456,12 +1441,11 @@ public class SynapseClientImpl extends SynapseClientBase implements
 	}
 
 	@Override
-	public PaginatedResults<V2WikiHeader> getV2WikiHeaderTree(String ownerId, String ownerType)
+	public List<V2WikiHeader> getV2WikiHeaderTree(String ownerId, String ownerType)
 			throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
-			return convertPaginated(synapseClient
-					.getV2WikiHeaderTree(ownerId, ObjectType.valueOf(ownerType)));
+			return getAllWikiHeaderTree(ownerId, ObjectType.valueOf(ownerType), synapseClient);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}
@@ -2289,9 +2273,8 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			RestrictableObjectDescriptor subjectId = new RestrictableObjectDescriptor();
 			subjectId.setId(entityId);
 			subjectId.setType(RestrictableObjectType.ENTITY);
-
-			org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> currentARs = client.getAccessRequirements(subjectId);
-			if (currentARs.getTotalNumberOfResults()==0L) {
+			org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> currentARs = client.getAccessRequirements(subjectId, 1L, ZERO_OFFSET.longValue());
+			if (currentARs.getResults().isEmpty()) {
 				client.createLockAccessRequirement(entityId);
 			}
 		}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/TutorialWizardTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/TutorialWizardTest.java
@@ -13,13 +13,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.sagebionetworks.repo.model.wiki.WikiHeader;
-import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.widget.entity.TutorialWizard;
 import org.sagebionetworks.web.client.widget.entity.TutorialWizardView;
-import org.sagebionetworks.web.shared.PaginatedResults;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -32,12 +30,12 @@ public class TutorialWizardTest {
 	TutorialWizard presenter;
 	TutorialWizardView mockView;
 	SynapseClientAsync mockSynapseClient;
-	List<WikiHeader> wikiHeadersList;
-	WikiHeader testRootHeader, page1, page2;
+	List<V2WikiHeader> wikiHeadersList;
+	V2WikiHeader testRootHeader, page1, page2;
 	
 	
-	private WikiHeader createWikiHeader(String id, String parentId, String title) {
-		WikiHeader header = new WikiHeader();
+	private V2WikiHeader createWikiHeader(String id, String parentId, String title) {
+		V2WikiHeader header = new V2WikiHeader();
 		header.setId(id);
 		header.setParentId(parentId);
 		header.setTitle(title);
@@ -48,9 +46,7 @@ public class TutorialWizardTest {
 	public void before() throws JSONObjectAdapterException{
 		mockSynapseClient = Mockito.mock(SynapseClientAsync.class);
 		mockView = Mockito.mock(TutorialWizardView.class);
-			
-		PaginatedResults<WikiHeader> wikiHeaders = new PaginatedResults<WikiHeader>();
-		wikiHeadersList = new ArrayList<WikiHeader>();
+		wikiHeadersList = new ArrayList<V2WikiHeader>();
 		testRootHeader = createWikiHeader("123",null,"my test root wiki header (page)");
 		page1 = createWikiHeader("99999", "123", "Step 1");
 		page2 = createWikiHeader("1", "123", "Step 2");
@@ -59,8 +55,7 @@ public class TutorialWizardTest {
 		wikiHeadersList.add(page2);
 		wikiHeadersList.add(page1);
 		
-		wikiHeaders.setResults(wikiHeadersList);
-		AsyncMockStubber.callSuccessWith(wikiHeaders).when(mockSynapseClient).getWikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+		AsyncMockStubber.callSuccessWith(wikiHeadersList).when(mockSynapseClient).getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
 		
 		// setup the entity editor with 
 		presenter = new TutorialWizard(mockView, mockSynapseClient);
@@ -79,7 +74,7 @@ public class TutorialWizardTest {
 			}
 		});
 		ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-		verify(mockSynapseClient).getWikiHeaderTree(anyString(),  anyString(),  any(AsyncCallback.class));
+		verify(mockSynapseClient).getV2WikiHeaderTree(anyString(),  anyString(),  any(AsyncCallback.class));
 		verify(mockView).showWizard(anyString(), captor.capture());
 		List sortedHeaders = captor.getValue();
 		
@@ -92,7 +87,7 @@ public class TutorialWizardTest {
 	
 	@Test
 	public void testConfigureFail() {
-		AsyncMockStubber.callFailureWith(new Exception()).when(mockSynapseClient).getWikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+		AsyncMockStubber.callFailureWith(new Exception()).when(mockSynapseClient).getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
 		presenter.configure("syn1234", null);
 		verify(mockView).showErrorMessage(anyString());
 	}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/APITableWidgetTest.java
@@ -244,7 +244,7 @@ public class APITableWidgetTest {
 	
 	@Test
 	public void testQueryServicePagingURINodeSearch() throws JSONObjectAdapterException {
-		String expectedOffset = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM_NO_OFFSET_EQUALS_ONE;
+		String expectedOffset = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM;
 		widget.configure(testWikiKey, descriptor, null, null);
 		String testServiceCall = ClientProperties.QUERY_SERVICE_PREFIX+"select+*+from+project";
 		String pagedURI = widget.getPagedURI(testServiceCall);
@@ -253,7 +253,7 @@ public class APITableWidgetTest {
 	
 	@Test
 	public void testQueryServicePagingURISubmissionSearch() throws JSONObjectAdapterException {
-		String expectedOffset = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM_NEW;
+		String expectedOffset = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM;
 		widget.configure(testWikiKey, descriptor, null, null);
 		String testServiceCall = ClientProperties.EVALUATION_QUERY_SERVICE_PREFIX+"select+*+from+evaluation_1234";
 		String pagedURI = widget.getPagedURI(testServiceCall);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesTest.java
@@ -79,8 +79,7 @@ public class WikiSubpagesTest {
 		bundle.setEntity(new Project());
 		AsyncMockStubber.callSuccessWith(bundle).when(mockSynapseClient).getEntityBundle(anyString(), anyInt(), any(AsyncCallback.class));
 
-		AsyncMockStubber.callSuccessWith("").when(mockSynapseClient).getWikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
-		PaginatedResults<V2WikiHeader> wikiHeaders = new PaginatedResults<V2WikiHeader>();
+		AsyncMockStubber.callSuccessWith("").when(mockSynapseClient).getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
 		wikiHeadersList = new ArrayList<V2WikiHeader>();
 		testRootHeader = new V2WikiHeader();
 		testRootHeader.setId("123");
@@ -88,10 +87,9 @@ public class WikiSubpagesTest {
 		testRootHeader.setTitle("my test root wiki header (page)");
 		wikiHeadersList.add(testRootHeader);
 
-		wikiHeaders.setResults(wikiHeadersList);
 		mockV2WikiOrderHint = mock(V2WikiOrderHint.class);
 		when(mockV2WikiOrderHint.getIdList()).thenReturn(null);
-		AsyncMockStubber.callSuccessWith(wikiHeaders).when(mockSynapseClient).getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+		AsyncMockStubber.callSuccessWith(wikiHeadersList).when(mockSynapseClient).getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
 		AsyncMockStubber.callSuccessWith(mockV2WikiOrderHint).when(mockSynapseClient).getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
 		reset(mockView);
 	}

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -908,10 +908,12 @@ public class SynapseClientImplTest {
 			page1Results.add(Mockito.mock(V2WikiHeader.class));
 		}
 		when(headerTreePage1.getResults()).thenReturn(page1Results);
-		when(headerTreePage2.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
+		//second page has a single page
+		V2WikiHeader singleHeader = Mockito.mock(V2WikiHeader.class);
+		when(headerTreePage2.getResults()).thenReturn(Collections.singletonList(singleHeader));
 		List<V2WikiHeader> results = synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
-		//1 full page of results
-		assertEquals(SynapseClientImpl.LIMIT_50, results.size());
+		//1 full page of results, and 1 result on second page
+		assertEquals(SynapseClientImpl.LIMIT_50 + 1, results.size());
 		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.ZERO_OFFSET.longValue()));
 		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.LIMIT_50));
 	}
@@ -1821,11 +1823,13 @@ public class SynapseClientImplTest {
 			page1Results.add(Mockito.mock(AccessRequirement.class));
 		}
 		when(page1.getResults()).thenReturn(page1Results);
-		when(page2.getResults()).thenReturn(new LinkedList<AccessRequirement>());
+		// second page has a single result
+		AccessRequirement singleAccessRequirement = Mockito.mock(AccessRequirement.class);
+		when(page2.getResults()).thenReturn(Collections.singletonList(singleAccessRequirement));
 		boolean unmetOnly = true;
 		org.sagebionetworks.web.shared.PaginatedResults<AccessRequirement> results = synapseClient.getEntityAccessRequirements(entityId, unmetOnly, null);
 		//1 full page of results
-		assertEquals(SynapseClientImpl.LIMIT_50, results.getResults().size());
+		assertEquals(SynapseClientImpl.LIMIT_50 + 1, results.getResults().size());
 		verify(mockSynapse).getUnmetAccessRequirements(any(RestrictableObjectDescriptor.class), any(ACCESS_TYPE.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.ZERO_OFFSET.longValue()));
 		verify(mockSynapse).getUnmetAccessRequirements(any(RestrictableObjectDescriptor.class), any(ACCESS_TYPE.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.LIMIT_50));
 	}

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -894,15 +894,31 @@ public class SynapseClientImplTest {
 	}
 
 	@Test
-	public void testGetV2WikiHeaderTree() throws Exception {
-		PaginatedResults<V2WikiHeader> headerTreeResults = new PaginatedResults<V2WikiHeader>();
-		when(
-				mockSynapse.getV2WikiHeaderTree(anyString(),
-						any(ObjectType.class))).thenReturn(headerTreeResults);
-		synapseClient.getV2WikiHeaderTree("testId",
-				ObjectType.ENTITY.toString());
-		verify(mockSynapse).getV2WikiHeaderTree(anyString(),
-				any(ObjectType.class));
+	public void testGetV2WikiHeaderTreeOnePage() throws Exception {
+		PaginatedResults<V2WikiHeader> headerTreeResults = Mockito.mock(PaginatedResults.class);
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class)))
+				.thenReturn(headerTreeResults);
+		when(headerTreeResults.getTotalNumberOfResults()).thenReturn(0L);
+		when(headerTreeResults.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
+		synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
+	}
+
+	@Test
+	public void testGetV2WikiHeaderTreeTwoPage() throws Exception {
+		PaginatedResults<V2WikiHeader> headerTreePage1 = Mockito.mock(PaginatedResults.class);
+		PaginatedResults<V2WikiHeader> headerTreePage2 = Mockito.mock(PaginatedResults.class);
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class)))
+				.thenReturn(headerTreePage1, headerTreePage2);
+		when(headerTreePage1.getTotalNumberOfResults()).thenReturn(2L);
+		when(headerTreePage1.getResults()).thenReturn(Arrays.asList(new V2WikiHeader()));
+		when(headerTreePage2.getTotalNumberOfResults()).thenReturn(0L);
+		when(headerTreePage2.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
+		org.sagebionetworks.web.shared.PaginatedResults<V2WikiHeader> results = synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
+		assertEquals(results.getResults().size(), 1);
+		assertEquals(results.getTotalNumberOfResults(), 1);
+		assertEquals(results.getResults().get(0), new V2WikiHeader());
+		verify(mockSynapse, times(2)).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
 	}
 
 	@Test
@@ -2525,5 +2541,5 @@ public class SynapseClientImplTest {
 		assertEquals(name, SynapseClientImpl.getFileNameFromExternalUrl("/root/" + name));
 		assertEquals(name, SynapseClientImpl.getFileNameFromExternalUrl("http://google.com/" + name));
 	}
-	
+
 }

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -886,13 +886,15 @@ public class SynapseClientImplTest {
 	@Test
 	public void testGetV2WikiHeaderTree() throws Exception {
 		PaginatedResults<V2WikiHeader> headerTreeResults = new PaginatedResults<V2WikiHeader>();
+		headerTreeResults.setResults(new ArrayList<V2WikiHeader>());
 		when(
 				mockSynapse.getV2WikiHeaderTree(anyString(),
-						any(ObjectType.class))).thenReturn(headerTreeResults);
+						any(ObjectType.class),
+						anyLong(), anyLong())).thenReturn(headerTreeResults);
 		synapseClient.getV2WikiHeaderTree("testId",
 				ObjectType.ENTITY.toString());
 		verify(mockSynapse).getV2WikiHeaderTree(anyString(),
-				any(ObjectType.class));
+				any(ObjectType.class),anyLong(), anyLong());
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -911,7 +911,7 @@ public class SynapseClientImplTest {
 		when(headerTreePage2.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
 		List<V2WikiHeader> results = synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
 		//1 full page of results
-		assertEquals(results.size(), SynapseClientImpl.LIMIT_50);
+		assertEquals(SynapseClientImpl.LIMIT_50, results.size());
 		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.ZERO_OFFSET.longValue()));
 		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.LIMIT_50));
 	}
@@ -1810,6 +1810,26 @@ public class SynapseClientImplTest {
 				anyLong());
 	}
 
+	@Test
+	public void testGetAllEntityAccessRequirementsTwoPage() throws Exception {
+		PaginatedResults<AccessRequirement> page1 = Mockito.mock(PaginatedResults.class);
+		PaginatedResults<AccessRequirement> page2 = Mockito.mock(PaginatedResults.class);
+		when(mockSynapse.getUnmetAccessRequirements(any(RestrictableObjectDescriptor.class), any(ACCESS_TYPE.class), anyLong(), anyLong()))
+				.thenReturn(page1, page2);
+		List<AccessRequirement> page1Results = new ArrayList<AccessRequirement>();
+		for (int i = 0; i < SynapseClientImpl.LIMIT_50; i++) {
+			page1Results.add(Mockito.mock(AccessRequirement.class));
+		}
+		when(page1.getResults()).thenReturn(page1Results);
+		when(page2.getResults()).thenReturn(new LinkedList<AccessRequirement>());
+		boolean unmetOnly = true;
+		org.sagebionetworks.web.shared.PaginatedResults<AccessRequirement> results = synapseClient.getEntityAccessRequirements(entityId, unmetOnly, null);
+		//1 full page of results
+		assertEquals(SynapseClientImpl.LIMIT_50, results.getResults().size());
+		verify(mockSynapse).getUnmetAccessRequirements(any(RestrictableObjectDescriptor.class), any(ACCESS_TYPE.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.ZERO_OFFSET.longValue()));
+		verify(mockSynapse).getUnmetAccessRequirements(any(RestrictableObjectDescriptor.class), any(ACCESS_TYPE.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.LIMIT_50));
+	}
+	
 	// pass through tests for email validation
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -896,19 +896,19 @@ public class SynapseClientImplTest {
 	@Test
 	public void testGetV2WikiHeaderTreeOnePage() throws Exception {
 		PaginatedResults<V2WikiHeader> headerTreeResults = Mockito.mock(PaginatedResults.class);
-		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class)))
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong()))
 				.thenReturn(headerTreeResults);
 		when(headerTreeResults.getTotalNumberOfResults()).thenReturn(0L);
 		when(headerTreeResults.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
 		synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
-		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong());
 	}
 
 	@Test
 	public void testGetV2WikiHeaderTreeTwoPage() throws Exception {
 		PaginatedResults<V2WikiHeader> headerTreePage1 = Mockito.mock(PaginatedResults.class);
 		PaginatedResults<V2WikiHeader> headerTreePage2 = Mockito.mock(PaginatedResults.class);
-		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class)))
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong()))
 				.thenReturn(headerTreePage1, headerTreePage2);
 		when(headerTreePage1.getTotalNumberOfResults()).thenReturn(2L);
 		when(headerTreePage1.getResults()).thenReturn(Arrays.asList(new V2WikiHeader()));
@@ -918,7 +918,8 @@ public class SynapseClientImplTest {
 		assertEquals(results.getResults().size(), 1);
 		assertEquals(results.getTotalNumberOfResults(), 1);
 		assertEquals(results.getResults().get(0), new V2WikiHeader());
-		verify(mockSynapse, Mockito.times(2)).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(50L), eq(0L));
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(50L), eq(50L));
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -918,7 +918,7 @@ public class SynapseClientImplTest {
 		assertEquals(results.getResults().size(), 1);
 		assertEquals(results.getTotalNumberOfResults(), 1);
 		assertEquals(results.getResults().get(0), new V2WikiHeader());
-		verify(mockSynapse, times(2)).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
+		verify(mockSynapse, Mockito.times(2)).getV2WikiHeaderTree(anyString(), any(ObjectType.class));
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -435,12 +435,12 @@ public class SynapseClientImplTest {
 		ars.setResults(new ArrayList<AccessRequirement>());
 		when(
 				mockSynapse
-						.getAccessRequirements(any(RestrictableObjectDescriptor.class)))
+						.getAccessRequirements(any(RestrictableObjectDescriptor.class), anyLong(), anyLong()))
 				.thenReturn(ars);
 		when(
 				mockSynapse.getUnmetAccessRequirements(
 						any(RestrictableObjectDescriptor.class),
-						any(ACCESS_TYPE.class))).thenReturn(ars);
+						any(ACCESS_TYPE.class), anyLong(), anyLong())).thenReturn(ars);
 		mockEvaluation = Mockito.mock(Evaluation.class);
 		when(mockEvaluation.getStatus()).thenReturn(EvaluationStatus.OPEN);
 		when(mockSynapse.getEvaluation(anyString())).thenReturn(mockEvaluation);
@@ -815,16 +815,6 @@ public class SynapseClientImplTest {
 	}
 
 	@Test
-	public void testGetWikiHeaderTree() throws Exception {
-		PaginatedResults<WikiHeader> headerTreeResults = new PaginatedResults<WikiHeader>();
-		when(mockSynapse.getWikiHeaderTree(anyString(), any(ObjectType.class)))
-				.thenReturn(headerTreeResults);
-		synapseClient.getWikiHeaderTree("testId", ObjectType.ENTITY.toString());
-		verify(mockSynapse).getWikiHeaderTree(anyString(),
-				eq(ObjectType.ENTITY));
-	}
-	
-	@Test
 	public void testGetWikiAttachmentHandles() throws Exception {
 		FileHandleResults testResults = new FileHandleResults();
 		Mockito.when(
@@ -892,19 +882,35 @@ public class SynapseClientImplTest {
 		verify(mockSynapse).restoreV2WikiPage(anyString(),
 				any(ObjectType.class), any(String.class), anyLong());
 	}
-
 	@Test
-	public void testGetV2WikiHeaderTree() throws Exception {
-		PaginatedResults<V2WikiHeader> headerTreeResults = new PaginatedResults<V2WikiHeader>();
-		when(
-				mockSynapse.getV2WikiHeaderTree(anyString(),
-						any(ObjectType.class))).thenReturn(headerTreeResults);
-		synapseClient.getV2WikiHeaderTree("testId",
-				ObjectType.ENTITY.toString());
-		verify(mockSynapse).getV2WikiHeaderTree(anyString(),
-				any(ObjectType.class));
+	public void testGetV2WikiHeaderTreeOnePage() throws Exception {
+		PaginatedResults<V2WikiHeader> headerTreeResults = Mockito.mock(PaginatedResults.class);
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong()))
+				.thenReturn(headerTreeResults);
+		when(headerTreeResults.getTotalNumberOfResults()).thenReturn(0L);
+		when(headerTreeResults.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
+		synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong());
 	}
 
+	@Test
+	public void testGetV2WikiHeaderTreeTwoPage() throws Exception {
+		PaginatedResults<V2WikiHeader> headerTreePage1 = Mockito.mock(PaginatedResults.class);
+		PaginatedResults<V2WikiHeader> headerTreePage2 = Mockito.mock(PaginatedResults.class);
+		when(mockSynapse.getV2WikiHeaderTree(anyString(), any(ObjectType.class), anyLong(), anyLong()))
+				.thenReturn(headerTreePage1, headerTreePage2);
+		List<V2WikiHeader> page1Results = new ArrayList<V2WikiHeader>();
+		for (int i = 0; i < SynapseClientImpl.LIMIT_50; i++) {
+			page1Results.add(Mockito.mock(V2WikiHeader.class));
+		}
+		when(headerTreePage1.getResults()).thenReturn(page1Results);
+		when(headerTreePage2.getResults()).thenReturn(new LinkedList<V2WikiHeader>());
+		List<V2WikiHeader> results = synapseClient.getV2WikiHeaderTree("testId", ObjectType.ENTITY.toString());
+		//1 full page of results
+		assertEquals(results.size(), SynapseClientImpl.LIMIT_50);
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.ZERO_OFFSET.longValue()));
+		verify(mockSynapse).getV2WikiHeaderTree(anyString(), any(ObjectType.class), eq(SynapseClientImpl.LIMIT_50), eq(SynapseClientImpl.LIMIT_50));
+	}
 	@Test
 	public void testGetV2WikiOrderHint() throws Exception {
 		V2WikiOrderHint orderHint = new V2WikiOrderHint();
@@ -1785,7 +1791,9 @@ public class SynapseClientImplTest {
 		verify(mockSynapse)
 				.getUnmetAccessRequirements(
 						any(RestrictableObjectDescriptor.class),
-						any(ACCESS_TYPE.class));
+						any(ACCESS_TYPE.class),
+						anyLong(),
+						anyLong());
 	}
 
 	@Test
@@ -1793,7 +1801,9 @@ public class SynapseClientImplTest {
 		// verify it calls getAccessRequirements when unmet is false
 		synapseClient.getEntityAccessRequirements(entityId, false, null);
 		verify(mockSynapse).getAccessRequirements(
-				any(RestrictableObjectDescriptor.class));
+				any(RestrictableObjectDescriptor.class),
+				anyLong(),
+				anyLong());
 	}
 
 	// pass through tests for email validation

--- a/src/test/java/org/sagebionetworks/web/unitserver/setup/TestBootstrapLocalSynapse.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/setup/TestBootstrapLocalSynapse.java
@@ -140,7 +140,7 @@ public class TestBootstrapLocalSynapse {
 		RestrictableObjectDescriptor rod = new RestrictableObjectDescriptor();
 		rod.setId(entityId);
 		rod.setType(RestrictableObjectType.ENTITY);
-		org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> vcpr = synapseClient.getAccessRequirements(rod);
+		org.sagebionetworks.reflection.model.PaginatedResults<AccessRequirement> vcpr = synapseClient.getAccessRequirements(rod, 50L, 0L);
 		if(vcpr != null && vcpr.getTotalNumberOfResults() > 0){
 			for(AccessRequirement ar: vcpr.getResults()){
 				if(ar.getAccessType().equals(type)){


### PR DESCRIPTION
and java client methods require limit and offset.  when gathering wiki header tree, return all.  same for access requirements (>50 access requirements on an entity/team!)