### PR TITLE
SWC-3883

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.web.client.widget.entity.EntityMetadata;
 import org.sagebionetworks.web.client.widget.entity.ModifiedCreatedByWidget;
 import org.sagebionetworks.web.client.widget.entity.WikiPageWidget;
 import org.sagebionetworks.web.client.widget.entity.file.DockerTitleBar;
+import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
 import org.sagebionetworks.web.client.widget.provenance.ProvenanceWidget;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
@@ -67,12 +68,12 @@ public class DockerRepoWidget {
 		return view.asWidget();
 	}
 
-	public void configure(EntityBundle bundle, final EntityUpdatedHandler handler) {
+	public void configure(EntityBundle bundle, final EntityUpdatedHandler handler, ActionMenuWidget actionMenu) {
 		this.entity = (DockerRepository)bundle.getEntity();
 		this.handler = handler;
 		this.canEdit = bundle.getPermissions().getCanCertifiedUserEdit();
 		metadata.setEntityUpdatedHandler(handler);
-		metadata.setEntityBundle(bundle, null);
+		metadata.configure(bundle, null, actionMenu);
 		dockerTitleBar.configure(entity);
 		modifiedCreatedBy.configure(entity.getCreatedOn(), entity.getCreatedBy(), entity.getModifiedOn(), entity.getModifiedBy());
 		configureWikiPage(bundle);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataView.java
@@ -5,14 +5,22 @@ import com.google.gwt.user.client.ui.IsWidget;
 public interface EntityMetadataView extends IsWidget {
 
 	public void setDetailedMetadataVisible(boolean visible);
-
+		
+	void setAnnotationsVisible(boolean visible);
+	
 	public interface Presenter {
 		
 		void fireEntityUpdatedEvent();
 		
 	}
 	
+	void setFileHistoryVisible(boolean visible);
+
+	void setFileHistoryWidget(IsWidget fileHistoryWidget);
+
 	public void setDoiWidget(IsWidget doiWidget);
+
+	public void setAnnotationsRendererWidget(IsWidget annotationsWidget);
 
 	void clear();
 
@@ -26,4 +34,5 @@ public interface EntityMetadataView extends IsWidget {
 
 	void setUploadDestinationText(String text);
 	void setRestrictionWidgetV2Visible(boolean visible);
+	void setAnnotationsTitleText(String text);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.web.client.widget.entity;
 
+import org.gwtbootstrap3.client.ui.Collapse;
 import org.gwtbootstrap3.client.ui.html.Span;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.IconsImageBundle;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 
@@ -12,6 +15,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
@@ -33,11 +37,21 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 	@UiField
 	Span doiPanel;
 	@UiField
+	Collapse annotationsContent;
+	@UiField
+	SimplePanel annotationsContainer;
+	@UiField
 	Span restrictionPanelV2;
+	@UiField
+	Collapse fileHistoryContent;
+	@UiField
+	SimplePanel fileHistoryContainer;
 	@UiField
 	Span uploadDestinationPanel;
 	@UiField
 	Span uploadDestinationField;
+	@UiField
+	Text annotationsTitleText;
 		
 	@UiField(provided = true)
 	final IconsImageBundle icons;
@@ -46,6 +60,7 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 	public EntityMetadataViewImpl(IconsImageBundle icons, final SynapseJSNIUtils jsniUtils) {
 		this.icons = icons;
 		initWidget(uiBinder.createAndBindUi(this));
+		fileHistoryContainer.getElement().setAttribute("highlight-box-title", "File History");
 		idField.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
@@ -59,6 +74,11 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 		doiPanel.clear();
 		doiPanel.add(doiWidget);
 	}
+
+	@Override
+	public void setAnnotationsRendererWidget(IsWidget annotationsWidget) {
+		annotationsContainer.setWidget(annotationsWidget);		
+	}
 	
 	@Override
 	public void setUploadDestinationPanelVisible(boolean isVisible) {
@@ -69,10 +89,35 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 	public void setUploadDestinationText(String text) {
 		uploadDestinationField.setText(text);
 	}
+
+	@Override
+	public void setAnnotationsVisible(boolean visible) {
+		if (visible) {
+			annotationsContent.show();
+		} else {
+			annotationsContent.hide();
+		}
+	}
+	
+	@Override
+	public void setFileHistoryWidget(IsWidget fileHistoryWidget) {
+		fileHistoryContainer.setWidget(fileHistoryWidget);
+	}
+	
+	@Override
+	public void setFileHistoryVisible(boolean visible) {
+		if (visible) {
+			fileHistoryContent.show();
+		} else {
+			fileHistoryContent.hide();
+		}
+	}
 	
 	@Override
 	public void clear() {
+		fileHistoryContent.hide();
 		dataUseContainer.setVisible(false);
+		annotationsContent.hide();
 		uploadDestinationField.setText("");
 		uploadDestinationPanel.setVisible(false);
 	}
@@ -100,5 +145,9 @@ public class EntityMetadataViewImpl extends Composite implements EntityMetadataV
 	@Override
 	public void setRestrictionWidgetV2Visible(boolean visible) {
 		restrictionPanelV2.setVisible(visible);
+	}
+	@Override
+	public void setAnnotationsTitleText(String text) {
+		annotationsTitleText.setText(text);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
@@ -126,6 +126,8 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 
 		entityActionMenu.addControllerWidget(entityActionController.asWidget());
 		view.setEntityActionMenu(entityActionMenu.asWidget());
+		
+		projectMetadata.setAnnotationsTitleText("Project Annotations");
 	}
 
 	public CallbackP<String> getEntitySelectedCallback(final EntityArea newArea) {
@@ -218,14 +220,14 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 		int mask = ENTITY | ANNOTATIONS | PERMISSIONS | ENTITY_PATH | HAS_CHILDREN | FILE_HANDLES | ROOT_WIKI_ID | DOI | FILE_NAME | BENEFACTOR_ACL | TABLE_DATA | ACL | BENEFACTOR_ACL;
 		projectBundle = null;
 		projectBundleLoadError = null;
-		view.setProjectInformationVisible(false);
+		projectMetadata.setVisible(false);
 		AsyncCallback<EntityBundle> callback = new AsyncCallback<EntityBundle>() {
 			@Override
 			public void onSuccess(EntityBundle bundle) {
 				view.setLoadingVisible(false);
 				// by default, all tab entity bundles point to the project entity bundle
 				projectBundle = filesEntityBundle = tablesEntityBundle = dockerEntityBundle = bundle;
-				projectMetadata.setEntityBundle(projectBundle, null);
+				projectMetadata.configure(projectBundle, null, projectActionMenu);
 				initAreaToken();
 				showSelectedTabs();
 				configureEntity(entity.getId(), filesVersionNumber);
@@ -251,7 +253,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 				updateEntityBundle(bundle, version);
 				boolean isCurrentVersion = version == null;
 				entityActionController.configure(entityActionMenu, bundle, isCurrentVersion, null, area, entityUpdateHandler);
-				view.setProjectInformationVisible(bundle.getEntity() instanceof Project);
+				projectMetadata.setVisible(bundle.getEntity() instanceof Project);
 				reconfigureCurrentArea();
 				view.setLoadingVisible(false);
 			}
@@ -423,7 +425,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 
 	public void initAreaToken() {
 		if (entity instanceof Project) {
-			view.setProjectInformationVisible(true);
+			projectMetadata.setVisible(true);
 		}
 
 		//set area, if undefined
@@ -497,7 +499,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 	public void configureFilesTab() {
 		if (filesTab.asTab().isContentStale()) {
 			filesTab.setProject(projectHeader.getId(), projectBundle, projectBundleLoadError);
-			filesTab.configure(filesEntityBundle, entityUpdateHandler, filesVersionNumber);
+			filesTab.configure(filesEntityBundle, entityUpdateHandler, filesVersionNumber, entityActionMenu);
 			filesTab.asTab().setContentStale(false);
 		}
 		boolean isCurrentVersion = filesVersionNumber == null;
@@ -537,7 +539,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 			if (isWikiTabShown) {
 				//initially push the configured place into the browser history
 				tabs.showTab(wikiTab.asTab(), PUSH_TAB_URL_TO_BROWSER_HISTORY);
-				view.setProjectInformationVisible(true);
+				projectMetadata.setVisible(true);
 			}
 
 			CallbackP<String> wikiReloadHandler = new CallbackP<String>(){
@@ -584,7 +586,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget  {
 	public void configureDockerTab() {
 		if (dockerTab.asTab().isContentStale()) {
 			dockerTab.setProject(projectHeader.getId(), projectBundle, projectBundleLoadError);
-			dockerTab.configure(dockerEntityBundle, entityUpdateHandler, dockerAreaToken);
+			dockerTab.configure(dockerEntityBundle, entityUpdateHandler, dockerAreaToken, entityActionMenu);
 			dockerTab.asTab().setContentStale(false);
 		}
 		entityActionController.configure(entityActionMenu, dockerEntityBundle, true, null, area, entityUpdateHandler);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopView.java
@@ -10,6 +10,5 @@ public interface EntityPageTopView extends IsWidget, SynapseView {
 	void setTabs(Widget w);
 	void setProjectActionMenu(Widget w);
 	void setEntityActionMenu(Widget w);
-	void setProjectInformationVisible(boolean isVisible);
 	void setLoadingVisible(boolean visible);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.java
@@ -17,9 +17,6 @@ public class EntityPageTopViewImpl extends Composite implements EntityPageTopVie
 	}
 	
 	@UiField
-	Div projectMetaContainer;
-	
-	@UiField
 	Div tabsUI;
 	@UiField
 	Span loadingUI;
@@ -27,8 +24,6 @@ public class EntityPageTopViewImpl extends Composite implements EntityPageTopVie
 	//project level info
 	@UiField
 	SimplePanel projectMetadataContainer;
-	@UiField
-	SimplePanel projectDescriptionContainer;
 	@UiField
 	Span projectActionMenuContainer;
 	@UiField
@@ -79,11 +74,6 @@ public class EntityPageTopViewImpl extends Composite implements EntityPageTopVie
 	public void setTabs(Widget w) {
 		tabsUI.clear();
 		tabsUI.add(w);
-	}
-	
-	@Override
-	public void setProjectInformationVisible(boolean isVisible) {
-		projectMetaContainer.setVisible(isVisible);
 	}
 	
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidget.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.sagebionetworks.repo.model.EntityBundle;
 import org.sagebionetworks.web.client.events.EntityUpdatedHandler;
+import org.sagebionetworks.web.client.utils.Callback;
+import org.sagebionetworks.web.client.widget.entity.controller.PreflightController;
 import org.sagebionetworks.web.client.widget.entity.dialog.Annotation;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -13,11 +15,14 @@ import com.google.inject.Inject;
 /**
  * Render entity annotations
  */
-public class AnnotationsRendererWidget implements IsWidget {
+public class AnnotationsRendererWidget implements AnnotationsRendererWidgetView.Presenter, IsWidget {
+	private EntityBundle bundle;
 	private AnnotationsRendererWidgetView view;
 	private AnnotationTransformer annotationTransformer;
+	private EditAnnotationsDialog editorDialog;
 	EntityUpdatedHandler entityUpdatedHandler;
 	List<Annotation> annotationsList;
+	private PreflightController preflightController;
 	
 	/**
 	 * 
@@ -27,20 +32,29 @@ public class AnnotationsRendererWidget implements IsWidget {
 	 */
 	@Inject
 	public AnnotationsRendererWidget(AnnotationsRendererWidgetView propertyView, 
-			AnnotationTransformer annotationTransformer) {
+			AnnotationTransformer annotationTransformer, 
+			EditAnnotationsDialog editorDialog, 
+			PreflightController preflightController) {
 		super();
 		this.view = propertyView;
 		this.annotationTransformer = annotationTransformer;
+		this.editorDialog = editorDialog;
+		this.preflightController = preflightController;
+		this.view.setPresenter(this);
+		this.view.addEditorToPage(editorDialog.asWidget());
 	}
 
-	public void configure(EntityBundle bundle) {
+	public void configure(EntityBundle bundle, boolean canEdit, boolean isCurrentVersion) {
+		this.bundle = bundle;
 		annotationsList = annotationTransformer.annotationsToList(bundle.getAnnotations());
 		if (!annotationsList.isEmpty())
 			view.configure(annotationsList);
 		else {
 			view.showNoAnnotations();
 		}
+		view.setEditUIVisible(isCurrentVersion && canEdit);
 	}
+
 
 	public boolean isEmpty() {
 		return annotationsList.isEmpty();
@@ -53,5 +67,15 @@ public class AnnotationsRendererWidget implements IsWidget {
 
 	public void setEntityUpdatedHandler(EntityUpdatedHandler handler) {
 		this.entityUpdatedHandler = handler;
+	}
+
+	@Override
+	public void onEdit() {
+		preflightController.checkUploadToEntity(bundle, new Callback() {
+			@Override
+			public void invoke() {
+				editorDialog.configure(bundle, entityUpdatedHandler);
+			}
+		});
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetView.java
@@ -2,11 +2,21 @@ package org.sagebionetworks.web.client.widget.entity.annotation;
 
 import java.util.List;
 
+import org.sagebionetworks.repo.model.EntityBundle;
 import org.sagebionetworks.web.client.widget.entity.dialog.Annotation;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 
 public interface AnnotationsRendererWidgetView extends IsWidget{
+	
+	public interface Presenter {
+		 void onEdit();
+	}
+
 	void configure(List<Annotation> annotations);
+	void setPresenter(Presenter presenter);
+	void setEditUIVisible(boolean isVisible);
 	void showNoAnnotations();
+	void addEditorToPage(Widget editorWidget);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetViewImpl.java
@@ -3,12 +3,16 @@ package org.sagebionetworks.web.client.widget.entity.annotation;
 import java.util.List;
 
 import org.gwtbootstrap3.client.ui.Alert;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.html.Span;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.sagebionetworks.web.client.view.bootstrap.table.TBody;
 import org.sagebionetworks.web.client.view.bootstrap.table.TableData;
 import org.sagebionetworks.web.client.view.bootstrap.table.TableRow;
 import org.sagebionetworks.web.client.widget.entity.dialog.Annotation;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -22,20 +26,37 @@ import com.google.inject.Inject;
  */
 public class AnnotationsRendererWidgetViewImpl implements AnnotationsRendererWidgetView {
 	@UiField
+	Button editAnnotationsButton;
+	@UiField
 	TBody tableBody;
 	@UiField
 	Alert noAnnotationsFoundAlert;
+	@UiField
+	Span clickEditText;
 	
 	@UiField
 	FlowPanel modalContainer;
 	
 	public interface Binder extends UiBinder<Widget, AnnotationsRendererWidgetViewImpl> {	}
+	
+	private Presenter presenter;
 	private AnnotationTransformer transformer;
 	private Widget widget;
 	@Inject
 	public AnnotationsRendererWidgetViewImpl(final Binder uiBinder, AnnotationTransformer transformer){
 		widget = uiBinder.createAndBindUi(this);
 		this.transformer = transformer;
+		editAnnotationsButton.addClickHandler(new ClickHandler() {
+			@Override
+			public void onClick(ClickEvent event) {
+				presenter.onEdit();
+			}
+		});
+	}
+	
+	@Override
+	public void setPresenter(Presenter presenter) {
+		this.presenter = presenter;
 	}
 	
 	@Override
@@ -68,8 +89,19 @@ public class AnnotationsRendererWidgetViewImpl implements AnnotationsRendererWid
 	}
 	
 	@Override
+	public void setEditUIVisible(boolean isVisible) {
+		editAnnotationsButton.setVisible(isVisible);
+		clickEditText.setVisible(isVisible);
+	}
+	
+	@Override
 	public void showNoAnnotations() {
 		tableBody.setVisible(false);
 		noAnnotationsFoundAlert.setVisible(true);
+	}
+	
+	@Override
+	public void addEditorToPage(Widget editorWidget) {
+		modalContainer.add(editorWidget);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -54,12 +54,9 @@ import org.sagebionetworks.web.client.widget.asynch.IsACTMemberAsyncHandler;
 import org.sagebionetworks.web.client.widget.docker.modal.AddExternalRepoModal;
 import org.sagebionetworks.web.client.widget.entity.EditFileMetadataModalWidget;
 import org.sagebionetworks.web.client.widget.entity.EditProjectMetadataModalWidget;
-import org.sagebionetworks.web.client.widget.entity.FileHistoryWidget;
 import org.sagebionetworks.web.client.widget.entity.RenameEntityModalWidget;
 import org.sagebionetworks.web.client.widget.entity.WikiMarkdownEditor;
 import org.sagebionetworks.web.client.widget.entity.act.ApproveUserAccessModal;
-import org.sagebionetworks.web.client.widget.entity.annotation.AnnotationsRendererWidget;
-import org.sagebionetworks.web.client.widget.entity.annotation.EditAnnotationsDialog;
 import org.sagebionetworks.web.client.widget.entity.browse.EntityFilter;
 import org.sagebionetworks.web.client.widget.entity.browse.EntityFinder;
 import org.sagebionetworks.web.client.widget.entity.download.AddFolderDialogWidget;
@@ -122,8 +119,6 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 	EvaluationSubmitter submitter;
 	EditFileMetadataModalWidget editFileMetadataModalWidget;
 	EditProjectMetadataModalWidget editProjectMetadataModalWidget;
-	AnnotationsRendererWidget annotationsRendererWidget;
-	EditAnnotationsDialog editAnnotationsDialog;
 	
 	EntityBundle entityBundle;
 	String wikiPageId, parentWikiPageId;
@@ -347,8 +342,6 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 
 		// hide all commands by default
 		actionMenu.hideAllActions();
-		view.hideAnnotations();
-		view.hideFileHistory();
 		
 		// Setup the actions
 		configureDeleteAction();
@@ -659,14 +652,12 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 			actionMenu.setActionVisible(Action.SHOW_ANNOTATIONS, false);
 		} else {
 			actionMenu.setActionVisible(Action.SHOW_ANNOTATIONS, true);
-			actionMenu.setActionListener(Action.SHOW_ANNOTATIONS, this);
 		}
 	}
 	
 	private void configureFileHistory(){
 		if(entityBundle.getEntity() instanceof FileEntity){
 			actionMenu.setActionVisible(Action.SHOW_FILE_HISTORY, true);
-			actionMenu.setActionListener(Action.SHOW_FILE_HISTORY, this);
 		}else{
 			actionMenu.setActionVisible(Action.SHOW_FILE_HISTORY, false);
 		}
@@ -896,12 +887,6 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 		case MANAGE_ACCESS_REQUIREMENTS:
 			onManageAccessRequirements();
 			break;
-		case SHOW_ANNOTATIONS :
-			onShowAnnotations();
-			break;
-		case SHOW_FILE_HISTORY : 
-			onShowFileHistory();
-			break;
 		case UPLOAD_FILE :
 			onUploadNewFileEntity();
 			break;
@@ -1044,47 +1029,6 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 				postChangeStorageLocation();
 			}
 		});
-	}
-	
-	private AnnotationsRendererWidget getAnnotationsRendererWidget() {
-		if (annotationsRendererWidget == null) {
-			annotationsRendererWidget = ginInjector.getAnnotationsRendererWidget();
-			view.setAnnotationsRendererWidget(annotationsRendererWidget);
-		}
-		return annotationsRendererWidget;
-	}
-	
-	private EditAnnotationsDialog getEditAnnotationsDialog() {
-		if (editAnnotationsDialog == null) {
-			editAnnotationsDialog = ginInjector.getEditAnnotationsDialog();
-		}
-		return editAnnotationsDialog;
-	}
-	
-	private void onShowAnnotations() {
-		// configure and show annotations
-		if (entityBundle.getPermissions().getCanCertifiedUserEdit()) {
-			// show editor, if user passes preflight test
-			preflightController.checkUpdateEntity(entityBundle, new Callback() {
-				@Override
-				public void invoke() {
-					getEditAnnotationsDialog().configure(entityBundle, entityUpdateHandler);
-				}
-			});
-		} else {
-			// show renderer
-			getAnnotationsRendererWidget().configure(entityBundle);
-			view.showAnnotations();
-		}
-	}
-	
-	private void onShowFileHistory() {
-		FileHistoryWidget fileHistoryWidget = ginInjector.getFileHistoryWidget();
-		view.setFileHistoryWidget(fileHistoryWidget);
-		// configure and show file history
-		fileHistoryWidget.setEntityBundle(entityBundle, getVersion(), isCurrentVersion);
-		fileHistoryWidget.setEntityUpdatedHandler(entityUpdateHandler);
-		view.showFileHistory();
 	}
 	
 	private void postChangeStorageLocation() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerView.java
@@ -46,12 +46,6 @@ public interface EntityActionControllerView extends ShowsErrors, IsWidget {
 
 	void addWidget(IsWidget asWidget);
 	void showDeleteWikiModal(String wikiPageId, Map<String, V2WikiHeader> id2HeaderMap, Map<String, List<V2WikiHeader>> id2ChildrenMap);
-	void setAnnotationsRendererWidget(IsWidget w);
-	void showAnnotations();
-	void hideAnnotations();
-	void setFileHistoryWidget(IsWidget w);
-	void showFileHistory();
-	void hideFileHistory();
 	void setPresenter(Presenter p);
 	
 	public interface Presenter {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.java
@@ -45,14 +45,6 @@ public class EntityActionControllerViewImpl implements
 	Div wikiHeaderTreeContainer;
 	@UiField
 	Button deleteWikiButton;
-	@UiField
-	Div fileHistoryContainer;
-	@UiField
-	Modal fileHistoryDialog;
-	@UiField
-	Div annotationsRendererContainer;
-	@UiField
-	Modal annotationsDialog;
 	Widget widget;
 	Presenter presenter;
 	@Inject
@@ -130,32 +122,5 @@ public class EntityActionControllerViewImpl implements
 				addToDeleteListRecursive(child.getId(), id2HeaderMap, id2ChildrenMap, ul);
 			}
 		}
-	}
-	
-	@Override
-	public void setAnnotationsRendererWidget(IsWidget w) {
-		annotationsRendererContainer.clear();
-		annotationsRendererContainer.add(w);
-	}
-	@Override
-	public void setFileHistoryWidget(IsWidget w) {
-		fileHistoryContainer.clear();
-		fileHistoryContainer.add(w);
-	}
-	@Override
-	public void showAnnotations() {
-		annotationsDialog.show();
-	}
-	@Override
-	public void hideAnnotations() {
-		annotationsDialog.hide();
-	}
-	@Override
-	public void showFileHistory() {
-		fileHistoryDialog.show();
-	}
-	@Override
-	public void hideFileHistory() {
-		fileHistoryDialog.hide();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/DockerTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/DockerTab.java
@@ -18,13 +18,16 @@ import org.sagebionetworks.web.client.widget.breadcrumb.LinkData;
 import org.sagebionetworks.web.client.widget.docker.DockerRepoListWidget;
 import org.sagebionetworks.web.client.widget.docker.DockerRepoWidget;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
+import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
 import org.sagebionetworks.web.shared.WebConstants;
 
 import com.google.gwt.place.shared.Place;
 import com.google.inject.Inject;
 
 public class DockerTab implements DockerTabView.Presenter{
-	private static final String DOCKER_TAB_TITLE = "Docker";
+	public static final String DOCKER = "Docker";
+
+	private static final String DOCKER_TAB_TITLE = DOCKER;
 
 	Tab tab;
 	DockerTabView view;
@@ -32,6 +35,7 @@ public class DockerTab implements DockerTabView.Presenter{
 	Breadcrumb breadcrumb;
 	PortalGinInjector ginInjector;
 	StuAlert synAlert;
+	ActionMenuWidget actionMenu;
 
 	EntityBundle projectBundle;
 	Throwable projectBundleLoadError;
@@ -84,8 +88,9 @@ public class DockerTab implements DockerTabView.Presenter{
 		tab.addTabClickedCallback(onClickCallback);
 	}
 
-	public void configure(EntityBundle entityBundle, EntityUpdatedHandler handler, String areaToken) {
+	public void configure(EntityBundle entityBundle, EntityUpdatedHandler handler, String areaToken, ActionMenuWidget actionMenu) {
 		lazyInject();
+		this.actionMenu = actionMenu;
 		this.areaToken = areaToken;
 		this.handler = handler;
 		synAlert.clear();
@@ -131,12 +136,11 @@ public class DockerTab implements DockerTabView.Presenter{
 				tab.setEntityNameAndPlace(bundle.getEntity().getName(), new Synapse(bundle.getEntity().getId(), null, null, null));
 				List<LinkData> links = new ArrayList<LinkData>();
 				Place projectPlace = new Synapse(projectEntityId, null, EntityArea.DOCKER, null);
-				String projectName = bundle.getPath().getPath().get(1).getName();
-				links.add(new LinkData(projectName, EntityTypeUtils.getIconTypeForEntityClassName(Project.class.getName()), projectPlace));
+				links.add(new LinkData(DOCKER, EntityTypeUtils.getIconTypeForEntityClassName(DockerRepository.class.getName()), projectPlace));
 				breadcrumb.configure(links, ((DockerRepository)entity).getRepositoryName());
 				DockerRepoWidget repoWidget = ginInjector.createNewDockerRepoWidget();
 				view.setDockerRepoWidget(repoWidget.asWidget());
-				repoWidget.configure(bundle, handler);
+				repoWidget.configure(bundle, handler, actionMenu);
 			} else if (isProject) {
 				areaToken = null;
 				showProjectLevelUI();

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
@@ -32,6 +32,7 @@ import org.sagebionetworks.web.client.widget.entity.browse.FilesBrowser;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
 import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBar;
 import org.sagebionetworks.web.client.widget.entity.file.FileTitleBar;
+import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
 import org.sagebionetworks.web.client.widget.provenance.ProvenanceWidget;
 import org.sagebionetworks.web.client.widget.refresh.RefreshAlert;
 import org.sagebionetworks.web.shared.WebConstants;
@@ -57,7 +58,7 @@ public class FilesTab {
 	SynapseClientAsync synapseClient;
 	GlobalApplicationState globalApplicationState;
 	DiscussionThreadListWidget discussionThreadListWidget;
-	
+	ActionMenuWidget actionMenu;
 	ModifiedCreatedByWidget modifiedCreatedBy;
 	
 	public static int WIDGET_HEIGHT_PX = 270;
@@ -161,9 +162,10 @@ public class FilesTab {
 		this.projectBundleLoadError = projectBundleLoadError;
 	}
 	
-	public void configure(EntityBundle targetEntityBundle, EntityUpdatedHandler handler, Long versionNumber) {
+	public void configure(EntityBundle targetEntityBundle, EntityUpdatedHandler handler, Long versionNumber, ActionMenuWidget actionMenu) {
 		lazyInject();
 		this.handler = handler;
+		this.actionMenu = actionMenu;
 		fileTitleBar.setEntityUpdatedHandler(handler);
 		metadata.setEntityUpdatedHandler(handler);
 		
@@ -248,7 +250,7 @@ public class FilesTab {
 		boolean isMetadataVisible = isFile || isFolder;
 		view.setMetadataVisible(isMetadataVisible);
 		if (isMetadataVisible) {
-			metadata.setEntityBundle(bundle, versionNumber);
+			metadata.configure(bundle, versionNumber, actionMenu);
 		}
 		EntityArea area = isProject ? EntityArea.FILES : null;
 		tab.setEntityNameAndPlace(bundle.getEntity().getName(), new Synapse(currentEntityId, versionNumber, area, null));

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
@@ -56,7 +56,6 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 	Map<String,String> configMap;
 	ActionMenuWidget entityActionMenu;
 	CallbackP<String> entitySelectedCallback;
-	
 	public static final String TABLES_HELP = "Build structured queryable data that can be described by a schema using the Tables.";
 	public static final String TABLES_HELP_URL = WebConstants.DOCS_URL + "tables.html";
 	
@@ -190,7 +189,7 @@ public class TablesTab implements TablesTabView.Presenter, QueryChangeHandler{
 		
 		if (isTable) {
 			breadcrumb.configure(bundle.getPath(), EntityArea.TABLES);
-			metadata.setEntityBundle(bundle, null);
+			metadata.configure(bundle, null, entityActionMenu);
 			tableTitleBar.configure(bundle);
 			modifiedCreatedBy.configure(entity.getCreatedOn(), entity.getCreatedBy(), entity.getModifiedOn(), entity.getModifiedBy());
 			v2TableWidget = ginInjector.createNewTableEntityWidget();

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.ui.xml
@@ -28,5 +28,19 @@
 							href="http://docs.synapse.org/articles/access_controls.html#conditions_of_use" addStyleNames="margin-left-5"/>
 		    </bh:Div>
 	    </g:HTMLPanel>
+    	<b:Collapse ui:field="annotationsContent" toggle="false" b:id="annotationContentCollapse">
+	    	<g:FlowPanel addStyleNames="light-border padding-10 margin-bottom-15 margin-top-30">
+	    		<bh:Div addStyleNames="highlight-title">
+	    			<bh:Text ui:field="annotationsTitleText">Annotations</bh:Text>
+	    			<w:HelpWidget helpMarkdown="Projects, folder and files can be annotated with key-value terms describing the content.&#10;These terms enables data queries through the web or the Synapse analytical clients" 
+						href="http://docs.synapse.org/articles/annotation_and_query.html" addStyleNames="margin-left-5"/>
+	    		</bh:Div>
+	    		<g:SimplePanel ui:field="annotationsContainer" />
+	    	</g:FlowPanel>
+	    	 
+	    </b:Collapse>
+	    <b:Collapse ui:field="fileHistoryContent" toggle="false" b:id="fileHistoryContentCollapse">
+	    	<g:SimplePanel ui:field="fileHistoryContainer" addStyleNames="highlight-box margin-bottom-15"></g:SimplePanel> 
+	    </b:Collapse>
 	</g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
@@ -8,21 +8,16 @@
 		<!--Project level information -->
 		<bh:Div addStyleNames="min-height-48">
 			<b:Row addStyleNames="padding-top-15 projectMetadata" >
-				<b:Column size="XS_12,SM_6">
-					<bh:Div addStyleNames="margin-left-15 margin-right-15" ui:field="projectMetaContainer" visible="false">
+				<b:Column size="XS_12">
+					<bh:Span ui:field="entityActionMenuContainer" addStyleNames="right"/>
+					<bh:Span ui:field="projectActionMenuContainer" addStyleNames="right"/>
+					<bh:Span addStyleNames="margin-left-15 margin-right-15">
 						<g:SimplePanel ui:field="projectMetadataContainer"/>
-						<g:SimplePanel ui:field="projectDescriptionContainer"/>
-					</bh:Div>
-				</b:Column>
-				<b:Column size="XS_12,SM_2">
-					<bh:Span ui:field="loadingUI" addStyleNames="margin-right-5">
-						<g:Image resource='{sageImageBundle.loading31}' />
-						<bh:Span text="Loading..."></bh:Span>
 					</bh:Span>
-				</b:Column>
-				<b:Column size="XS_12,SM_4">
-					<bh:Span ui:field="entityActionMenuContainer"/>
-					<bh:Span ui:field="projectActionMenuContainer"/>
+					<bh:Span ui:field="loadingUI" addStyleNames="center-block center">
+						<g:Image resource='{sageImageBundle.loading31}' />
+						<bh:Text>&nbsp;Loading...</bh:Text>
+					</bh:Span>
 				</b:Column>
 			</b:Row>
 		</bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/annotation/AnnotationsRendererWidgetViewImpl.ui.xml
@@ -19,7 +19,10 @@
 		</t:Table>
 		<b:Alert type="INFO" ui:field="noAnnotationsFoundAlert" >
 			<bh:Strong text="No annotations found."/>
+			<bh:Span ui:field="clickEditText" addStyleNames="margin-left-5"><bh:Text text="Click on the Edit button below to annotate." /></bh:Span>
 		</b:Alert>
+
+		<b:Button ui:field="editAnnotationsButton" icon="GEAR" type="INFO" visible="false">Edit</b:Button>
 		<g:FlowPanel ui:field="modalContainer"/>
 	</g:HTMLPanel>
 

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.ui.xml
@@ -31,30 +31,6 @@
 				<b:Button ui:field="deleteWikiButton" type="DANGER">Delete</b:Button>
 			</b:ModalFooter>
 		</b:Modal>
-		<b:Modal ui:field="annotationsDialog" dataBackdrop="STATIC" dataKeyboard="false" addStyleNames="modal-fullscreen">
-			<b:ModalHeader closable="false">
-				<b:Heading size="H4" text="Annotations" addStyleNames="displayInline" />
-				<w:HelpWidget helpMarkdown="Projects, folder and files can be annotated with key-value terms describing the content.&#10;These terms enables data queries through the web or the Synapse analytical clients" 
-					href="http://docs.synapse.org/articles/annotation_and_query.html" addStyleNames="margin-left-5"/>
-			</b:ModalHeader>
-			<b:ModalBody>
-				<bh:Div ui:field="annotationsRendererContainer" />
-			</b:ModalBody>
-			<b:ModalFooter>
-				<b:Button ui:field="annotationsOkButton" type="PRIMARY"  dataDismiss="MODAL">OK</b:Button>
-			</b:ModalFooter>
-		</b:Modal>
-		<b:Modal ui:field="fileHistoryDialog" dataBackdrop="STATIC" dataKeyboard="false" addStyleNames="modal-fullscreen">
-			<b:ModalHeader closable="false">
-				<b:Heading size="H4" text="File History" addStyleNames="displayInline" />
-			</b:ModalHeader>
-			<b:ModalBody>
-				<bh:Div ui:field="fileHistoryContainer" />
-			</b:ModalBody>
-			<b:ModalFooter>
-				<b:Button ui:field="fileHistoryOkButton" type="PRIMARY"  dataDismiss="MODAL">OK</b:Button>
-			</b:ModalFooter>
-		</b:Modal>
 		<bh:Div ui:field="extraWidgetsContainer" />
 	</bh:Span>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.ui.xml
@@ -23,7 +23,7 @@
 						<a:ActionMenuItem icon="HDD_O" iconFixedWidth="true" action="SHOW_VIEW_SCOPE">Scope</a:ActionMenuItem>
 						<a:ActionMenuItem icon="DATABASE" iconFixedWidth="true" action="CHANGE_STORAGE_LOCATION">Change Storage Location</a:ActionMenuItem>
 						<a:ActionMenuItem icon="UPLOAD" iconFixedWidth="true" action="UPLOAD_NEW_FILE">Upload a New Version of File</a:ActionMenuItem>
-						<a:ActionMenuItem icon="HISTORY" iconFixedWidth="true" action="SHOW_FILE_HISTORY">View File Version History</a:ActionMenuItem>
+						<a:ActionMenuItem icon="HISTORY" iconFixedWidth="true" action="SHOW_FILE_HISTORY">File Version History</a:ActionMenuItem>
 						<a:ActionMenuItem icon="TELEVISION" iconFixedWidth="true" action="PROJECT_DISPLAY">Project Display Settings</a:ActionMenuItem>
 						<a:ActionMenuItem icon="UPLOAD" iconFixedWidth="true" action="UPLOAD_TABLE_DATA">Upload Data to Table</a:ActionMenuItem>
 						<a:ActionMenuItem icon="DOWNLOAD" iconFixedWidth="true" action="DOWNLOAD_TABLE_QUERY_RESULTS">Download Query Results</a:ActionMenuItem>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
@@ -61,6 +61,8 @@ public class DockerRepoWidgetTest {
 	DockerCommitListWidget mockDockerCommitListWidget;
 	@Mock
 	CookieProvider mockCookieProvider;
+	@Mock
+	ActionMenuWidget mockActionWidget;
 
 	DockerRepoWidget dockerRepoWidget;
 	String entityId = "syn123";
@@ -106,13 +108,13 @@ public class DockerRepoWidgetTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testConfigure() {
-		dockerRepoWidget.configure(mockEntityBundle, mockHandler);
+		dockerRepoWidget.configure(mockEntityBundle, mockHandler, mockActionWidget);
 		verify(mockWikiPageWidget).configure(any(WikiPageKey.class), eq(canEdit), any(WikiPageWidget.Callback.class));
 		verify(mockWikiPageWidget).setWikiReloadHandler(any(CallbackP.class));
 		verify(mockProvWidget).configure(any(Map.class));
 		verify(mockView).setDockerPullCommand(DOCKER_PULL_COMMAND + repoName);
 		verify(mockMetadata).setEntityUpdatedHandler(mockHandler);
-		verify(mockMetadata).setEntityBundle(mockEntityBundle, null);
+		verify(mockMetadata).configure(mockEntityBundle, null, mockActionWidget);
 		verify(mockDockerTitleBar).configure(mockEntity);
 		verify(mockModifiedCreatedBy).configure(createdOn, createdBy, modifiedOn, modifiedBy);
 		verify(mockDockerCommitListWidget).configure(entityId, false);
@@ -124,13 +126,13 @@ public class DockerRepoWidgetTest {
 	public void testConfigureCannotEdit() {
 		canEdit = false;
 		when(mockPermissions.getCanCertifiedUserEdit()).thenReturn(canEdit);
-		dockerRepoWidget.configure(mockEntityBundle, mockHandler);
+		dockerRepoWidget.configure(mockEntityBundle, mockHandler, mockActionWidget);
 		verify(mockWikiPageWidget).configure(any(WikiPageKey.class), eq(canEdit), any(WikiPageWidget.Callback.class));
 		verify(mockWikiPageWidget).setWikiReloadHandler(any(CallbackP.class));
 		verify(mockProvWidget).configure(any(Map.class));
 		verify(mockView).setDockerPullCommand(DOCKER_PULL_COMMAND + repoName);
 		verify(mockMetadata).setEntityUpdatedHandler(mockHandler);
-		verify(mockMetadata).setEntityBundle(mockEntityBundle, null);
+		verify(mockMetadata).configure(mockEntityBundle, null, mockActionWidget);
 		verify(mockDockerTitleBar).configure(mockEntity);
 		verify(mockModifiedCreatedBy).configure(createdOn, createdBy, modifiedOn, modifiedBy);
 	}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityPageTopTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityPageTopTest.java
@@ -225,7 +225,7 @@ public class EntityPageTopTest {
 		
 		//Once to show the active tab, and once after configuration so that the place is pushed into the history.
 		verify(mockTabs, times(2)).showTab(mockWikiInnerTab, EntityPageTop.PUSH_TAB_URL_TO_BROWSER_HISTORY);
-		verify(mockEntityMetadata).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata).configure(mockProjectBundle, null, mockProjectActionMenuWidget);
 		verify(mockWikiInnerTab).setContentStale(true);
 		verify(mockWikiInnerTab).setContentStale(false);
 		
@@ -235,22 +235,22 @@ public class EntityPageTopTest {
 		verify(mockProjectActionController).configure(mockProjectActionMenuWidget, mockProjectBundle, true, projectWikiId, projectSettingsEntityArea, mockEntityUpdatedHandler);
 		
 		verify(mockFilesTab, never()).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab, never()).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab, never()).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		verify(mockTablesTab, never()).setProject(projectEntityId, mockProjectBundle, null);
 		verify(mockTablesTab, never()).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		verify(mockChallengeTab, never()).configure(projectEntityId, projectName);
 		verify(mockDiscussionTab, never()).configure(projectEntityId, projectName, areaToken, canModerate, mockActionMenuWidget);
-		verify(mockDockerTab, never()).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken);
+		verify(mockDockerTab, never()).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		
 		clickAllTabs();
 		
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		verify(mockTablesTab).setProject(projectEntityId, mockProjectBundle, null);
 		verify(mockTablesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		verify(mockChallengeTab).configure(projectEntityId, projectName);
 		verify(mockDiscussionTab).configure(projectEntityId, projectName, areaToken, canModerate, mockActionMenuWidget);
-		verify(mockDockerTab).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken);
+		verify(mockDockerTab).configure(mockProjectBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 	}
 	
 	private void clickAllTabs() {
@@ -305,17 +305,17 @@ public class EntityPageTopTest {
 		verify(mockTablesTab).resetView();
 
 		verify(mockTabs).showTab(mockFilesInnerTab, EntityPageTop.PUSH_TAB_URL_TO_BROWSER_HISTORY);
-		verify(mockEntityMetadata).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata).configure(mockProjectBundle, null, mockProjectActionMenuWidget);
 		
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		
 		verify(mockWikiTab, never()).configure(eq(projectEntityId), eq(projectName), eq(projectWikiId), eq(canEdit), any(WikiPageWidget.Callback.class), any(ActionMenuWidget.class));
 		verify(mockTablesTab, never()).setProject(projectEntityId, mockProjectBundle, null);
 		verify(mockTablesTab, never()).configure(any(EntityBundle.class), eq(mockEntityUpdatedHandler), eq(areaToken), any(ActionMenuWidget.class));
 		verify(mockChallengeTab, never()).configure(projectEntityId, projectName);
 		verify(mockDiscussionTab, never()).configure(projectEntityId, projectName, null, canModerate, mockActionMenuWidget);
-		verify(mockDockerTab, never()).configure(mockEntityBundle, mockEntityUpdatedHandler, null);
+		verify(mockDockerTab, never()).configure(mockEntityBundle, mockEntityUpdatedHandler, null, mockActionMenuWidget);
 	}
 	
 	@Test
@@ -329,10 +329,10 @@ public class EntityPageTopTest {
 		pageTop.configure(mockFileEntity, versionNumber, mockProjectHeader, area, areaToken);
 		verify(mockTabs).showTab(mockFilesInnerTab, EntityPageTop.PUSH_TAB_URL_TO_BROWSER_HISTORY);
 		
-		verify(mockEntityMetadata, Mockito.never()).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata, Mockito.never()).configure(mockProjectBundle, null, null);
 		EntityBundle expectedProjectEntityBundle = null;
 		verify(mockFilesTab).setProject(projectEntityId, expectedProjectEntityBundle, projectLoadError);
-		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		
 		clickAllTabs();
 		//project bundle is null, unable to get wiki id or canEdit.
@@ -343,7 +343,7 @@ public class EntityPageTopTest {
 		verify(mockTablesTab).configure(any(EntityBundle.class), eq(mockEntityUpdatedHandler), eq(areaToken), any(ActionMenuWidget.class));
 		verify(mockChallengeTab).configure(projectEntityId, projectName);
 		verify(mockDiscussionTab).configure(projectEntityId, projectName, null, canModerate, mockActionMenuWidget);
-		verify(mockDockerTab).configure(null, mockEntityUpdatedHandler, null);
+		verify(mockDockerTab).configure(null, mockEntityUpdatedHandler, null, mockActionMenuWidget);
 	}
 	
 	@Test
@@ -355,7 +355,7 @@ public class EntityPageTopTest {
 		pageTop.configure(mockTableEntity, versionNumber, mockProjectHeader, area, areaToken);
 		verify(mockTabs).showTab(mockTablesInnerTab, EntityPageTop.PUSH_TAB_URL_TO_BROWSER_HISTORY);
 		
-		verify(mockEntityMetadata).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata).configure(mockProjectBundle, null, mockProjectActionMenuWidget);
 		
 		verify(mockTablesTab).setProject(projectEntityId, mockProjectBundle, null);
 		verify(mockTablesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
@@ -363,10 +363,10 @@ public class EntityPageTopTest {
 		clickAllTabs();
 		verify(mockWikiTab).configure(eq(projectEntityId), eq(projectName), eq(projectWikiId), eq(canEdit), any(WikiPageWidget.Callback.class), eq(mockActionMenuWidget));
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		verify(mockChallengeTab).configure(projectEntityId, projectName);
 		verify(mockDiscussionTab).configure(projectEntityId, projectName, null, canModerate, mockActionMenuWidget);
-		verify(mockDockerTab).configure(mockProjectBundle, mockEntityUpdatedHandler, null);
+		verify(mockDockerTab).configure(mockProjectBundle, mockEntityUpdatedHandler, null, mockActionMenuWidget);
 	}
 
 	@Test
@@ -378,14 +378,14 @@ public class EntityPageTopTest {
 		pageTop.configure(mockDockerEntity, versionNumber, mockProjectHeader, area, areaToken);
 		verify(mockTabs).showTab(mockDockerInnerTab, EntityPageTop.PUSH_TAB_URL_TO_BROWSER_HISTORY);
 		
-		verify(mockEntityMetadata).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata).configure(mockProjectBundle, null, mockProjectActionMenuWidget);
 		
-		verify(mockDockerTab).configure(mockEntityBundle, mockEntityUpdatedHandler, areaToken);
+		verify(mockDockerTab).configure(mockEntityBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		
 		clickAllTabs();
 		verify(mockWikiTab).configure(eq(projectEntityId), eq(projectName), eq(projectWikiId), eq(canEdit), any(WikiPageWidget.Callback.class), eq(mockActionMenuWidget));
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 		verify(mockTablesTab).setProject(projectEntityId, mockProjectBundle, null);
 		verify(mockTablesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, null, mockActionMenuWidget);
 		verify(mockChallengeTab).configure(projectEntityId, projectName);
@@ -400,10 +400,10 @@ public class EntityPageTopTest {
 		Long versionNumber = null;
 		pageTop.configure(mockFileEntity, versionNumber, mockProjectHeader, area, areaToken);
 		
-		verify(mockEntityMetadata).setEntityBundle(mockProjectBundle, null);
+		verify(mockEntityMetadata).configure(mockProjectBundle, null, mockProjectActionMenuWidget);
 		//ignore specified area, target entity is a File so configure and show the Files tab
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockEntityBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 	}
 	
 	@Test
@@ -455,7 +455,7 @@ public class EntityPageTopTest {
 		when(mockWikiInnerTab.isContentStale()).thenReturn(true);
 		//since the project does not have a root wiki id, it should go to the files tab
 		verify(mockFilesTab).setProject(projectEntityId, mockProjectBundle, null);
-		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber);
+		verify(mockFilesTab).configure(mockProjectBundle, mockEntityUpdatedHandler, versionNumber, mockActionMenuWidget);
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/AnnotationsRendererWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/AnnotationsRendererWidgetTest.java
@@ -1,11 +1,6 @@
 package org.sagebionetworks.web.unitclient.widget.entity.annotation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,13 +8,25 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
 import org.sagebionetworks.repo.model.Annotations;
 import org.sagebionetworks.repo.model.EntityBundle;
+import org.sagebionetworks.web.client.events.EntityUpdatedHandler;
+import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.entity.annotation.AnnotationTransformer;
 import org.sagebionetworks.web.client.widget.entity.annotation.AnnotationsRendererWidget;
 import org.sagebionetworks.web.client.widget.entity.annotation.AnnotationsRendererWidgetView;
+import org.sagebionetworks.web.client.widget.entity.annotation.EditAnnotationsDialog;
+import org.sagebionetworks.web.client.widget.entity.controller.PreflightController;
 import org.sagebionetworks.web.client.widget.entity.dialog.ANNOTATION_TYPE;
 import org.sagebionetworks.web.client.widget.entity.dialog.Annotation;
+import org.sagebionetworks.web.test.helper.AsyncMockStubber;
+
+import com.google.gwt.user.client.ui.Widget;
 
 public class AnnotationsRendererWidgetTest {
 	
@@ -27,13 +34,17 @@ public class AnnotationsRendererWidgetTest {
 	
 	AnnotationsRendererWidgetView mockView;
 	AnnotationTransformer mockAnnotationTransformer;
+	EditAnnotationsDialog mockEditAnnotationsDialog;
 	EntityBundle mockBundle;
 	List<Annotation> annotationList;
+	PreflightController mockPreflightController;
 	@Before
 	public void setUp() throws Exception {
+		mockEditAnnotationsDialog = mock(EditAnnotationsDialog.class);
 		mockView = mock(AnnotationsRendererWidgetView.class);
 		mockAnnotationTransformer = mock(AnnotationTransformer.class);
-		widget = new AnnotationsRendererWidget(mockView, mockAnnotationTransformer);
+		mockPreflightController = mock(PreflightController.class);
+		widget = new AnnotationsRendererWidget(mockView, mockAnnotationTransformer, mockEditAnnotationsDialog, mockPreflightController);
 		mockBundle = mock(EntityBundle.class);
 		annotationList = new ArrayList<Annotation>();
 		annotationList.add(new Annotation(ANNOTATION_TYPE.STRING, "key", Collections.EMPTY_LIST));
@@ -43,26 +54,78 @@ public class AnnotationsRendererWidgetTest {
 	@Test
 	public void testConfigureEmptyAnnotations() {
 		//also verify construction
+		verify(mockView).setPresenter(widget);
+		verify(mockView).addEditorToPage(any(Widget.class));
+		
 		annotationList.clear();
-		widget.configure(mockBundle);
+		boolean canEdit = true;
+		boolean isCurrentVersion = true;
+		widget.configure(mockBundle, canEdit, isCurrentVersion);
 		
 		verify(mockView).showNoAnnotations();
+		verify(mockView).setEditUIVisible(true);
 		
 		assertTrue(widget.isEmpty());
 	}
 	
 	@Test
 	public void testConfigureAnnotations() {
-		widget.configure(mockBundle);
+		boolean canEdit = false;
+		boolean isCurrentVersion = true;
+		widget.configure(mockBundle, canEdit, isCurrentVersion);
 		
 		verify(mockView).configure(annotationList);
+		verify(mockView).setEditUIVisible(false);
 		
 		assertFalse(widget.isEmpty());
 	}
-	
+	@Test
+	public void testConfigureAnnotationsNotCurrentVersion() {
+		boolean canEdit = true;
+		boolean isCurrentVersion = false;
+		widget.configure(mockBundle, canEdit, isCurrentVersion);
+		
+		verify(mockView).configure(annotationList);
+		verify(mockView).setEditUIVisible(false);
+		
+		assertFalse(widget.isEmpty());
+	}
+
+
 	@Test
 	public void testAsWidget() {
 		widget.asWidget();
 		verify(mockView).asWidget();
 	}
+
+	@Test
+	public void testOnEdit() {
+		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkUploadToEntity(any(EntityBundle.class), any(Callback.class));
+		EntityUpdatedHandler updateHandler = mock(EntityUpdatedHandler.class);
+		widget.configure(mockBundle, true, true);
+		widget.setEntityUpdatedHandler(updateHandler);
+		
+		//test that on edit, we pass the bundle and update handler to the edit dialog
+		widget.onEdit();
+		
+		ArgumentCaptor<EntityUpdatedHandler> updateCaptor = ArgumentCaptor.forClass(EntityUpdatedHandler.class);
+		ArgumentCaptor<EntityBundle> bundleCaptor = ArgumentCaptor.forClass(EntityBundle.class);
+		
+		verify(mockEditAnnotationsDialog).configure(bundleCaptor.capture(), updateCaptor.capture());
+		
+		assertEquals(updateCaptor.getValue(), updateHandler);
+		assertEquals(bundleCaptor.getValue(), mockBundle);
+	}
+	
+	@Test
+	public void testOnEditFailedPreflight() {
+		AsyncMockStubber.callNoInvovke().when(mockPreflightController).checkUploadToEntity(any(EntityBundle.class), any(Callback.class));
+		widget.configure(mockBundle, true, true);
+		//test that on edit, we pass the bundle and update handler to the edit dialog
+		widget.onEdit();
+		
+		verify(mockEditAnnotationsDialog, never()).configure(any(EntityBundle.class), any(EntityUpdatedHandler.class));
+	}
+	
+
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -34,7 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidget.WizardCallback;
+
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.extras.bootbox.client.callback.PromptCallback;
 import org.junit.Before;
@@ -121,6 +121,7 @@ import org.sagebionetworks.web.client.widget.sharing.AccessControlListModalWidge
 import org.sagebionetworks.web.client.widget.table.modal.fileview.CreateTableViewWizard;
 import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
 import org.sagebionetworks.web.client.widget.table.modal.upload.UploadTableModalWidget;
+import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidget.WizardCallback;
 import org.sagebionetworks.web.client.widget.team.SelectTeamModal;
 import org.sagebionetworks.web.shared.PublicPrincipalIds;
 import org.sagebionetworks.web.shared.WikiPageKey;
@@ -204,12 +205,6 @@ public class EntityActionControllerImplTest {
 	@Mock
 	AccessControlList mockACL;
 	@Mock
-	FileHistoryWidget mockFileHistoryWidget;
-	@Mock
-	EditAnnotationsDialog mockEditAnnotationsDialog;
-	@Mock
-	AnnotationsRendererWidget mockAnnotationsRendererWidget;
-	@Mock
 	SynapseJavascriptClient mockSynapseJavascriptClient;
 	@Mock
 	AddFolderDialogWidget mockAddFolderDialogWidget;
@@ -272,9 +267,6 @@ public class EntityActionControllerImplTest {
 		when(mockPortalGinInjector.getSynapseClientAsync()).thenReturn(mockSynapseClient);
 		when(mockPortalGinInjector.getGlobalApplicationState()).thenReturn(mockGlobalApplicationState);
 		when(mockPortalGinInjector.getEvaluationSubmitter()).thenReturn(mockSubmitter);
-		when(mockPortalGinInjector.getFileHistoryWidget()).thenReturn(mockFileHistoryWidget);
-		when(mockPortalGinInjector.getEditAnnotationsDialog()).thenReturn(mockEditAnnotationsDialog);
-		when(mockPortalGinInjector.getAnnotationsRendererWidget()).thenReturn(mockAnnotationsRendererWidget);
 		when(mockGlobalApplicationState.getPublicPrincipalIds()).thenReturn(mockPublicPrincipalIds);
 		when(mockPortalGinInjector.getSynapseJavascriptClient()).thenReturn(mockSynapseJavascriptClient);
 		when(mockPortalGinInjector.getCreateTableViewWizard()).thenReturn(mockCreateTableViewWizard);
@@ -463,7 +455,6 @@ public class EntityActionControllerImplTest {
 		
 		verify(mockActionMenu).setActionIcon(Action.SHARE, IconType.GLOBE);
 		verify(mockActionMenu).setActionVisible(Action.SHOW_ANNOTATIONS, true);
-		verify(mockActionMenu).setActionListener(eq(Action.SHOW_ANNOTATIONS), any(ActionListener.class));
 		// for a table entity, do not show file history
 		verify(mockActionMenu).setActionVisible(Action.SHOW_FILE_HISTORY, false);
 		
@@ -502,10 +493,8 @@ public class EntityActionControllerImplTest {
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea, mockEntityUpdatedHandler);
 		verify(mockActionMenu).setActionIcon(Action.SHARE, IconType.GLOBE);
 		verify(mockActionMenu).setActionVisible(Action.SHOW_ANNOTATIONS, true);
-		verify(mockActionMenu).setActionListener(eq(Action.SHOW_ANNOTATIONS), any(ActionListener.class));
 		// for a table entity, do not show file history
 		verify(mockActionMenu).setActionVisible(Action.SHOW_FILE_HISTORY, true);
-		verify(mockActionMenu).setActionListener(eq(Action.SHOW_FILE_HISTORY), any(ActionListener.class));
 		
 		//table commands not shown for File
 		verify(mockActionMenu).setActionVisible(Action.UPLOAD_TABLE_DATA, false);
@@ -1635,58 +1624,6 @@ public class EntityActionControllerImplTest {
 		//initially hide, never show
 		verify(mockActionMenu).setActionVisible(Action.CREATE_DOI, false);
 		verify(mockActionMenu, never()).setActionVisible(Action.CREATE_DOI, true);
-	}
-	
-	@Test
-	public void testOnFileHistoryToggled() {
-		boolean isCurrentVersion = true;
-		Long entityVersion = 42L;
-		FileEntity file = new FileEntity();
-		file.setId(entityId);
-		file.setParentId(parentId);
-		file.setVersionNumber(entityVersion);
-		entityBundle.setEntity(file);
-		
-		controller.configure(mockActionMenu, entityBundle, isCurrentVersion, wikiPageId, currentEntityArea, mockEntityUpdatedHandler);
-		controller.onAction(Action.SHOW_FILE_HISTORY);
-		
-		verify(mockView).setFileHistoryWidget(mockFileHistoryWidget);
-		verify(mockFileHistoryWidget).setEntityBundle(entityBundle, entityVersion, isCurrentVersion);
-		verify(mockFileHistoryWidget).setEntityUpdatedHandler(mockEntityUpdatedHandler);
-		verify(mockView).showFileHistory();
-	}
-	
-	@Test
-	public void testOnShowAnnotationsCanEditAndCertified() {
-		entityBundle.getPermissions().setCanCertifiedUserEdit(true);
-		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-		
-		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea, mockEntityUpdatedHandler);
-		controller.onAction(Action.SHOW_ANNOTATIONS);
-		
-		verify(mockEditAnnotationsDialog).configure(entityBundle, mockEntityUpdatedHandler);
-	}
-	
-	@Test
-	public void testOnShowAnnotationsCanEditNotCertified() {
-		entityBundle.getPermissions().setCanCertifiedUserEdit(true);
-		
-		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea, mockEntityUpdatedHandler);
-		controller.onAction(Action.SHOW_ANNOTATIONS);
-		
-		verify(mockEditAnnotationsDialog, never()).configure(entityBundle, mockEntityUpdatedHandler);
-	}
-
-	@Test
-	public void testOnShowAnnotationsCannotEditIsCertified() {
-		entityBundle.getPermissions().setCanCertifiedUserEdit(false);
-		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkUploadToEntity(any(EntityBundle.class), any(Callback.class));
-		
-		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea, mockEntityUpdatedHandler);
-		controller.onAction(Action.SHOW_ANNOTATIONS);
-		
-		verify(mockAnnotationsRendererWidget).configure(entityBundle);
-		verify(mockView).showAnnotations();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DockerTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DockerTabTest.java
@@ -36,6 +36,7 @@ import org.sagebionetworks.web.client.widget.breadcrumb.LinkData;
 import org.sagebionetworks.web.client.widget.docker.DockerRepoListWidget;
 import org.sagebionetworks.web.client.widget.docker.DockerRepoWidget;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
+import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
 import org.sagebionetworks.web.client.widget.entity.tabs.DockerTab;
 import org.sagebionetworks.web.client.widget.entity.tabs.DockerTabView;
 import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
@@ -82,6 +83,8 @@ public class DockerTabTest {
 	ArgumentCaptor<CallbackP> callbackPCaptor;
 	@Mock
 	CallbackP<String> mockEntitySelectedCallback;
+	@Mock
+	ActionMenuWidget mockActionMenuWidget;
 	DockerTab tab;
 
 	String projectEntityId = "syn123";
@@ -166,7 +169,7 @@ public class DockerTabTest {
 		String areaToken = null;
 		tab.setEntitySelectedCallback(mockUpdateEntityCallback);
 		tab.setProject(projectEntityId, mockProjectEntityBundle, null);
-		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, areaToken);
+		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		verify(mockSynAlert, atLeastOnce()).clear();
 		verify(mockTab).setEntityNameAndPlace(eq(projectName), any(Synapse.class));
 		verify(mockView, times(2)).setBreadcrumbVisible(false);
@@ -182,7 +185,7 @@ public class DockerTabTest {
 		mockProjectEntityBundle = null;
 		tab.setEntitySelectedCallback(mockUpdateEntityCallback);
 		tab.setProject(projectEntityId, mockProjectEntityBundle, mockProjectBundleLoadError);
-		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, areaToken);
+		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		verify(mockSynAlert, atLeastOnce()).clear();
 		verify(mockTab).setEntityNameAndPlace(eq(projectEntityId), any(Synapse.class));
 		verify(mockDockerRepoListWidget, never()).configure(projectEntityId);
@@ -195,7 +198,7 @@ public class DockerTabTest {
 		String areaToken = null;
 		tab.setEntitySelectedCallback(mockUpdateEntityCallback);
 		tab.setProject(projectEntityId, mockProjectEntityBundle, mockProjectBundleLoadError);
-		tab.configure(mockDockerRepoEntityBundle, mockEntityUpdatedHandler, areaToken);
+		tab.configure(mockDockerRepoEntityBundle, mockEntityUpdatedHandler, areaToken, mockActionMenuWidget);
 		verify(mockTab).setEntityNameAndPlace(eq(dockerRepoName), any(Synapse.class));
 		verify(mockTab).showTab();
 		verify(mockView).setBreadcrumbVisible(true);
@@ -208,8 +211,8 @@ public class DockerTabTest {
 		assertNotNull(list);
 		assertEquals(1, list.size());
 		assertEquals(list.get(0).getPlace(), new Synapse(projectEntityId, null, EntityArea.DOCKER, null));
-		assertEquals(list.get(0).getText(), projectName);
-		assertEquals(list.get(0).getIconType(), EntityTypeUtils.getIconTypeForEntityClassName(Project.class.getName()));
+		assertEquals(list.get(0).getText(), DockerTab.DOCKER);
+		assertEquals(list.get(0).getIconType(), EntityTypeUtils.getIconTypeForEntityClassName(DockerRepository.class.getName()));
 		verify(mockGinInjector).createNewDockerRepoWidget();
 		verify(mockView).setDockerRepoWidget(any(Widget.class));
 		verify(mockDockerRepoListWidget, never()).configure(projectEntityId);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
@@ -49,6 +49,7 @@ import org.sagebionetworks.web.client.widget.entity.browse.FilesBrowser;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
 import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBar;
 import org.sagebionetworks.web.client.widget.entity.file.FileTitleBar;
+import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
 import org.sagebionetworks.web.client.widget.entity.tabs.FilesTab;
 import org.sagebionetworks.web.client.widget.entity.tabs.FilesTabView;
 import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
@@ -121,6 +122,8 @@ public class FilesTabTest {
 	DiscussionThreadBundle mockBundle;
 	@Captor
 	ArgumentCaptor<CallbackP> callbackPCaptor;
+	@Mock
+	ActionMenuWidget mockActionMenuWidget;
 	
 	FilesTab tab;
 	String projectEntityId = "syn9";
@@ -224,7 +227,7 @@ public class FilesTabTest {
 		when(mockPermissions.getIsCertifiedUser()).thenReturn(isCertifiedUser);
 		
 		tab.setProject(projectEntityId, mockProjectEntityBundle, null);
-		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, version);
+		tab.configure(mockProjectEntityBundle, mockEntityUpdatedHandler, version, mockActionMenuWidget);
 		
 		verify(mockFileTitleBar).setEntityUpdatedHandler(mockEntityUpdatedHandler);
 		verify(mockEntityMetadata).setEntityUpdatedHandler(mockEntityUpdatedHandler);
@@ -260,7 +263,7 @@ public class FilesTabTest {
 	public void testConfigureWithFileNoFileHandles() {
 		Long version = 4L;
 		when(mockEntityBundle.getEntity()).thenReturn(mockFileEntity);
-		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version);
+		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version, mockActionMenuWidget);
 		
 		verify(mockView, times(2)).setPreviewVisible(false);
 		verify(mockView, never()).setPreviewVisible(true);
@@ -278,7 +281,7 @@ public class FilesTabTest {
 		when(mockEntityBundle.getEntity()).thenReturn(mockFileEntity);
 		
 		tab.setProject(projectEntityId, mockProjectEntityBundle, null);
-		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version);
+		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version, mockActionMenuWidget);
 
 		verify(mockFileTitleBar).setEntityUpdatedHandler(mockEntityUpdatedHandler);
 		verify(mockEntityMetadata).setEntityUpdatedHandler(mockEntityUpdatedHandler);
@@ -296,7 +299,7 @@ public class FilesTabTest {
 		verify(mockFileTitleBar).configure(mockEntityBundle);
 		verify(mockPreviewWidget).configure(mockEntityBundle);
 		
-		verify(mockEntityMetadata).setEntityBundle(mockEntityBundle, version);
+		verify(mockEntityMetadata).configure(mockEntityBundle, version, mockActionMenuWidget);
 		
 		verify(mockBreadcrumb).configure(any(EntityPath.class), eq(EntityArea.FILES));
 		
@@ -336,7 +339,7 @@ public class FilesTabTest {
 		when(mockPermissions.getIsCertifiedUser()).thenReturn(isCertifiedUser);
 		
 		tab.setProject(projectEntityId, mockProjectEntityBundle, null);
-		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version);
+		tab.configure(mockEntityBundle, mockEntityUpdatedHandler, version, mockActionMenuWidget);
 		
 		verify(mockFileTitleBar).setEntityUpdatedHandler(mockEntityUpdatedHandler);
 		verify(mockEntityMetadata).setEntityUpdatedHandler(mockEntityUpdatedHandler);
@@ -355,7 +358,7 @@ public class FilesTabTest {
 
 		verify(mockBasicTitleBar).configure(mockEntityBundle);
 		
-		verify(mockEntityMetadata).setEntityBundle(mockEntityBundle, version);
+		verify(mockEntityMetadata).configure(mockEntityBundle, version, mockActionMenuWidget);
 		
 		
 		verify(mockBreadcrumb).configure(any(EntityPath.class), eq(EntityArea.FILES));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -209,7 +209,7 @@ public class TablesTabTest {
 	private void verifyTableConfiguration() {
 		verify(mockBreadcrumb).configure(any(EntityPath.class), eq(EntityArea.TABLES));
 		verify(mockBasicTitleBar).configure(mockTableEntityBundle);
-		verify(mockEntityMetadata).setEntityBundle(mockTableEntityBundle, null);
+		verify(mockEntityMetadata).configure(mockTableEntityBundle, null, mockActionMenuWidget);
 		verify(mockTableEntityWidget).configure(eq(mockTableEntityBundle), eq(true), eq(tab), eq(mockActionMenuWidget));
 		verify(mockView).setTableEntityWidget(any(Widget.class));
 		verify(mockModifiedCreatedBy).configure(any(Date.class), anyString(), any(Date.class), anyString());


### PR DESCRIPTION
revert changes for annotations renderer widget and editor, and pass action menu around so that entity metadata can listen for annotations and file history action events