### PR TITLE
Remove unused synapse client method

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
@@ -53,8 +53,6 @@ public interface SynapseClient extends RemoteService {
 
 	PaginatedResults<TrashedEntity> viewTrashForUser(long offset, long limit) throws RestServiceException;
 
-	void purgeTrashForUser() throws RestServiceException;
-
 	void purgeMultipleTrashedEntitiesForUser(Set<String> entityIds) throws RestServiceException;
 
 	/**

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
@@ -177,8 +177,6 @@ public interface SynapseClientAsync {
 	 */
 	void validateTableQuery(String sql, AsyncCallback<Void> callback);
 
-	void purgeTrashForUser(AsyncCallback<Void> callback);
-
 	void restoreFromTrash(String entityId, String newParentId, AsyncCallback<Void> callback);
 
 	void viewTrashForUser(long offset, long limit, AsyncCallback<PaginatedResults<TrashedEntity>> callback);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -266,16 +266,6 @@ public class SynapseClientImpl extends SynapseClientBase implements SynapseClien
 	}
 
 	@Override
-	public void purgeTrashForUser() throws RestServiceException {
-		try {
-			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();
-			synapseClient.purgeTrashForUser();
-		} catch (SynapseException e) {
-			throw ExceptionUtil.convertSynapseException(e);
-		}
-	}
-
-	@Override
 	public void purgeMultipleTrashedEntitiesForUser(Set<String> entityIds) throws RestServiceException {
 		try {
 			org.sagebionetworks.client.SynapseClient synapseClient = createSynapseClient();


### PR DESCRIPTION
Small PR due to https://sagebionetworks.jira.com/browse/PLFM-5932 we removed an old and deprecated API call. I removed it from the synapse client as I noticed it was not used in the web client.