### PR TITLE
SWC-5258: use cell renderer in multi-value cell editor

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorView.java
@@ -1,8 +1,11 @@
 package org.sagebionetworks.web.client.widget.table.v2.results.cell;
 
+import org.sagebionetworks.repo.model.table.ColumnModel;
+
 public interface JSONListCellEditorView extends CellEditorView {
 	public interface Presenter{
 		void onEditButtonClick();
+		ColumnModel getColumnModel();
 	}
 
 	void setPresenter(Presenter editor);

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.java
@@ -5,7 +5,6 @@ import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Div;
-import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.shared.GwtEvent;
@@ -49,6 +48,7 @@ public class JSONListCellEditorViewImpl implements JSONListCellEditorView {
 	public JSONListCellEditorViewImpl(Binder binder, CellFactory cellFactory) {
 		widget = binder.createAndBindUi(this);
 		this.cellFactory = cellFactory;
+		rendererFocusPanel.getElement().setAttribute("readonly", "true");
 		// users want us to select all on focus see SWC-2213
 		rendererFocusPanel.addClickHandler(clickEvent -> presenter.onEditButtonClick() );
 		editButton.addClickHandler(clickEvent -> presenter.onEditButtonClick());

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.ui.xml
@@ -9,9 +9,11 @@
 	<b:FormGroup ui:field="formGroup"
 		addStyleNames="margin-bottom-0-imp">
 		<b:InputGroup width="100%" addStyleNames="show-icon-on-hover">
-			<b:TextBox ui:field="textBox" styleName="form-control min-width-140 cursor-pointer" readOnly="true"/>
+			<g:FocusPanel ui:field="rendererFocusPanel" addStyleNames="form-control min-width-140 cursor-pointer">
+				<bh:Div ui:field="rendererContainer"/>
+			</g:FocusPanel>
 			<b:Icon ui:field="editButton" type="PENCIL"
-					addStyleNames="synapse-blue imageButton topLevelZIndex" marginLeft="-20" paddingTop="10"/>
+					addStyleNames="synapse-blue imageButton topLevelZIndex"/>
 		</b:InputGroup>
 		<b:HelpBlock ui:field="helpBlock" visible="false" />
 	</b:FormGroup>

--- a/src/main/webapp/sass/swc.scss
+++ b/src/main/webapp/sass/swc.scss
@@ -3193,5 +3193,8 @@ div.border {
 
 	&:hover i {
 		display: inline-block;
+		position: absolute;
+		right: 5px;
+		top: 10px;
 	}
 }


### PR DESCRIPTION
With the exception of UserIDList and EntityIDList, which renders links (which interfere with multi-value editor modal CTA)