### PR TITLE
SWC-3826: ignore responses that are out of date (not related to the current wiki page id)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiHistoryWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiHistoryWidget.java
@@ -64,6 +64,10 @@ public class WikiHistoryWidget implements WikiHistoryWidgetView.Presenter,
 		view.configure(canEdit, actionHandler);
 	}
 	
+	public void clear() {
+		view.clear();
+	}
+	
 	@Override
 	public void configureNextPage(final Long offset, final Long limit) {
 		synapseClient.getV2WikiHistory(wikiKey, limit, offset, new AsyncCallback<PaginatedResults<V2WikiHistorySnapshot>>() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiHistoryWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiHistoryWidgetViewImpl.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.repo.model.v2.wiki.V2WikiHistorySnapshot;
 import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
+import org.sagebionetworks.web.client.SageImageBundle;
 import org.sagebionetworks.web.client.DisplayUtils.MessagePopup;
 import org.sagebionetworks.web.client.view.bootstrap.table.TBody;
 import org.sagebionetworks.web.client.view.bootstrap.table.THead;
@@ -25,6 +26,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -44,10 +46,12 @@ public class WikiHistoryWidgetViewImpl extends FlowPanel implements WikiHistoryW
 	private int offset;
 	private int resultSize;
 	DateTimeUtils dateTimeUtils;
-	
+	HTML loadingUI;
 	@Inject
-	public WikiHistoryWidgetViewImpl(DateTimeUtils dateTimeUtils) {
+	public WikiHistoryWidgetViewImpl(DateTimeUtils dateTimeUtils, SageImageBundle sageImageBundle) {
 		this.dateTimeUtils = dateTimeUtils;
+		addStyleName("min-height-200");
+		loadingUI = new HTML(DisplayUtils.getLoadingHtml(sageImageBundle, "Loading"));
 	}
 	
 	private static class HistoryEntry {
@@ -69,6 +73,8 @@ public class WikiHistoryWidgetViewImpl extends FlowPanel implements WikiHistoryW
 		this.isFirstGetHistory = true;
 		this.offset = 0;
 		// Reset history
+		hideHistoryWidget();
+		add(loadingUI);
 		historyList = new ArrayList<V2WikiHistorySnapshot>();
 		historyEntries = new ArrayList<HistoryEntry>();
 		presenter.configureNextPage(new Long(offset), new Long(10));
@@ -223,15 +229,16 @@ public class WikiHistoryWidgetViewImpl extends FlowPanel implements WikiHistoryW
 		historyPanel.add(wrapWidget(historyTable, "margin-top-5"));
 		historyPanel.add(loadMoreHistoryButton);
 		add(historyPanel);
+		loadingUI.removeFromParent();
 	}
 	
 	@Override
 	public void hideHistoryWidget() {
 		if(historyPanel != null) {
-			historyPanel.setVisible(false);
+			historyPanel.removeFromParent();
 		}
 		if(inlineErrorMessagePanel != null) {
-			inlineErrorMessagePanel.setVisible(false);
+			inlineErrorMessagePanel.removeFromParent();
 		}
 	}
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
@@ -178,6 +178,10 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 	}
 	
 	public void setWikiPage(WikiPage result) {
+		if (!result.getId().equals(wikiKey.getWikiPageId())) {
+			// if this result is not the wiki page that we want, then ignore.
+			return;
+		}
 		try {
 			view.setDiffVersionAlertVisible(false);
 			view.setModifiedCreatedByHistoryPanelVisible(isModifiedCreatedByHistoryVisible);
@@ -358,9 +362,10 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 		wikiKey.setWikiPageId(currentPage.getId());
 		resetWikiMarkdown(currentPage.getMarkdown());
 		configureWikiTitle(isRootWiki, currentPage.getTitle());
-		configureHistoryWidget(canEdit);
 		view.setCreatedOn(dateTimeUtils.convertDateToSmallString(result.getCreatedOn()));
 		view.setModifiedOn(dateTimeUtils.convertDateToSmallString(result.getModifiedOn()));
+		view.setWikiHistoryVisible(false);
+		historyWidget.clear();
 	}
 	
 	@Override
@@ -427,4 +432,8 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 		isModifiedCreatedByHistoryVisible = isVisible;
 	}
 	
+	@Override
+	public void showWikiHistory() {
+		configureHistoryWidget(canEdit);
+	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.web.client.widget.entity;
 
+import java.util.Objects;
+
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiPage;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
 import org.sagebionetworks.schema.adapter.AdapterFactory;
@@ -178,7 +180,7 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 	}
 	
 	public void setWikiPage(WikiPage result) {
-		if (!result.getId().equals(wikiKey.getWikiPageId())) {
+		if (!Objects.equals(result.getId(), wikiKey.getWikiPageId())) {
 			// if this result is not the wiki page that we want, then ignore.
 			return;
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetView.java
@@ -28,6 +28,7 @@ public interface WikiPageWidgetView extends IsWidget {
 		public void restoreClicked();
 		void configureWikiSubpagesWidget();
 		void configureHistoryWidget(boolean canEdit);
+		void showWikiHistory();
 	}
 	
 	void setWikiHistoryWidget(IsWidget historyWidget);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.java
@@ -121,6 +121,7 @@ public class WikiPageWidgetViewImpl extends FlowPanel implements WikiPageWidgetV
 				} else {
 					wikiHistoryButton.setIcon(IconType.CARET_SQUARE_O_DOWN);
 					historyCollapse.show();
+					presenter.showWikiHistory();
 				}
 			}
 		});
@@ -272,8 +273,10 @@ public class WikiPageWidgetViewImpl extends FlowPanel implements WikiPageWidgetV
 	public void setWikiHistoryVisible(boolean isVisible) {
 		if (isVisible) {
 			historyCollapse.show();
+			wikiHistoryButton.setIcon(IconType.CARET_SQUARE_O_DOWN);
 		} else {
 			historyCollapse.hide();
+			wikiHistoryButton.setIcon(IconType.CARET_SQUARE_O_RIGHT);
 		}
 	}
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -257,6 +257,13 @@ public class WikiPageWidgetTest {
 		//also verify that the created by and modified by are updated when wiki page is reloaded
 		verify(mockView, times(2)).setModifiedOn(anyString());
 		verify(mockView, times(2)).setCreatedOn(anyString());
+		
+		//verify response for a different wiki is ignored (if it does not match the current wiki page id, then the markdown widget is not updated).
+		reset(mockMarkdownWidget);
+		wikiPage = new WikiPage();
+		wikiPage.setId("different wiki page id");
+		presenter.setWikiPage(wikiPage);
+		verifyZeroInteractions(mockMarkdownWidget);
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
@@ -99,6 +99,7 @@ public class WikiPageWidgetTest {
 	WikiPageWidget presenter;
 	WikiPage testPage;
 	private static final String MY_TEST_ENTITY_OWNER_NAME = "My Test Entity Owner Name";
+	public static final String WIKI_PAGE_ID = "12345";
 	
 	@Before
 	public void before() throws Exception{
@@ -116,7 +117,7 @@ public class WikiPageWidgetTest {
 		headers.setResults(resultHeaderList);
 		AsyncMockStubber.callSuccessWith(headers).when(mockSynapseClient).getEntityHeaderBatch(any(ReferenceList.class), any(AsyncCallback.class));
 		testPage = new WikiPage();
-		testPage.setId("wikiPageId");
+		testPage.setId(WIKI_PAGE_ID);
 		testPage.setMarkdown("my test markdown");
 		testPage.setTitle("My Test Wiki Title");
 		AsyncMockStubber.callSuccessWith(testPage).when(mockSynapseJavascriptClient).getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
@@ -138,12 +139,11 @@ public class WikiPageWidgetTest {
 		String suffix = "-test-suffix";
 		String formattedDate = "today";
 		when(mockDateTimeUtils.convertDateToSmallString(any(Date.class))).thenReturn(formattedDate);
-		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null, showSubpages);
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null, showSubpages);
 		verify(mockView).setLoadingVisible(true);
 		verify(mockSynapseJavascriptClient).getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
 		verify(mockMarkdownWidget).configure(anyString(), any(WikiPageKey.class), any(Long.class));
-		verify(mockHistoryWidget).configure(any(WikiPageKey.class), anyBoolean(), any(ActionHandler.class));
-		verify(mockView, times(2)).setWikiHistoryWidget(any(IsWidget.class));
+		verify(mockView).setWikiHistoryWidget(any(IsWidget.class));
 		verify(mockView).setWikiSubpagesContainers(any(WikiSubpagesWidget.class));
 		verify(mockSubpages).configure(any(WikiPageKey.class), any(Callback.class), anyBoolean(), any(CallbackP.class));
 		verify(mockView).setWikiSubpagesWidget(mockSubpages);
@@ -153,6 +153,12 @@ public class WikiPageWidgetTest {
 		// once to clear, once after loading shown
 		verify(mockView, times(2)).setLoadingVisible(false);
 		verify(mockView).scrollWikiHeadingIntoView();
+		verify(mockView).setWikiHistoryVisible(false);
+		verify(mockHistoryWidget).clear();
+		
+		verify(mockHistoryWidget, never()).configure(any(WikiPageKey.class), anyBoolean(), any(ActionHandler.class));
+		presenter.showWikiHistory();
+		verify(mockHistoryWidget).configure(any(WikiPageKey.class), anyBoolean(), any(ActionHandler.class));
 	}
 	
 	@Test
@@ -214,7 +220,7 @@ public class WikiPageWidgetTest {
 		boolean showSubpages = true;
 		boolean canEdit = true;
 		presenter.setModifiedCreatedByHistoryVisible(false);
-		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null, showSubpages);
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null, showSubpages);
 		verify(mockView).setModifiedCreatedByHistoryPanelVisible(false);
 	}
 	
@@ -233,13 +239,13 @@ public class WikiPageWidgetTest {
 		boolean canEdit = true;
 		boolean showSubpages = true;
 		presenter.setWikiReloadHandler(mockCallbackP);
-		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), "123", 1L);
+		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, 1L);
 		WikiPage wikiPage = new WikiPage();
 		wikiPage.setId(wikiPageKey.getWikiPageId());
 		presenter.setWikiPageKey(wikiPageKey);
 		AsyncMockStubber.callSuccessWith(wikiPage).when(mockSynapseJavascriptClient).getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
 		
-		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null, showSubpages);
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null, showSubpages);
 		
 		verify(mockSubpages).configure(any(WikiPageKey.class), any(Callback.class), anyBoolean(), callbackPCaptor.capture());
 		// invoke subpage clicked
@@ -257,7 +263,7 @@ public class WikiPageWidgetTest {
 	public void testReloadWikiPageFailure() {
 		boolean showSubpages = true;
 		boolean canEdit = false;
-		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null, showSubpages);
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null, showSubpages);
 		
 		// fail to reload wiki page
 		AsyncMockStubber.callFailureWith(new BadRequestException()).when(mockSynapseJavascriptClient).getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
@@ -275,7 +281,7 @@ public class WikiPageWidgetTest {
 		WikiPage cachedWikiPage = new WikiPage();
 		cachedWikiPage.setTitle("testTitle");
 		cachedWikiPage.setMarkdown(md);
-		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null);
+		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null);
 		cachedWikiPage.setId(wikiPageKey.getWikiPageId());
 		cachedWikiPage.setEtag(etag);
 		
@@ -300,7 +306,7 @@ public class WikiPageWidgetTest {
 		WikiPage cachedWikiPage = new WikiPage();
 		cachedWikiPage.setTitle("testTitle");
 		cachedWikiPage.setMarkdown(md);
-		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null);
+		WikiPageKey wikiPageKey = new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null);
 		cachedWikiPage.setId(wikiPageKey.getWikiPageId());
 		cachedWikiPage.setEtag(oldEtag);
 		
@@ -310,6 +316,7 @@ public class WikiPageWidgetTest {
 		
 		V2WikiPage currentV2WikiPage = new V2WikiPage();
 		currentV2WikiPage.setEtag(newEtag);
+		currentV2WikiPage.setId(wikiPageKey.getWikiPageId());
 		AsyncMockStubber.callSuccessWith(currentV2WikiPage).when(mockSynapseJavascriptClient).getV2WikiPage(eq(wikiPageKey), any(AsyncCallback.class));
 		
 		presenter.configure(wikiPageKey, false, null, false);


### PR DESCRIPTION
also clean up the wiki history widget.  it used to initialize (before show wiki history button was selected).  it also hid old widgets, so that they were hidden but still in the dom!