### PR TITLE
SWC-3998: for s3 direct uploader, multipart uploader, and sftp link, …

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
@@ -278,8 +278,7 @@ public class DisplayConstants {
 	public static final String DOWNLOAD_CREDENTIALS_REQUIRED = "Sign in to download from ";
 	public static final String SUCCESSFULLY_LINKED_OAUTH2_ACCOUNT = "Successfully linked the external account to your Synapse profile.";
 	public static final String INVALID_EMAIL = "Email address is not valid.";
-	
-	public static final String MD5_CALCULATION_ERROR = "Unable to upload. Please select a set of accessible Files to upload.";
+	public static final String MD5_CALCULATION_ERROR = "Unable to upload. Please select a set of accessible Files to upload.  Uploading a Folder is not supported.";
 
 	// Button styles
 	public static final String PRIMARY_BUTTON_STYLE = "btn-primary";

--- a/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayConstants.java
@@ -278,6 +278,8 @@ public class DisplayConstants {
 	public static final String DOWNLOAD_CREDENTIALS_REQUIRED = "Sign in to download from ";
 	public static final String SUCCESSFULLY_LINKED_OAUTH2_ACCOUNT = "Successfully linked the external account to your Synapse profile.";
 	public static final String INVALID_EMAIL = "Email address is not valid.";
+	
+	public static final String MD5_CALCULATION_ERROR = "Unable to upload. Please select a set of accessible Files to upload.";
 
 	// Button styles
 	public static final String PRIMARY_BUTTON_STYLE = "btn-primary";

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/S3DirectUploader.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/S3DirectUploader.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.web.client.widget.upload.MultipartUploaderImpl
 
 import org.sagebionetworks.repo.model.file.ExternalObjectStoreFileHandle;
 import org.sagebionetworks.web.client.ContentTypeUtils;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -124,6 +125,10 @@ public class S3DirectUploader implements S3DirectUploadHandler {
 			@Override
 			public void setMD5(String hexValue) {
 				md5 = hexValue;
+				if (md5 == null) {
+					handler.uploadFailed(DisplayConstants.MD5_CALCULATION_ERROR);
+					return;
+				}
 				awsSdk.getS3(accessKeyId, secretAccessKey, bucketName, endpoint, new CallbackP<JavaScriptObject>() {
 					@Override
 					public void invoke(JavaScriptObject s3) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/Uploader.java
@@ -41,7 +41,6 @@ import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.i18n.client.NumberFormat;
@@ -569,6 +568,10 @@ public class Uploader implements UploaderView.Presenter, SynapseWidgetPresenter,
 		synapseJsniUtils.getFileMd5(blob, new MD5Callback() {
 			@Override
 			public void setMD5(String hexValue) {
+				if (hexValue == null) {
+					view.showErrorMessage(DisplayConstants.MD5_CALCULATION_ERROR);
+					return;
+				}
 				boolean isUpdating = entityId != null || entity != null;
 				long fileSize = (long)synapseJsniUtils.getFileSize(blob);
 				String fileName = fileNames[currIndex];

--- a/src/main/java/org/sagebionetworks/web/client/widget/upload/MultipartUploaderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/upload/MultipartUploaderImpl.java
@@ -12,6 +12,7 @@ import org.sagebionetworks.repo.model.file.MultipartUploadStatus;
 import org.sagebionetworks.repo.model.file.PartPresignedUrl;
 import org.sagebionetworks.repo.model.file.PartUtils;
 import org.sagebionetworks.repo.model.util.ContentTypeUtils;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.MultipartFileUploadClientAsync;
@@ -99,6 +100,10 @@ public class MultipartUploaderImpl implements MultipartUploader {
 		synapseJsniUtils.getFileMd5(blob, new MD5Callback() {
 			@Override
 			public void setMD5(String md5) {
+				if (md5 == null) {
+					handler.uploadFailed(DisplayConstants.MD5_CALCULATION_ERROR);
+					return;
+				}
 				long fileSize = (long)synapseJsniUtils.getFileSize(blob);
 				long partSizeBytes = PartUtils.choosePartSize(fileSize);
 				long numberOfParts = PartUtils.calculateNumberOfParts(

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
@@ -229,8 +229,6 @@ public class UploaderTest {
 		verify(view).showInfo(anyString(), anyString());
 	}
 
-	
-
 	@Test
 	public void testSetNewSftpExternalPath() throws Exception {
 		//this is the full success test
@@ -240,7 +238,25 @@ public class UploaderTest {
 		verify(synapseClient).createExternalFile(anyString(), anyString(), anyString(), anyString(), anyLong(), eq(md5), eq(storageLocationId), any(AsyncCallback.class));
 		verify(view).showInfo(anyString(), anyString());
 	}
-	
+
+	@Test
+	public void testSetSftpExternalPathToFolder() throws Exception {
+		// attempt to uplaod a Folder to sftp external link
+		uploader.setFileNames(new String[] {"testfolder"});
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+                final Object[] args = invocation.getArguments();
+                ((MD5Callback) args[args.length - 1]).setMD5(null);
+				return null;
+			}
+		}).when(synapseJsniUtils).getFileMd5(any(JavaScriptObject.class), any(MD5Callback.class));
+		
+		uploader.setSftpExternalFilePath("http://fakepath.url/blah.xml", storageLocationId);
+		verify(synapseClient, never()).createExternalFile(anyString(), anyString(), anyString(), anyString(), anyLong(), eq(md5), eq(storageLocationId), any(AsyncCallback.class));
+		verify(view).showErrorMessage(DisplayConstants.MD5_CALCULATION_ERROR);
+	}
+
 	@Test
 	public void testSetSftpExternalPathFailedCreate() throws Exception {
 		uploader.setFileNames(new String[] {"test.txt"});

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/MultipartUploaderTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/MultipartUploaderTest.java
@@ -39,6 +39,7 @@ import org.sagebionetworks.repo.model.file.PartPresignedUrl;
 import org.sagebionetworks.repo.model.file.PartUtils;
 import org.sagebionetworks.repo.model.util.ContentTypeUtils;
 import org.sagebionetworks.web.client.ClientProperties;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.MultipartFileUploadClientAsync;
 import org.sagebionetworks.web.client.ProgressCallback;
@@ -158,6 +159,23 @@ public class MultipartUploaderTest {
     
 	private void setPartsState(String partsState) {
 		when(mockMultipartUploadStatus.getPartsState()).thenReturn(partsState);
+	}
+	
+	@Test
+	public void testDirectUploadFolder() throws Exception {
+		setPartsState("0");
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+                final Object[] args = invocation.getArguments();
+                ((MD5Callback) args[args.length - 1]).setMD5(null);
+				return null;
+			}
+		}).when(synapseJsniUtils).getFileMd5(any(JavaScriptObject.class), any(MD5Callback.class));
+		
+		uploader.uploadFile(FILE_NAME, CONTENT_TYPE, mockFileBlob, mockHandler, storageLocationId, mockView);
+		verify(synapseJsniUtils).getFileMd5(any(JavaScriptObject.class), any(MD5Callback.class));
+		verify(mockHandler).uploadFailed(DisplayConstants.MD5_CALCULATION_ERROR);
 	}
 	
 	@Test


### PR DESCRIPTION
…if md5 calculation fails then inform user that it was unable to download, and that they must select a set of accessible Files to upload