### PR TITLE
PORTALS-591: set repo and swc SRC endpoints

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.web.client;
 
 import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEntryPoint;
 import static org.sagebionetworks.web.client.cookie.CookieKeys.SHOW_DATETIME_IN_UTC;
+import static org.sagebionetworks.web.shared.WebConstants.REPO_SERVICE_URL_KEY;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -476,6 +477,15 @@ public class GlobalApplicationStateImpl implements GlobalApplicationState {
 	
 	private void initStep2(Callback finalCallback) {
 		view.initGlobalViewProperties();
+		
+		String repoServiceUrl = synapseProperties.getSynapseProperty(REPO_SERVICE_URL_KEY);
+		String repoUrl = repoServiceUrl.substring(0, repoServiceUrl.indexOf("/repo/")) + "/";
+		String portalUrl = gwt.getHostPrefix();
+		if (!portalUrl.endsWith("/")) {
+			portalUrl += "/";
+		}
+		view.initSRCEndpoints(repoUrl, portalUrl);
+		
 		String showInUTC = cookieProvider.getCookie(SHOW_DATETIME_IN_UTC);
 		if (showInUTC != null) {
 			setShowUTCTime(Boolean.parseBoolean(showInUTC));

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateView.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateView.java
@@ -6,4 +6,5 @@ public interface GlobalApplicationStateView {
 	void initGlobalViewProperties();
 	void showGetVersionError(String error);
 	void back();
+	void initSRCEndpoints(String repoEndpoint, String portalEndpoint);
 }

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateViewImpl.java
@@ -29,6 +29,25 @@ public class GlobalApplicationStateViewImpl implements
 		options.setAnimate(false);
 		Bootbox.setDefaults(options);
 	}
+
+	@Override
+	public void initSRCEndpoints(String repoEndpoint, String portalEndpoint ) {
+		_initSRCEndpoints(repoEndpoint, portalEndpoint);
+	}
+	private final static native void _initSRCEndpoints(
+			String repoEndpoint,
+			String portalEndpoint
+			) /*-{
+		try {
+			$wnd.SRC.OVERRIDE_ENDPOINT_CONFIG = {
+				REPO: repoEndpoint,
+				PORTAL: portalEndpoint,
+			}
+		} catch (err) {
+			console.error(err);
+		}
+	}-*/;
+
 	
 	public void preloadNewVersion() {
 		//preload, after a (10 minute) delay

--- a/src/test/java/org/sagebionetworks/web/unitclient/GlobalApplicationStateImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/GlobalApplicationStateImplTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.unitclient;
 
+import static org.sagebionetworks.web.shared.WebConstants.REPO_SERVICE_URL_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,6 +80,9 @@ public class GlobalApplicationStateImplTest {
 	ArgumentCaptor<Callback> synapsePropertiesInitCallbackCaptor;
 	@Mock
 	SessionStorage mockSessionStorage;
+	public static final String REPO_ENDPOINT = "https://repo-staging.prod.sagebase.org/";
+	public static final String SWC_ENDPOINT = "https://staging.synapse.org/";
+	
 	@Before
 	public void before(){
 		MockitoAnnotations.initMocks(this);
@@ -93,6 +97,8 @@ public class GlobalApplicationStateImplTest {
 		globalApplicationState = new GlobalApplicationStateImpl(mockView, mockCookieProvider, mockEventBus, mockStackConfigService, mockSynapseJSNIUtils, mockLocalStorage, mockGWT, mockDateTimeUtils, mockJsClient, mockSynapseProperties, mockSessionStorage);
 		globalApplicationState.setPlaceController(mockPlaceController);
 		globalApplicationState.setAppPlaceHistoryMapper(mockAppPlaceHistoryMapper);
+		when(mockSynapseProperties.getSynapseProperty(REPO_SERVICE_URL_KEY)).thenReturn(REPO_ENDPOINT + "repo/v1");
+		when(mockGWT.getHostPrefix()).thenReturn(SWC_ENDPOINT);
 	}
 	
 	/**
@@ -263,6 +269,7 @@ public class GlobalApplicationStateImplTest {
 		verifyAndInvokeSynapsePropertiesInitCallback();
 		
 		verify(mockView).initGlobalViewProperties();
+		verify(mockView).initSRCEndpoints(REPO_ENDPOINT, SWC_ENDPOINT);
 		verify(mockCallback).invoke();
 	}
 	


### PR DESCRIPTION
Fix for stack-286 (latest version of SRC requires endpoint override based on properties filled in by build)