### PR TITLE
SWC-4097 : show log-in link if anonymously viewing the ACL editor

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/DisplayUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/DisplayUtils.java
@@ -74,6 +74,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.logical.shared.AttachEvent.Handler;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
@@ -112,6 +113,12 @@ public class DisplayUtils {
 			event.stopPropagation();
 		}
 	};
+	
+	public static final Handler getHideModalOnDetachHandler() {
+		return event -> {
+			((Modal)event.getSource()).hide();
+		};
+	}
 	
 	/**
 	 * This key down handler prevents the user from tabbing forward off of the given Focusable widget.

--- a/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidget.java
@@ -35,10 +35,11 @@ public class LoginWidget implements LoginWidgetView.Presenter {
 		this.globalApplicationState = globalApplicationState;
 		this.synAlert = synAlert;
 		view.setSynAlert(synAlert);
-		view.setPresenter(this);
 	}
 
 	public Widget asWidget() {
+		// setPresenter in asWidget() is necessary to connect the singleton view to the current presenter (which contains the current UserListener)
+		view.setPresenter(this);
 		return view.asWidget();
 	}
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditor.java
@@ -21,7 +21,6 @@ import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
-import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.SynapseProperties;
@@ -202,7 +201,7 @@ public class AccessControlListEditor implements AccessControlListEditorView.Pres
 		view.showLoading();
 		boolean isInherited = !acl.getId().equals(entity.getId());
 		boolean canEnableInheritance = uep.getCanEnableInheritance();
-		view.buildWindow(entity instanceof Project, isInherited, acl.getId(), canEnableInheritance, canChangePermission, PermissionLevel.CAN_DOWNLOAD);
+		view.buildWindow(entity instanceof Project, isInherited, acl.getId(), canEnableInheritance, canChangePermission, PermissionLevel.CAN_DOWNLOAD, authenticationController.isLoggedIn());
 		populateAclEntries();
 		updateIsPublicAccess();
 	}

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorView.java
@@ -23,7 +23,7 @@ public interface AccessControlListEditorView extends IsWidget, SynapseView {
 	 * @param principals the available principals
 	 * @param isEditable
 	 */
-	public void buildWindow(boolean isProject, boolean isInherited, String aclEntityId, boolean canEnableInheritance, boolean canChangePermission, PermissionLevel defaultPermissionLevel);
+	public void buildWindow(boolean isProject, boolean isInherited, String aclEntityId, boolean canEnableInheritance, boolean canChangePermission, PermissionLevel defaultPermissionLevel, boolean isLoggedIn);
 	
 	/**
 	 * Add an ACL Entry to the permissions dialog

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListEditorViewImpl.java
@@ -18,7 +18,6 @@ import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.HelpWidget;
 import org.sagebionetworks.web.client.widget.LoadingSpinner;
 import org.sagebionetworks.web.client.widget.search.UserGroupSuggestion;
-import org.sagebionetworks.web.client.widget.table.v2.results.cell.EntityIdCellRenderer;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.EntityIdCellRendererImpl;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.users.AclEntry;
@@ -38,7 +37,7 @@ public class AccessControlListEditorViewImpl extends FlowPanel implements Access
 	public static final String CREATE_ACL_HELP_TEXT = "By default the sharing settings are inherited from the parent folder or project. If you want to have different settings on a specific file, folder, or table you need to create local sharing settings and then modify them.";
 
 	private static final String CANNOT_MODIFY_ACL_TEXT = "You do not have sufficient privileges to modify the sharing settings.";
-	
+	private static final String CANNOT_MODIFY_ACL_ANONYMOUS_HTML = "You must be <a href=\"#!LoginPlace:0\">logged in</a> and have sufficient privileges to modify the sharing settings.";
 	private Presenter presenter;
 	private Map<PermissionLevel, String> permissionDisplay;
 	private Long publicAclPrincipalId, authenticatedPrincipalId;
@@ -134,7 +133,7 @@ public class AccessControlListEditorViewImpl extends FlowPanel implements Access
 	}
 	
 	@Override
-	public void buildWindow(boolean isProject, boolean isInherited, String aclEntityId, boolean canEnableInheritance, boolean canChangePermission, PermissionLevel defaultPermissionLevel) {		
+	public void buildWindow(boolean isProject, boolean isInherited, String aclEntityId, boolean canEnableInheritance, boolean canChangePermission, PermissionLevel defaultPermissionLevel, boolean isLoggedIn) {		
 		clear();
 		this.defaultPermissionLevel = defaultPermissionLevel;
 		// Display Permissions grid.
@@ -186,8 +185,12 @@ public class AccessControlListEditorViewImpl extends FlowPanel implements Access
 		
 		if (!canChangePermission) {
 			// Inform user of restricted privileges.
-			Label canNotModify = new Label();
-			canNotModify.setText(CANNOT_MODIFY_ACL_TEXT);
+			IsWidget canNotModify;
+			if (isLoggedIn) {
+				canNotModify = new Label(CANNOT_MODIFY_ACL_TEXT);
+			} else {
+				canNotModify = new HTML(CANNOT_MODIFY_ACL_ANONYMOUS_HTML);
+			}
 			add(canNotModify);
 		} else {
 			if(isInherited) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/AccessControlListModalWidgetViewImpl.java
@@ -7,6 +7,7 @@ import org.gwtbootstrap3.client.ui.constants.HeadingSize;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.DisplayUtils;
 
+import com.google.gwt.core.shared.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -43,6 +44,7 @@ public class AccessControlListModalWidgetViewImpl implements
 	@Inject
 	public AccessControlListModalWidgetViewImpl(Binder binder) {
 		modal = binder.createAndBindUi(this);
+		modal.addAttachHandler(DisplayUtils.getHideModalOnDetachHandler());
 		primaryButton.addDomHandler(DisplayUtils.getPreventTabHandler(primaryButton), KeyDownEvent.getType());
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/EvaluationAccessControlListEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/EvaluationAccessControlListEditor.java
@@ -210,7 +210,7 @@ public class EvaluationAccessControlListEditor implements AccessControlListEdito
 	private void setViewDetails() {
 		validateEditorState();
 		view.showLoading();
-		view.buildWindow(false, false, null, false, true, PermissionLevel.CAN_VIEW);
+		view.buildWindow(false, false, null, false, true, PermissionLevel.CAN_VIEW, authenticationController.isLoggedIn());
 		populateAclEntries();
 		updateIsPublicAccess();
 	}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/login/LoginWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/login/LoginWidgetTest.java
@@ -77,7 +77,6 @@ public class LoginWidgetTest {
 		usd.setSession(mockSession);
 		when(mockSession.getAcceptsTermsOfUse()).thenReturn(true);
 		AsyncMockStubber.callSuccessWith(usd).when(mockAuthController).loginUser(anyString(),anyString(),any(AsyncCallback.class));
-		verify(mockView).setPresenter(loginWidget);
 		verify(mockView).setSynAlert(mockSynAlert);
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
 	}
@@ -85,6 +84,7 @@ public class LoginWidgetTest {
 	@Test
 	public void testAsWidget(){
 		loginWidget.asWidget();
+		verify(mockView).setPresenter(loginWidget);
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/AccessControlListEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/AccessControlListEditorTest.java
@@ -266,8 +266,8 @@ public class AccessControlListEditorTest {
 		assertEquals("Created ACL is invalid", localACL, returnedACL);
 		verify(mockACLEView, never()).showErrorMessage(anyString());
 		// verify initially inherited acl, then local ACL
-		verify(mockACLEView, times(1)).buildWindow(anyBoolean(), anyBoolean(), eq(INHERITED_ACL_ID), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
-		verify(mockACLEView, times(2)).buildWindow(anyBoolean(), anyBoolean(), eq(ENTITY_ID), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(1)).buildWindow(anyBoolean(), anyBoolean(), eq(INHERITED_ACL_ID), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
+		verify(mockACLEView, times(2)).buildWindow(anyBoolean(), anyBoolean(), eq(ENTITY_ID), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 		
 		verify(mockACLEView).setPublicAclPrincipalId(any(Long.class));
 		
@@ -315,7 +315,7 @@ public class AccessControlListEditorTest {
 		
 		assertEquals("Updated ACL is invalid", localACL, returnedACL);
 		verify(mockACLEView, never()).showErrorMessage(anyString());
-		verify(mockACLEView, times(6)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(6)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 		verify(mockACLEView).setPublicAclPrincipalId(any(Long.class));
 		
 		ArgumentCaptor<Set> recipientSetCaptor = ArgumentCaptor.forClass(Set.class);
@@ -406,7 +406,7 @@ public class AccessControlListEditorTest {
 		returnedACL.setResourceAccess(null);
 		assertTrue(localACL.equals(returnedACL));
 		verify(mockACLEView, never()).showErrorMessage(anyString());
-		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 		
 		verify(mockSynapseClient, never()).sendMessage(anySet(), anyString(), anyString(), anyString(), any(AsyncCallback.class));
 	}
@@ -438,7 +438,7 @@ public class AccessControlListEditorTest {
 		
 		assertEquals("Updated ACL is invalid", localACL, returnedACL);
 		verify(mockACLEView, never()).showErrorMessage(anyString());
-		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 		
 		verify(mockSynapseClient, never()).sendMessage(anySet(), anyString(), anyString(), anyString(), any(AsyncCallback.class));
 	}
@@ -461,7 +461,7 @@ public class AccessControlListEditorTest {
 		
 		verify(mockSynapseClient).deleteAcl(eq(ENTITY_ID), any(AsyncCallback.class));
 		verify(mockACLEView, never()).showErrorMessage(anyString());
-		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 		
 		verify(mockSynapseClient, never()).sendMessage(anySet(), anyString(), anyString(), anyString(), any(AsyncCallback.class));
 	}
@@ -517,7 +517,7 @@ public class AccessControlListEditorTest {
 		
 		assertEquals("Updated ACL is invalid", localACL, returnedACL);
 		verify(mockACLEView, never()).showErrorMessage(anyString());
-		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView, times(3)).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -525,7 +525,8 @@ public class AccessControlListEditorTest {
 	public void setAdminAccessTest() throws Exception {
 		// configure mocks
 		AsyncMockStubber.callSuccessWith(entityBundleTransport_localACL).when(mockSynapseJavascriptClient).getEntityBundle(anyString(), anyInt(), any(AsyncCallback.class));
-		
+		boolean isLoggedIn = true;
+		when(mockAuthenticationController.isLoggedIn()).thenReturn(isLoggedIn);
 		// update
 		acle.refresh();
 		acle.setAccess(ADMIN_ID, PermissionLevel.CAN_VIEW);
@@ -537,7 +538,7 @@ public class AccessControlListEditorTest {
 		String aclEntityId = ENTITY_ID;
 		boolean canEnableInheritance = true;
 		boolean canChangePermission = true;
-		verify(mockACLEView).buildWindow(eq(isProject), eq(isInherited), eq(aclEntityId), eq(canEnableInheritance), eq(canChangePermission), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView).buildWindow(eq(isProject), eq(isInherited), eq(aclEntityId), eq(canEnableInheritance), eq(canChangePermission), eq(PermissionLevel.CAN_DOWNLOAD), eq(isLoggedIn));
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -550,7 +551,7 @@ public class AccessControlListEditorTest {
 		acle.refresh();
 		acle.pushChangesToSynapse(false,mockPushToSynapseCallback);
 		
-		verify(mockACLEView).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -565,6 +566,6 @@ public class AccessControlListEditorTest {
 		acle.pushChangesToSynapse(false,mockPushToSynapseCallback);
 
 		verify(mockSynAlert).showError(anyString());
-		verify(mockACLEView).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD));
+		verify(mockACLEView).buildWindow(anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyBoolean(), eq(PermissionLevel.CAN_DOWNLOAD), anyBoolean());
 	}
 }


### PR DESCRIPTION
And bug fixes around this behavior: 
- On modal detach (change place), hide the dialog.
- Update the LoginWidget view (singleton) presenter in asWidget(), since it will change.