### PR TITLE
SWC-4113

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -59,6 +59,7 @@ import org.sagebionetworks.web.shared.exceptions.ConflictException;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.gwt.activity.shared.AbstractActivity;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.place.shared.Place;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -247,7 +248,6 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 	@Override
 	public void setPlace(Profile place) {
 		this.place = place;
-		this.view.setPresenter(this);
 		this.view.clear();
 		resetSynAlertWidgets();
 		showView(place);
@@ -998,7 +998,13 @@ public class ProfilePresenter extends AbstractActivity implements ProfileView.Pr
 		currentArea = place.getArea();
 		filterType = place.getProjectFilter();
 		filterTeamId = place.getTeamId();
-		view.setPresenter(this);
+		if (loadMoreProjectsWidgetContainer != null) {
+			loadMoreProjectsWidgetContainer.clear();
+		}
+		if (loadMoreTeamsWidgetContainer != null) {
+			loadMoreTeamsWidgetContainer.clear();
+		}
+		
 		if (token.equals("oauth_bound")) {
 			view.showInfo("", DisplayConstants.SUCCESSFULLY_LINKED_OAUTH2_ACCOUNT);
 			token = "v";

--- a/src/main/java/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainer.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainer.java
@@ -79,6 +79,7 @@ public class LoadMoreWidgetContainer implements IsWidget, HasWidgets {
 	@Override
 	public void clear() {
 		view.clear();
+		setIsMore(false);
 	}
 
 	@Override

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -568,6 +568,11 @@ public class ProfilePresenterTest {
 		verify(mockSynapseJavascriptClient).getMyProjects(eq(ProjectListType.MY_PROJECTS), anyInt(), anyInt(), any(ProjectListSortColumn.class), any(SortDirection.class),  any(AsyncCallback.class));
 		verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
 		verify(mockView).setProjectSortVisible(true);
+		verify(mockLoadMoreContainer, never()).clear();
+		
+		// if we set the place and get projects again, verify existing project load more container is cleared (deregisters callback)
+		profilePresenter.setPlace(place);
+		verify(mockLoadMoreContainer).clear();
 	}
 	
 	@Test
@@ -970,6 +975,11 @@ public class ProfilePresenterTest {
 		verify(mockSynapseJavascriptClient).listTeams(teamIds);
 		verify(mockTeamListWidget).addTeam(any(Team.class));
 		verify(mockView, Mockito.never()).setTeamNotificationCount(anyString());
+		verify(mockLoadMoreContainer, never()).clear();
+		
+		// if we set the place and get teams again, verify existing teams load more container is cleared (deregisters callback)
+		profilePresenter.setPlace(place);
+		verify(mockLoadMoreContainer).clear();
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/LoadMoreWidgetContainerTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/LoadMoreWidgetContainerTest.java
@@ -41,6 +41,7 @@ public class LoadMoreWidgetContainerTest {
 		widget.setIsMore(isMore);
 		verify(mockView).setLoadMoreVisibility(isMore);
 		verify(mockLazyLoadCallbackQueue).subscribe(any(Callback.class));
+		verify(mockLazyLoadCallbackQueue, never()).unsubscribe(any(Callback.class));
 	}
 	
 	@Test
@@ -49,6 +50,7 @@ public class LoadMoreWidgetContainerTest {
 		widget.setIsMore(isMore);
 		verify(mockView).setLoadMoreVisibility(isMore);
 		verify(mockLazyLoadCallbackQueue, never()).subscribe(any(Callback.class));
+		verify(mockLazyLoadCallbackQueue).unsubscribe(any(Callback.class));
 	}
 
 
@@ -68,6 +70,8 @@ public class LoadMoreWidgetContainerTest {
 	public void testClear() {
 		widget.clear();
 		verify(mockView).clear();
+		verify(mockView).setLoadMoreVisibility(false);
+		verify(mockLazyLoadCallbackQueue).unsubscribe(any(Callback.class));
 	}
 
 	@Test
@@ -77,7 +81,6 @@ public class LoadMoreWidgetContainerTest {
 		verify(mockLazyLoadCallbackQueue, never()).subscribe(any(Callback.class));
 		verify(mockLoadMoreCallback, never()).invoke();
 	}
-
 	
 	@Test
 	public void testCheckForInViewAndLoadDataAttachedNotInViewport() {


### PR DESCRIPTION
when load more widget is cleared, it stops listening for timer callback.  when changing views in profile, clear load more containers (if set)