### PR TITLE
use faster way to get notification count, still get Teams (for the team filter in the project tab)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
@@ -492,4 +492,8 @@ public interface SynapseClient extends XsrfProtectedService {
 	void deleteAccessRequirement(Long accessRequirementId) throws RestServiceException;
 
 	void addTeamMember(String userGroupId, String teamId, String message, String hostPageBaseURL) throws RestServiceException;
+
+	Long getOpenMembershipInvitationCount() throws RestServiceException;
+
+	Long getOpenMembershipRequestCount() throws RestServiceException;
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
@@ -421,4 +421,8 @@ public interface SynapseClientAsync {
 
 	void addTeamMember(String userGroupId, String teamId, String message, String hostPageBaseURL,
 			AsyncCallback<Void> callback);
+
+	void getOpenMembershipInvitationCount(AsyncCallback<Long> callback);
+
+	void getOpenMembershipRequestCount(AsyncCallback<Long> callback);
 }

--- a/src/main/java/org/sagebionetworks/web/client/view/ProfileView.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ProfileView.java
@@ -80,8 +80,6 @@ public interface ProfileView extends IsWidget, SynapseView {
 		void createTeam(final String teamName);
 		void goTo(Place place);
 		void refreshTeams();
-		void updateTeamInvites(List<OpenUserInvitationBundle> invites);
-		void addMembershipRequests(int count);
 		void tabClicked(ProfileArea areaTab);
 		void unbindOrcId();
 		void certificationBadgeClicked();
@@ -91,7 +89,6 @@ public interface ProfileView extends IsWidget, SynapseView {
 		void onImportLinkedIn();
 		void setGetCertifiedDismissed();
 		void resort(SortOptionEnum sortOption);
-		void refreshTeamInvites();
 		void newVerificationSubmissionClicked();
 		void editVerificationSubmissionClicked();
 		void setVerifyDismissed();

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -40,6 +40,7 @@ import org.sagebionetworks.repo.model.AccessApproval;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.Annotations;
+import org.sagebionetworks.repo.model.Count;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityBundle;
 import org.sagebionetworks.repo.model.EntityChildrenRequest;
@@ -2925,5 +2926,25 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			throw ExceptionUtil.convertSynapseException(e);
 		}
 
+	}
+	
+	@Override
+	public Long getOpenMembershipInvitationCount() throws RestServiceException {
+		try {
+			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
+			return synapseClient.getOpenMembershipInvitationCount().getCount();
+		} catch (SynapseException e) {
+			throw ExceptionUtil.convertSynapseException(e);
+		}
+	}
+	
+	@Override
+	public Long getOpenMembershipRequestCount() throws RestServiceException {
+		try {
+			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
+			return synapseClient.getOpenMembershipRequestCount().getCount();
+		} catch (SynapseException e) {
+			throw ExceptionUtil.convertSynapseException(e);
+		}
 	}
 }


### PR DESCRIPTION
but do not get open request count for each team.