### PR TITLE
SWC-3815: get the display user name from the locally cached current user profile…

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
@@ -449,7 +449,8 @@ public class AccessControlListEditor implements AccessControlListEditorView.Pres
 			
 			if (newPrincipalIdSet.size() > 0) {
 				//now send a message to these users
-				String message = DisplayUtils.getShareMessage(getDisplayName(getCurrentUserId()), entity.getId(), gwt.getHostPageBaseURL());
+				String userDisplayName = DisplayUtils.getDisplayName(authenticationController.getCurrentUserSessionData().getProfile());
+				String message = DisplayUtils.getShareMessage(userDisplayName, entity.getId(), gwt.getHostPageBaseURL());
 				String subject = entity.getName() + DisplayConstants.SHARED_ON_SYNAPSE_SUBJECT;
 				synapseClient.sendMessage(newPrincipalIdSet, subject, message, gwt.getHostPageBaseURL(), new AsyncCallback<String>() {
 					@Override


### PR DESCRIPTION
…not from the ACL user group header (current user may not be listed)