### PR TITLE
SWC-5185: glyphicon-remove was undefined in version of bootstrap being pulled into SWC.

### DIFF
--- a/src/main/webapp/sass/swc.scss
+++ b/src/main/webapp/sass/swc.scss
@@ -2138,6 +2138,10 @@ ul, ol {
 	margin-bottom: 0px !important;
 }
 
+#body .glyphicon-remove:before {
+	content: "\f00d";
+}
+
 /*
  * Off Canvas
  * --------------------------------------------------


### PR DESCRIPTION
It's also undefined in Font-Awesome at that offset in the font file (this content change is actually to the font-awesome font definition)