### PR TITLE
SWC-3512: auto frame height

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/PreviewWidgetViewImpl.java
@@ -264,8 +264,8 @@ public class PreviewWidgetViewImpl extends FlowPanel implements PreviewWidgetVie
 			if (newHeightPx < 450) {
 				newHeightPx = 450;
 			}
-			var newHeightValue = newHeightPx + "px";
-			if (newHeightValue != iframe.height) {
+			var frameHeight = parseInt(iframe.height);
+			if (!frameHeight || (newHeightPx != frameHeight && newHeightPx > frameHeight)) {
 				iframe.height = "";
 				iframe.height = (newHeightPx + 50) + "px";
 			}


### PR DESCRIPTION
support html pages that consistently report frame height larger than the content body scrollHeight