### PR TITLE
SWC-4383: when markdown is null or empty, report that there is no content...

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidget.java
@@ -245,15 +245,21 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 	
 	@Override
 	public void resetWikiMarkdown(String markdown) {
-		view.setMarkdownVisible(true);
-		if(!isCurrentVersion) {
-			markdownWidget.configure(markdown, wikiKey, versionInView);
-			view.setDiffVersionAlertVisible(true);
-			if (canEdit) {
-				view.setRestoreButtonVisible(true);
+		if (DisplayUtils.isDefined(markdown)) {
+			view.setNoWikiCanEditMessageVisible(false);
+			view.setNoWikiCannotEditMessageVisible(false);
+			view.setMarkdownVisible(true);
+			if(!isCurrentVersion) {
+				markdownWidget.configure(markdown, wikiKey, versionInView);
+				view.setDiffVersionAlertVisible(true);
+				if (canEdit) {
+					view.setRestoreButtonVisible(true);
+				}
+			} else {
+				markdownWidget.configure(markdown, wikiKey, null);
 			}
 		} else {
-			markdownWidget.configure(markdown, wikiKey, null);
+			showNoWikiFoundUI();
 		}
 	}
 	
@@ -408,14 +414,19 @@ public class WikiPageWidget implements WikiPageWidgetView.Presenter, SynapseWidg
 		view.setMarkdownVisible(false);
 		view.setWikiHistoryVisible(false);
 		if (caught instanceof NotFoundException) {
-			if (canEdit) {
-				view.setNoWikiCanEditMessageVisible(true);
-			}else {
-				view.setNoWikiCannotEditMessageVisible(true);
-			}
+			showNoWikiFoundUI();
 		} else {
 			view.setMainPanelVisible(false);
 			stuAlert.handleException(caught);
+		}
+	}
+	
+	private void showNoWikiFoundUI() {
+		view.setMarkdownVisible(false);
+		if (canEdit) {
+			view.setNoWikiCanEditMessageVisible(true);
+		}else {
+			view.setNoWikiCannotEditMessageVisible(true);
 		}
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/upload/MultipartUploaderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/upload/MultipartUploaderImpl.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.utils.Callback;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.logical.shared.HasAttachHandlers;
 import com.google.gwt.i18n.client.NumberFormat;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
@@ -144,6 +144,8 @@ public class WikiPageWidgetTest {
 		verify(mockView).setLoadingVisible(true);
 		verify(mockSynapseJavascriptClient).getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
 		verify(mockMarkdownWidget).configure(anyString(), any(WikiPageKey.class), any(Long.class));
+		verify(mockView).setNoWikiCanEditMessageVisible(false);
+		verify(mockView).setNoWikiCannotEditMessageVisible(false);
 		verify(mockView).setWikiHistoryWidget(any(IsWidget.class));
 		verify(mockView).setModifiedCreatedByHistoryPanelVisible(true);
 		verify(mockView).setModifiedOn(formattedDate);
@@ -181,7 +183,7 @@ public class WikiPageWidgetTest {
 		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null);
 		
 		verify(mockStuAlert, never()).handleException(any(Exception.class));
-		verify(mockView).setMarkdownVisible(false);
+		verify(mockView, times(2)).setMarkdownVisible(false);
 		verify(mockView).setWikiHistoryVisible(false);
 		verify(mockView).setNoWikiCannotEditMessageVisible(true);
 		verify(mockView).setModifiedCreatedByHistoryPanelVisible(false);
@@ -194,7 +196,7 @@ public class WikiPageWidgetTest {
 		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), null, null), canEdit, null);
 		
 		verify(mockStuAlert, never()).handleException(any(Exception.class));
-		verify(mockView).setMarkdownVisible(false);
+		verify(mockView, times(2)).setMarkdownVisible(false);
 		verify(mockView).setWikiHistoryVisible(false);
 		verify(mockView).setNoWikiCanEditMessageVisible(true);
 		verify(mockView).setModifiedCreatedByHistoryPanelVisible(false);
@@ -360,5 +362,26 @@ public class WikiPageWidgetTest {
 		presenter.onWikiSubpagesExpandEvent(mockWikiSubpagesExpandEvent);
 		verify(mockView).expandWikiSubpages();
 	}
-
+	
+	@Test
+	public void testSetWikiPageEmptyMarkdownCannotEdit() {
+		boolean canEdit = false;
+		testPage.setMarkdown("");
+		
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null);
+		
+		verify(mockView).setNoWikiCannotEditMessageVisible(true);
+		verify(mockView).setMarkdownVisible(false);
+	}
+	
+	@Test
+	public void testSetWikiPageNullMarkdownCanEdit() {
+		boolean canEdit = true;
+		testPage.setMarkdown(null);
+		
+		presenter.configure(new WikiPageKey("ownerId", ObjectType.ENTITY.toString(), WIKI_PAGE_ID, null), canEdit, null);
+		
+		verify(mockView).setNoWikiCanEditMessageVisible(true);
+		verify(mockView).setMarkdownVisible(false);
+	}
 }


### PR DESCRIPTION
with the correct message that depends on if user can edit