### PR TITLE
PLFM-3890 - Update web client according to changes in PLFM-3385

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
-		<synapse.version>2017-10-27-2776-43fd00e54c</synapse.version>
+		<synapse.version>2017-11-01-2779-396f899934</synapse.version>
 		<gwtVersion>2.8.1</gwtVersion>
 		<org.springframework.version>4.3.3.RELEASE</org.springframework.version>
 		<guiceVersion>3.0</guiceVersion>

--- a/src/main/java/org/sagebionetworks/web/client/UserAccountService.java
+++ b/src/main/java/org/sagebionetworks/web/client/UserAccountService.java
@@ -26,8 +26,6 @@ public interface UserAccountService extends RemoteService {
 
 	void createUserStep1(NewUser newUser, String portalEndpoint) throws RestServiceException;
 
-	String createUserStep2(String userName, String fName, String lName, String password, String emailValidationToken) throws RestServiceException;
-
 	String createUserStep2(String userName, String fName, String lName, String password, EmailValidationSignedToken emailValidationSignedToken) throws RestServiceException;
 
 	void terminateSession(String sessionToken) throws RestServiceException;

--- a/src/main/java/org/sagebionetworks/web/client/UserAccountServiceAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/UserAccountServiceAsync.java
@@ -23,8 +23,6 @@ public interface UserAccountServiceAsync {
 
 	void createUserStep1(NewUser newUser, String portalEndpoint, AsyncCallback<Void> callback);
 
-	void createUserStep2(String userName, String fName, String lName, String password, String emailValidationToken, AsyncCallback<String> callback);
-
 	void createUserStep2(String userName, String fName, String lName, String password, EmailValidationSignedToken emailValidationSignedToken, AsyncCallback<String> callback);
 	
 	void terminateSession(String sessionToken, AsyncCallback<Void> callback);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.client.AsynchJobType;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
 import org.sagebionetworks.client.exceptions.SynapseTableUnavailableException;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessApproval;
@@ -88,7 +87,6 @@ import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 import org.sagebionetworks.repo.model.message.NotificationSettingsSignedToken;
 import org.sagebionetworks.repo.model.principal.AccountCreationToken;
-import org.sagebionetworks.repo.model.principal.AddEmailInfo;
 import org.sagebionetworks.repo.model.principal.AliasCheckRequest;
 import org.sagebionetworks.repo.model.principal.AliasCheckResponse;
 import org.sagebionetworks.repo.model.principal.AliasType;
@@ -151,7 +149,6 @@ import org.sagebionetworks.web.shared.exceptions.ConflictException;
 import org.sagebionetworks.web.shared.exceptions.ExceptionUtil;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
-import org.sagebionetworks.web.shared.exceptions.ResultNotReadyException;
 import org.sagebionetworks.web.shared.exceptions.TableQueryParseException;
 import org.sagebionetworks.web.shared.exceptions.TableUnavilableException;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
@@ -588,9 +585,7 @@ public class SynapseClientImpl extends SynapseClientBase implements
 			throws RestServiceException {
 		org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
 		try {
-			AddEmailInfo newEmailInfo = new AddEmailInfo();
-			newEmailInfo.setEmailValidationSignedToken(emailValidationSignedToken);
-			synapseClient.addEmail(newEmailInfo, true);
+			synapseClient.addEmail(emailValidationSignedToken, true);
 		} catch (SynapseException e) {
 			throw ExceptionUtil.convertSynapseException(e);
 		}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/UserAccountServiceImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/UserAccountServiceImpl.java
@@ -142,25 +142,6 @@ public class UserAccountServiceImpl extends RemoteServiceServlet implements User
 	}
 
 	@Override
-	public String createUserStep2(String userName, String fName, String lName, String password, String emailValidationToken) throws RestServiceException {
-		validateService();
-
-		SynapseClient client = createAnonymousSynapseClient();
-		try {
-			AccountSetupInfo accountSetup = new AccountSetupInfo();
-			accountSetup.setFirstName(fName);
-			accountSetup.setLastName(lName);
-			accountSetup.setUsername(userName);
-			accountSetup.setPassword(password);
-			accountSetup.setEmailValidationToken(emailValidationToken);
-			Session s = client.createNewAccount(accountSetup);
-			return s.getSessionToken();
-		} catch (SynapseException e) {
-			throw ExceptionUtil.convertSynapseException(e);
-		}
-	}
-
-	@Override
 	public String createUserStep2(String userName, String fName, String lName, String password, EmailValidationSignedToken emailValidationSignedToken) throws RestServiceException {
 		validateService();
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/NewAccountPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/NewAccountPresenterTest.java
@@ -67,7 +67,6 @@ public class NewAccountPresenterTest {
 		AsyncMockStubber.callSuccessWith(true).when(mockSynapseClient).isAliasAvailable(anyString(), eq(AliasType.USER_EMAIL.toString()), any(AsyncCallback.class));
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
 		
-		AsyncMockStubber.callSuccessWith(testSessionToken).when(mockUserService).createUserStep2(anyString(), anyString(), anyString(), anyString(), anyString(), any(AsyncCallback.class));
 		AsyncMockStubber.callSuccessWith(testSessionToken).when(mockUserService).createUserStep2(anyString(), anyString(), anyString(), anyString(), any(EmailValidationSignedToken.class), any(AsyncCallback.class));
 	}
 	

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientImplTest.java
@@ -119,7 +119,6 @@ import org.sagebionetworks.repo.model.file.UploadDestination;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 import org.sagebionetworks.repo.model.message.NotificationSettingsSignedToken;
 import org.sagebionetworks.repo.model.message.Settings;
-import org.sagebionetworks.repo.model.principal.AddEmailInfo;
 import org.sagebionetworks.repo.model.principal.EmailValidationSignedToken;
 import org.sagebionetworks.repo.model.principal.PrincipalAliasRequest;
 import org.sagebionetworks.repo.model.principal.PrincipalAliasResponse;
@@ -1654,7 +1653,7 @@ public class SynapseClientImplTest {
 	public void testAddEmail() throws Exception {
 		EmailValidationSignedToken emailValidationSignedToken = new EmailValidationSignedToken();
 		synapseClient.addEmail(emailValidationSignedToken);
-		verify(mockSynapse).addEmail(any(AddEmailInfo.class), anyBoolean());
+		verify(mockSynapse).addEmail(any(EmailValidationSignedToken.class), anyBoolean());
 	}
 
 	@Test


### PR DESCRIPTION
Fix addEmail and remove createUserStep2

The refactoring in https://sagebionetworks.jira.com/browse/PLFM-3385
removed AddEmailInfo and also removed AccountSetupInfo's
EmailValidationToken field. This commit updates the web client to not
use these deprecated objects.