### PR TITLE
SWC-3529: load defaults if no content (and nothing in the session storage)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayDialog.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayDialog.java
@@ -31,7 +31,7 @@ public class ProjectDisplayDialog implements ProjectDisplayView.Presenter, IsWid
 	public static final String CHALLENGE = "Challenge";
 	public static final String DISCUSSION = "Discussion";
 	public static final String DOCKER = "Docker";
-	
+	boolean isNothingSelected;
 	@Inject
 	public ProjectDisplayDialog(ProjectDisplayView view,
 			SynapseClientAsync synapseClient, 
@@ -79,11 +79,22 @@ public class ProjectDisplayDialog implements ProjectDisplayView.Presenter, IsWid
 				view.setDiscussion(discussion);
 				boolean docker = Boolean.parseBoolean(storage.get(tag + DOCKER)) || result.dockerHasContent();
 				view.setDocker(docker);
+				isNothingSelected = !(wiki || files || tables || challenge || discussion || docker);
+				if (isNothingSelected) {
+					setToDefaultSelections();
+				}
 				view.show();
 			}
 			
 		});
 		
+	}
+	
+	public void setToDefaultSelections() {
+		view.setWiki(true);
+		view.setFiles(true);
+		view.setTables(true);
+		view.setDiscussion(true);
 	}
 	
 	public void hide() {
@@ -131,9 +142,15 @@ public class ProjectDisplayDialog implements ProjectDisplayView.Presenter, IsWid
 	}
 	
 	@Override
-	public void cancel() {
-		synAlert.clear();
-		hide();
+	public void onCancel() {
+		// if cancel but we have no content and nothing in the session storage, then save default view to the cache.
+		if (isNothingSelected) {
+			setToDefaultSelections();
+			onSave();
+		} else {
+			synAlert.clear();
+			hide();	
+		}
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayView.java
@@ -1,15 +1,11 @@
 package org.sagebionetworks.web.client.widget.display;
 
-import org.sagebionetworks.web.client.SynapseView;
-import org.sagebionetworks.web.client.utils.Callback;
-
 import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
 
 public interface ProjectDisplayView extends IsWidget {
 	public interface Presenter {
 		void onSave();
-		void cancel();
+		void onCancel();
 	}
 
 	void setSynAlertWidget(IsWidget asWidget);

--- a/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/display/ProjectDisplayViewImpl.java
@@ -60,7 +60,7 @@ public class ProjectDisplayViewImpl implements ProjectDisplayView {
 		cancelButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				presenter.cancel();
+				presenter.onCancel();
 			}
 		});
 		


### PR DESCRIPTION
And if user cancels in this case, then load the defaults back into the view and save those to web storage state.