### PR TITLE
PORTALS-494: leave portals config cookie until...

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/mvp/AppActivityMapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/mvp/AppActivityMapper.java
@@ -11,6 +11,8 @@ import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
+import org.sagebionetworks.web.client.cookie.CookieKeys;
+import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.place.AccessRequirementsPlace;
 import org.sagebionetworks.web.client.place.Challenges;
 import org.sagebionetworks.web.client.place.ChangeUsername;
@@ -132,7 +134,13 @@ public class AppActivityMapper implements ActivityMapper {
 		}
 		
 		isFirstTime = false;
-		
+
+		// PORTALS-441: remove the portals cookie on place change, unless user is in transition (registering, password reset, ...)
+		CookieProvider cookies = ginjector.getCookieProvider();
+		if (cookies.getCookie(CookieKeys.PORTAL_CONFIG) != null && !excludeFromLastPlace.contains(place.getClass())) {
+			cookies.removeCookie(CookieKeys.PORTAL_CONFIG);
+		}
+
 		// If the user is not logged in then we redirect them to the login screen
 		// except for the fully public places
 		if(!openAccessPlaces.contains(place.getClass())) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/header/Header.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/header/Header.java
@@ -83,7 +83,6 @@ public class Header implements HeaderView.Presenter, IsWidget {
 		
 		if (cookies.getCookie(CookieKeys.PORTAL_CONFIG) != null) {
 			view.showPortalAlert(cookies.getCookie(CookieKeys.PORTAL_CONFIG));
-			cookies.removeCookie(CookieKeys.PORTAL_CONFIG);
 		}
 	}
 	


### PR DESCRIPTION
keep showing the bumper bar until user makes it out of a transition page (like registration, or login, or password reset)