### PR TITLE
SWC-3503: hide team member count

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidget.java
@@ -255,7 +255,7 @@ public class PreviewWidget implements PreviewWidgetView.Presenter, WidgetRendere
 				view.showLoading();
 				boolean isGetPreviewFile = PreviewFileType.HTML != previewType;
 				String contentType = isGetPreviewFile ? handle.getContentType() : originalFileHandle.getContentType();
-				
+				final String fileCreatedBy = originalFileHandle.getCreatedBy();
 				//must be a text type of some kind
 				//try to load the text of the preview, if available
 				requestBuilder.configure(RequestBuilder.GET, 
@@ -275,7 +275,7 @@ public class PreviewWidget implements PreviewWidgetView.Presenter, WidgetRendere
 								String responseText = response.getText();
 								if (responseText != null && responseText.length() > 0) {
 									if (previewType == PreviewFileType.HTML) {
-										renderHTML(fileEntity.getModifiedBy(), responseText);
+										renderHTML(fileCreatedBy, responseText);
 									} else {
 										if (responseText.length() > MAX_LENGTH) {
 											responseText = responseText.substring(0, MAX_LENGTH) + "...";

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -1978,10 +1978,9 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			boolean isLoggedIn) throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
-			org.sagebionetworks.reflection.model.PaginatedResults<TeamMember> allMembers = synapseClient
-					.getTeamMembers(teamId, null, 1, ZERO_OFFSET);
-			// get's total member count, can we get rid of this now?
-			long memberCount = allMembers.getTotalNumberOfResults();
+//			TODO:  SWC-3503: do service call to get the team member count (when available)
+//			long memberCount = allMembers.getTotalNumberOfResults();
+			long memberCount = -1;
 			boolean isAdmin = false;
 			Team team = synapseClient.getTeam(teamId);
 			TeamMembershipStatus membershipStatus = null;

--- a/src/main/resources/org/sagebionetworks/web/client/view/TeamViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/TeamViewImpl.ui.xml
@@ -39,9 +39,8 @@
 	        <g:SimplePanel ui:field="synAlertPanel"/>
 	    	<div class="row">
 		    	<g:HTMLPanel ui:field="mainContainer" styleName="col-md-12">
-		    	    <bh:Span addStyleNames="boldText margin-right-5">Total members: </bh:Span>
-		    	    <bh:Span ui:field="totalMemberCountField"/>
-		    	    <br/>
+		    	    <bh:Span addStyleNames="boldText margin-right-5" visible="false">Total members: </bh:Span>
+		    	    <bh:Span ui:field="totalMemberCountField" visible="false"/>
 		    	    <bh:Span ui:field="publicJoinField" visible="false" addStyleNames="boldText margin-right-5">Can be joined without team manager authorization </bh:Span>
 		    	    <g:TextBox ui:field="synapseEmailField" width="100%" addStyleNames="border-none noBackground margin-right-15" readOnly="true" />
 		    	    <b:Anchor ui:field="showMapLink" text="Show map" icon="MAP_MARKER" visible="false"/>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/PreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/PreviewWidgetTest.java
@@ -446,7 +446,7 @@ public class PreviewWidgetTest {
 	public void testRenderDangerousHTML() {
 		boolean isUserAllowedToRenderHTML = true;
 		String userId = "56765";
-		testEntity.setModifiedBy(userId);
+		mainFileHandle.setCreatedBy(userId);
 		String html = "<html><script></script></html>";
 		AsyncMockStubber.callSuccessWith(isUserAllowedToRenderHTML).when(mockSynapseClient).isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
 		when(mockResponse.getText()).thenReturn(html);

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -1505,14 +1505,8 @@ public class SynapseClientImplTest {
 	public void testGetTeamBundle() throws SynapseException,
 			RestServiceException, MalformedURLException,
 			JSONObjectAdapterException {
-		// set team member count
-		Long testMemberCount = 111L;
-		PaginatedResults<TeamMember> allMembers = new PaginatedResults<TeamMember>();
-		allMembers.setTotalNumberOfResults(testMemberCount);
-		when(
-				mockSynapse.getTeamMembers(anyString(), anyString(), anyLong(),
-						anyLong())).thenReturn(allMembers);
-
+		//TODO: test team member count
+		
 		// set team
 		Team team = new Team();
 		team.setId("test team id");
@@ -1539,7 +1533,6 @@ public class SynapseClientImplTest {
 		assertEquals(team, bundle.getTeam());
 		assertEquals(membershipStatus, bundle.getTeamMembershipStatus());
 		assertEquals(isAdmin, bundle.isUserAdmin());
-		assertEquals(testMemberCount, bundle.getTotalMemberCount());
 	}
 
 	@Test


### PR DESCRIPTION
and use file handle created by user instead of file entity modified by for html rendering.