### PR TITLE
SWC-3528: hide imposing restriction dialog after confirmation

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/RestrictionWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/RestrictionWidget.java
@@ -283,6 +283,7 @@ public class RestrictionWidget implements RestrictionWidgetView.Presenter, Synap
 			view.showErrorMessage("You must make a selection before continuing.");
 		} else {
 			view.showLoading();
+			view.setImposeRestrictionModalVisible(false);
 			//the access requirement dialog knows how to impose the restriction
 			accessRequirementDialog.imposeRestriction(bundle.getEntity().getId(), entityUpdated);
 		}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RestrictionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RestrictionWidgetTest.java
@@ -306,6 +306,7 @@ public class RestrictionWidgetTest {
 		when(mockView.isYesHumanDataRadioSelected()).thenReturn(true);
 		widget.imposeRestrictionOkClicked();
 		verify(mockView).showLoading();
+		verify(mockView).setImposeRestrictionModalVisible(false);
 		verify(mockAccessRequirementDialog).imposeRestriction(anyString(), any(Callback.class));
 	}
 


### PR DESCRIPTION
Much of this will be removed after migrating to the new Access Requirements place (with ACT management tools), but this feature must remain.