### PR TITLE
PLFM-5268 use dockerTag URI instead of dockerCommit URI

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
@@ -215,7 +215,7 @@ public class SynapseJavascriptClient {
 	public static final String INVITEE_ID = "/inviteeId";
 	public static final String ICON = "/icon";
 	public static final String PROJECTS_URI_PATH = "/projects";
-	public static final String DOCKER_COMMIT = "/dockerCommit";
+	public static final String DOCKER_TAG = "/dockerTag";
 	public static final String OFFSET_PARAMETER = "offset=";
 	public static final String LIMIT_PARAMETER = "limit=";
 	public static final String OBJECT_TYPE_PARAMETER = "objectType=";
@@ -1100,14 +1100,14 @@ public class SynapseJavascriptClient {
 		doGet(url, OBJECT_TYPE.Activity, callback);
 	}
 
-	public void getDockerCommits(
+	public void getDockerTaggedCommits(
 			String entityId, 
 			Long limit, 
 			Long offset,
 			DockerCommitSortBy sortBy, 
 			Boolean ascending,
 			AsyncCallback<ArrayList<DockerCommit>> callback) {
-		String url = getRepoServiceUrl() + ENTITY+"/"+entityId+DOCKER_COMMIT;
+		String url = getRepoServiceUrl() + ENTITY+"/"+entityId+ DOCKER_TAG;
 		List<String> requestParams = new ArrayList<String>();
 		if (limit!=null) {
 			requestParams.add(LIMIT_PARAMETER+limit);

--- a/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerCommitListWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerCommitListWidget.java
@@ -68,7 +68,7 @@ public class DockerCommitListWidget implements IsWidget, DockerCommitListWidgetV
 
 	public void loadMore() {
 		synAlert.clear();
-		jsClient.getDockerCommits(entityId, LIMIT, offset, order, ascending, new AsyncCallback<ArrayList<DockerCommit>>(){
+		jsClient.getDockerTaggedCommits(entityId, LIMIT, offset, order, ascending, new AsyncCallback<ArrayList<DockerCommit>>(){
 
 					@Override
 					public void onFailure(Throwable caught) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerCommitListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerCommitListWidgetTest.java
@@ -68,7 +68,7 @@ public class DockerCommitListWidgetTest {
 		entityId = "syn123";
 		dockerCommitList = new ArrayList<DockerCommit>();
 		AsyncMockStubber.callSuccessWith(dockerCommitList)
-			.when(mockJsClient).getDockerCommits(anyString(), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
+			.when(mockJsClient).getDockerTaggedCommits(anyString(), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
 	}
 
 	@Test
@@ -81,7 +81,7 @@ public class DockerCommitListWidgetTest {
 		Callback callback = captor.getValue();
 		callback.invoke();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(anyString(), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
+		verify(mockJsClient).getDockerTaggedCommits(anyString(), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
 	}
 
 	@Test
@@ -90,7 +90,7 @@ public class DockerCommitListWidgetTest {
 		dockerCommitListWidget.configure(entityId, withRadio);
 		verify(mockCommitsContainer).clear();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(eq(entityId), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
+		verify(mockJsClient).getDockerTaggedCommits(eq(entityId), anyLong(), anyLong(), any(DockerCommitSortBy.class), anyBoolean(), any(AsyncCallback.class));
 	}
 
 	@Test
@@ -100,7 +100,7 @@ public class DockerCommitListWidgetTest {
 		dockerCommitListWidget.configure(entityId, withRadio);
 		verify(mockCommitsContainer).clear();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(eq(entityId),
+		verify(mockJsClient).getDockerTaggedCommits(eq(entityId),
 				anyLong(), anyLong(), any(DockerCommitSortBy.class),
 				anyBoolean(), any(AsyncCallback.class));
 		verify(mockCommitsContainer, never()).add(any(Widget.class));
@@ -117,7 +117,7 @@ public class DockerCommitListWidgetTest {
 		verify(mockCommitRow).configure(mockCommit);
 		verify(mockCommitsContainer).clear();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(eq(entityId),
+		verify(mockJsClient).getDockerTaggedCommits(eq(entityId),
 				anyLong(), anyLong(), any(DockerCommitSortBy.class),
 				anyBoolean(), any(AsyncCallback.class));
 		verify(mockCommitsContainer).add(any(Widget.class));
@@ -155,7 +155,7 @@ public class DockerCommitListWidgetTest {
 		verify(mockRadioWidget).addClickHandler(any(ClickHandler.class));
 		verify(mockCommitsContainer).clear();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(eq(entityId),
+		verify(mockJsClient).getDockerTaggedCommits(eq(entityId),
 				anyLong(), anyLong(), any(DockerCommitSortBy.class),
 				anyBoolean(), any(AsyncCallback.class));
 		verify(mockCommitsContainer).add(any(Widget.class));
@@ -167,13 +167,13 @@ public class DockerCommitListWidgetTest {
 		boolean withRadio = false;
 		Throwable exception = new Throwable();
 		AsyncMockStubber.callFailureWith(exception)
-				.when(mockJsClient).getDockerCommits(anyString(),
+				.when(mockJsClient).getDockerTaggedCommits(anyString(),
 						anyLong(), anyLong(), any(DockerCommitSortBy.class),
 						anyBoolean(), any(AsyncCallback.class));
 		dockerCommitListWidget.configure(entityId, withRadio);
 		verify(mockCommitsContainer).clear();
 		verify(mockSynAlert).clear();
-		verify(mockJsClient).getDockerCommits(eq(entityId),
+		verify(mockJsClient).getDockerTaggedCommits(eq(entityId),
 				anyLong(), anyLong(), any(DockerCommitSortBy.class),
 				anyBoolean(), any(AsyncCallback.class));
 		verify(mockCommitsContainer, never()).add(any(Widget.class));


### PR DESCRIPTION
Just need to change an endpoint for
https://sagebionetworks.jira.com/browse/PLFM-5268

This is dependent on https://github.com/Sage-Bionetworks/Synapse-Repository-Services/pull/3453 being merged, so wait for that to be merged first (the deprecated URI has not been removed yet, so the portal will still work in the meantime).