### PR TITLE
SWC-4511: apply markdown style to access requirement widgets

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/AccessRequirementsPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/AccessRequirementsPresenter.java
@@ -77,7 +77,8 @@ public class AccessRequirementsPresenter extends AbstractActivity implements Pre
 		this.authController = authController;
 		view.addAboveBody(synAlert);
 		view.addAboveBody(createAccessRequirementButton);
-		metAccessRequirementsDiv.addStyleName("min-height-400");
+		unmetAccessRequirementsDiv.addStyleName("markdown");
+		metAccessRequirementsDiv.addStyleName("markdown min-height-400");
 		view.add(unmetAccessRequirementsDiv.asWidget());
 		view.add(metAccessRequirementsDiv.asWidget());
 		view.addTitle("All conditions for ");
@@ -209,8 +210,7 @@ public class AccessRequirementsPresenter extends AbstractActivity implements Pre
 	}
 	
 	@Override
-    public String mayStop() {
-        return null;
-    }
-	
+	public String mayStop() {
+		return null;
+	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementWidget.java
@@ -77,7 +77,6 @@ public class AccessRequirementWidget implements IsWidget{
 				w.hideButtons();
 			}
 			div.add(w);
-			w.addStyleNames("border-bottom-1");
 		} else if (requirement instanceof ACTAccessRequirement) {
 			ACTAccessRequirementWidget w = ginInjector.getACTAccessRequirementWidget();
 			w.setRequirement((ACTAccessRequirement) requirement, refreshCallback);

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementWidget.java
@@ -34,6 +34,7 @@ public class AccessRequirementWidget implements IsWidget{
 		this.dataAccessClient = dataAccessClient;
 		fixServiceEntryPoint(dataAccessClient);
 		this.div = div;
+		div.addStyleName("border-bottom-1 margin-bottom-15");
 	}
 	
 	public void configure(final String accessRequirementId, final RestrictableObjectDescriptor targetSubject) {
@@ -76,6 +77,7 @@ public class AccessRequirementWidget implements IsWidget{
 				w.hideButtons();
 			}
 			div.add(w);
+			w.addStyleNames("border-bottom-1");
 		} else if (requirement instanceof ACTAccessRequirement) {
 			ACTAccessRequirementWidget w = ginInjector.getACTAccessRequirementWidget();
 			w.setRequirement((ACTAccessRequirement) requirement, refreshCallback);

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/SelfSignAccessRequirementWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/SelfSignAccessRequirementWidgetViewImpl.java
@@ -46,7 +46,9 @@ public class SelfSignAccessRequirementWidgetViewImpl implements SelfSignAccessRe
 	Div subjectsWidgetContainer;
 	@UiField
 	Div manageAccessContainer;
-	
+	@UiField
+	Alert approvedAlert;
+
 	Callback onAttachCallback;
 	public interface Binder extends UiBinder<Widget, SelfSignAccessRequirementWidgetViewImpl> {
 	}
@@ -99,6 +101,7 @@ public class SelfSignAccessRequirementWidgetViewImpl implements SelfSignAccessRe
 	@Override
 	public void showApprovedHeading() {
 		approvedHeading.setVisible(true);
+		approvedAlert.setVisible(true);
 	}
 	@Override
 	public void showUnapprovedHeading() {
@@ -112,6 +115,7 @@ public class SelfSignAccessRequirementWidgetViewImpl implements SelfSignAccessRe
 	
 	@Override
 	public void resetState() {
+		approvedAlert.setVisible(false);
 		approvedHeading.setVisible(false);
 		unapprovedHeading.setVisible(false);
 		signTermsButton.setVisible(false);

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/TermsOfUseAccessRequirementWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/TermsOfUseAccessRequirementWidgetViewImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.client.widget.accessrequirements;
 
+import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.BlockQuote;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.html.Div;
@@ -8,9 +9,6 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.place.LoginPlace;
 import org.sagebionetworks.web.client.utils.Callback;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.HTML;
@@ -45,6 +43,8 @@ public class TermsOfUseAccessRequirementWidgetViewImpl implements TermsOfUseAcce
 	Div subjectsWidgetContainer;
 	@UiField
 	Div manageAccessContainer;
+	@UiField
+	Alert approvedAlert;
 	Callback onAttachCallback;
 	public interface Binder extends UiBinder<Widget, TermsOfUseAccessRequirementWidgetViewImpl> {
 	}
@@ -101,6 +101,7 @@ public class TermsOfUseAccessRequirementWidgetViewImpl implements TermsOfUseAcce
 	@Override
 	public void showApprovedHeading() {
 		approvedHeading.setVisible(true);
+		approvedAlert.setVisible(true);
 	}
 	@Override
 	public void showUnapprovedHeading() {
@@ -114,6 +115,7 @@ public class TermsOfUseAccessRequirementWidgetViewImpl implements TermsOfUseAcce
 	
 	@Override
 	public void resetState() {
+		approvedAlert.setVisible(false);
 		approvedHeading.setVisible(false);
 		unapprovedHeading.setVisible(false);
 		signTermsButton.setVisible(false);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.java
@@ -10,7 +10,6 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Italic;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.SynapseJSNIUtilsImpl;
 import org.sagebionetworks.web.client.DisplayUtils.MessagePopup;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.place.WikiDiff;
@@ -151,9 +150,11 @@ public class WikiPageWidgetViewImpl extends FlowPanel implements WikiPageWidgetV
 	@Override
 	public void setWikiHeadingText(String title) {
 		wikiHeadingContainer.clear();
-		wikiHeading = new Heading(HeadingSize.H2);
-		wikiHeading.setText(title);
-		wikiHeadingContainer.add(wikiHeading);
+		if (DisplayUtils.isDefined(title)) {
+			wikiHeading = new Heading(HeadingSize.H2);
+			wikiHeading.setText(title);
+			wikiHeadingContainer.add(wikiHeading);	
+		}
 	}
 	
 	@Override

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ACTAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ACTAccessRequirementWidgetViewImpl.ui.xml
@@ -30,7 +30,7 @@
 			<bh:Div>
 				<bh:Text>For more information on use conditions, please read the </bh:Text>
 				<b:Anchor text="Conditions for using Human Data in Synapse" styleName="link margin-left-5" href="http://docs.synapse.org/articles/governance.html" target="_blank" />
-				<bh:Text>.</bh:Text>
+				<bh:Text>.&nbsp;&nbsp;</bh:Text>
 				<bh:Text>If you think this data is posted inappropriately or should have different access conditions, please alert the Synapse Access and Compliance Team (ACT) to discuss at act@sagebase.org </bh:Text>
 			</bh:Div>
 			<bh:ClearFix />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ACTAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ACTAccessRequirementWidgetViewImpl.ui.xml
@@ -4,18 +4,18 @@
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	<ui:with field='icons' type='org.sagebionetworks.web.client.IconsImageBundle'/>
-	<b:Panel>
+	<b:Panel marginBottom="0">
 		<b:PanelBody>
 			<bh:Div styleName="margin-bottom-20">
 				<g:Image styleName="displayInline moveup-2 margin-right-5" resource='{icons.shieldRed16}' />
-		       	<b:Icon styleName="displayInline moveup-2 margin-right-5" type="SHIELD" emphasis="DANGER" />
-		       	<g:InlineLabel styleName="font-size-18" text="Access to these data is Controlled Use" />
+				<b:Icon styleName="displayInline moveup-2 margin-right-5" type="SHIELD" emphasis="DANGER" />
+				<g:InlineLabel styleName="font-size-18" text="Access to these data is Controlled Use" />
 			</bh:Div>
 			<bh:Div ui:field="approvedHeading" visible="false">
-			    <g:InlineLabel styleName="boldText" text="Access Requirements Fulfilled:  You have access to these data under the following terms:" />
+				<g:InlineLabel styleName="boldText" text="Access requirements fulfilled:  You have access to these data under the following terms:" />
 			</bh:Div>
 			<bh:Div ui:field="unapprovedHeading" visible="false">
-			    <g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and fulfill the following requirements:" />
+				<g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and fulfill the following requirements:" />
 			</bh:Div>
 			<!-- terms -->
 			<b:BlockQuote ui:field="wikiTermsUI" visible="false">
@@ -23,15 +23,15 @@
 			</b:BlockQuote>
 			
 			<b:BlockQuote ui:field="termsUI" visible="false">
-			    <bh:Paragraph>
-			    	<g:HTML ui:field="terms" styleName="font-size-14" />
-			    </bh:Paragraph>
+				<bh:Paragraph>
+					<g:HTML ui:field="terms" styleName="font-size-14" />
+				</bh:Paragraph>
 			</b:BlockQuote>
 			<bh:Div>
-			    <bh:Text>For more information on use conditions, please read the </bh:Text>
-			    <b:Anchor text="Conditions for using Human Data in Synapse" styleName="link margin-left-5" href="http://docs.synapse.org/articles/governance.html" target="_blank" />
-			    <bh:Text>.</bh:Text>
-			    <bh:Text>If you think this data is posted inappropriately or should have different access conditions, please alert the Synapse Access and Compliance Team (ACT) to discuss at act@sagebase.org </bh:Text>
+				<bh:Text>For more information on use conditions, please read the </bh:Text>
+				<b:Anchor text="Conditions for using Human Data in Synapse" styleName="link margin-left-5" href="http://docs.synapse.org/articles/governance.html" target="_blank" />
+				<bh:Text>.</bh:Text>
+				<bh:Text>If you think this data is posted inappropriately or should have different access conditions, please alert the Synapse Access and Compliance Team (ACT) to discuss at act@sagebase.org </bh:Text>
 			</bh:Div>
 			<bh:ClearFix />
 			<bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/LockAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/LockAccessRequirementWidgetViewImpl.ui.xml
@@ -4,7 +4,7 @@
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	<ui:with field='icons' type='org.sagebionetworks.web.client.IconsImageBundle'/>
-	<b:Panel>
+	<b:Panel marginBottom="0">
 		<b:PanelBody>
 			<bh:Div styleName="margin-bottom-20">
 				<g:Image styleName="displayInline moveup-2 margin-right-5" resource='{icons.shieldRed16}' />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.ui.xml
@@ -24,7 +24,7 @@
 			<bh:Div marginRight="30">
 			    <bh:Text>For more information on use conditions, please read the </bh:Text>
 			    <b:Anchor text="Conditions for using Human Data in Synapse" styleName="link margin-left-5" href="http://docs.synapse.org/articles/governance.html" target="_blank" />
-			    <bh:Text>.</bh:Text>
+			    <bh:Text>.&nbsp;&nbsp;</bh:Text>
 			    <bh:Text>If you think this data is posted inappropriately or should have different access conditions, please alert the Synapse Access and Compliance Team (ACT) to discuss at act@sagebase.org </bh:Text>
 			</bh:Div>
 			<bh:ClearFix />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.ui.xml
@@ -4,7 +4,7 @@
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	<ui:with field='icons' type='org.sagebionetworks.web.client.IconsImageBundle'/>
-	<b:Panel>
+	<b:Panel marginBottom="0">
 		<b:PanelBody>
 			<bh:Div styleName="margin-bottom-20">
 				<g:Image styleName="displayInline moveup-2 margin-right-5" resource='{icons.shieldRed16}' />
@@ -12,7 +12,7 @@
 		       	<g:InlineLabel styleName="font-size-18" text="Access to these data is Controlled Use" />
 			</bh:Div>
 			<bh:Div ui:field="approvedHeading" visible="false">
-			    <g:InlineLabel styleName="boldText" text="Access Requirements Fulfilled:  You have access to these data under the following terms:" />
+			    <g:InlineLabel styleName="boldText" text="You have access to these data under the following terms:" />
 			</bh:Div>
 			<bh:Div ui:field="unapprovedHeading" visible="false">
 			    <g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and fulfill the following requirements:" />
@@ -21,7 +21,7 @@
 			<b:BlockQuote>
 				<g:SimplePanel ui:field="wikiContainer" />	
 			</b:BlockQuote>
-			<bh:Div>
+			<bh:Div marginRight="30">
 			    <bh:Text>For more information on use conditions, please read the </bh:Text>
 			    <b:Anchor text="Conditions for using Human Data in Synapse" styleName="link margin-left-5" href="http://docs.synapse.org/articles/governance.html" target="_blank" />
 			    <bh:Text>.</bh:Text>
@@ -40,30 +40,31 @@
 				<bh:Div ui:field="iduReportButtonContainer" pull="RIGHT" addStyleNames="margin-right-5 margin-top-5" />
 				
 				<bh:Div ui:field="cancelRequestButtonContainer" pull="RIGHT">
-					<b:Button ui:field="cancelRequestButton" type="DEFAULT" size="SMALL" text="Cancel Request" visible="false" addStyleNames="margin-right-5 margin-top-5" />
+					<b:Button ui:field="cancelRequestButton" type="DEFAULT" text="Cancel Request" visible="false" addStyleNames="margin-right-5 margin-top-5" />
 				</bh:Div>
 				<bh:Div ui:field="updateRequestButtonContainer" pull="RIGHT">
-					<b:Button ui:field="updateRequestButton" type="DEFAULT" size="SMALL" text="Update Request" visible="false" addStyleNames="margin-right-5 margin-top-5"/>
+					<b:Button ui:field="updateRequestButton" type="DEFAULT" text="Update Request" visible="false" addStyleNames="margin-right-5 margin-top-5"/>
 				</bh:Div>
 				<bh:Div ui:field="requestAccessButtonContainer" pull="RIGHT">
 					<b:Button ui:field="requestAccessButton" type="PRIMARY" text="Request Access" visible="false" addStyleNames="margin-right-5 margin-top-5"/>
 					<b:Button ui:field="loginButton" type="PRIMARY" text="Request Access" visible="false" addStyleNames="margin-right-5 margin-top-5"/>
 				</bh:Div>
 				<bh:Div ui:field="requestSubmittedByOther" visible="false">
-					<b:Alert type="INFO" text="Data access has been requested on your behalf by:" pull="RIGHT" addStyleNames="small-alert margin-top-5 margin-right-2">
+					<b:Alert type="INFO" text="Data access has been requested on your behalf by:" pull="RIGHT" addStyleNames="padding-5 margin-top-5 margin-right-2">
 						<bh:Div ui:field="submitterUserBadgeContainer" />
 					</b:Alert>
 				</bh:Div>
 				
-				<b:Alert type="INFO" ui:field="requestSubmittedMessage" text="You have submitted a data access request." pull="RIGHT" visible="false" addStyleNames="small-alert margin-top-5 margin-right-2"/>
-				<b:Alert type="SUCCESS" ui:field="requestApprovedMessage" pull="RIGHT" visible="false" addStyleNames="small-alert margin-top-5 margin-right-2">
+				<b:Alert type="INFO" ui:field="requestSubmittedMessage" text="You have submitted a data access request." pull="RIGHT" visible="false" marginRight="5" addStyleNames="padding-5 margin-top-5"/>
+				<b:Alert type="SUCCESS" ui:field="requestApprovedMessage" pull="RIGHT" visible="false" marginRight="5" addStyleNames="padding-5 margin-top-5">
+					<b:Icon ui:field="icon" addStyleNames="font-size-17 black-25-percent" type="CHECK_CIRCLE" />
 					<bh:Text>Your data access request has been approved.</bh:Text>
 					<bh:Span ui:field="expirationUI" addStyleNames="margin-left-10">
 						<bh:Text>Access expires on </bh:Text>
 						<bh:Text ui:field="expirationDateText"/>
 					</bh:Span>
 				</b:Alert>
-				<b:Alert type="WARNING" ui:field="requestRejectedMessage" text="" pull="RIGHT" visible="false" addStyleNames="small-alert margin-top-5 margin-right-2"/>
+				<b:Alert type="WARNING" ui:field="requestRejectedMessage" text="" pull="RIGHT" visible="false" marginRight="5" addStyleNames="padding-5 margin-top-5"/>
 			</bh:Div>
 			<bh:ClearFix />
 			<bh:Div ui:field="requestDataAccessWizardContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/SelfSignAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/SelfSignAccessRequirementWidgetViewImpl.ui.xml
@@ -4,13 +4,13 @@
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	<ui:with field='icons' type='org.sagebionetworks.web.client.IconsImageBundle'/>
-	<b:Panel>
+	<b:Panel marginBottom="0">
 		<b:PanelBody>
 			<bh:Div ui:field="approvedHeading" visible="false">
-			    <g:InlineLabel styleName="boldText" text="Access Requirements Fulfilled:  You have access to these data under the following terms:" />
+				<g:InlineLabel styleName="boldText" text="You have accepted the following terms in order to access these data:" />
 			</bh:Div>
 			<bh:Div ui:field="unapprovedHeading">
-			    <g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and agree to the following terms and conditions:" />
+				<g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and agree to the following terms and conditions:" />
 			</bh:Div>
 			<b:BlockQuote>
 				<g:SimplePanel ui:field="wikiContainer" />
@@ -27,6 +27,14 @@
 				<bh:Div ui:field="subjectsWidgetContainer" pull="LEFT" addStyleNames="margin-left-5 margin-right-5" />
 				<bh:Div ui:field="editAccessRequirementContainer" pull="RIGHT" addStyleNames="margin-right-5"/>
 				<bh:Div ui:field="deleteAccessRequirementContainer" pull="RIGHT" addStyleNames="margin-right-5" />
+				<b:Alert ui:field="approvedAlert" type="SUCCESS" pull="RIGHT" addStyleNames="padding-5" marginRight="35">
+					<bh:Span>
+						<b:Icon ui:field="icon" addStyleNames="font-size-17 black-25-percent" type="CHECK_CIRCLE" />
+						<bh:Span marginRight="10">
+							Terms of Use Accepted
+						</bh:Span>
+					</bh:Span>
+				</b:Alert>
 			</bh:Div>
 			<bh:ClearFix />
 		</b:PanelBody>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/TermsOfUseAccessRequirementWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/TermsOfUseAccessRequirementWidgetViewImpl.ui.xml
@@ -4,22 +4,22 @@
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 	<ui:with field='icons' type='org.sagebionetworks.web.client.IconsImageBundle'/>
-	<b:Panel>
+	<b:Panel marginBottom="0">
 		<b:PanelBody>
 			<bh:Div ui:field="approvedHeading" visible="false">
-			    <g:InlineLabel styleName="boldText" text="Access Requirements Fulfilled:  You have access to these data under the following terms:" />
+				<g:InlineLabel styleName="boldText" text="You have accepted the following terms in order to access these data:" />
 			</bh:Div>
 			<bh:Div ui:field="unapprovedHeading">
-			    <g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and agree to the following terms and conditions:" />
+				<g:InlineLabel styleName="boldText" text="Access to the data requires that you are a registered Synapse user and agree to the following terms and conditions:" />
 			</bh:Div>
 			<!-- terms -->
 			<b:BlockQuote ui:field="wikiTermsUI" visible="false">
 				<g:SimplePanel ui:field="wikiContainer" />	
 			</b:BlockQuote>
 			<b:BlockQuote ui:field="termsUI" visible="false">
-			    <bh:Paragraph>
-			    	<g:HTML ui:field="terms" styleName="font-size-14" />
-			    </bh:Paragraph>
+				<bh:Paragraph>
+					<g:HTML ui:field="terms" styleName="font-size-14" />
+				</bh:Paragraph>
 			</b:BlockQuote>
 			<bh:ClearFix />
 			<bh:Div addStyleNames="margin-top-5">
@@ -29,6 +29,14 @@
 				<bh:Div ui:field="subjectsWidgetContainer" pull="LEFT" addStyleNames="margin-left-5 margin-right-5" />
 				<bh:Div ui:field="editAccessRequirementContainer" pull="RIGHT" addStyleNames="margin-right-5"/>
 				<bh:Div ui:field="deleteAccessRequirementContainer" pull="RIGHT" addStyleNames="margin-right-5" />
+				<b:Alert ui:field="approvedAlert" type="SUCCESS" pull="RIGHT" addStyleNames="padding-5" marginRight="35">
+					<bh:Span>
+						<b:Icon ui:field="icon" addStyleNames="font-size-17 black-25-percent" type="CHECK_CIRCLE" />
+						<bh:Span marginRight="10">
+							Terms of Use Accepted
+						</bh:Span>
+					</bh:Span>
+				</b:Alert>
 			</bh:Div>
 			<bh:ClearFix />
 		</b:PanelBody>


### PR DESCRIPTION
show success (if signed self-signed ToU type), and add line between access requirements to make it clear there's more than one