### PR TITLE
Change invalid char

### DIFF
--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
@@ -774,7 +774,7 @@ public class UploaderTest {
 
 	@Test
 	public void testUploadIllegalName() {
-		String[] files = {"test'.txt"};
+		String[] files = {"test&.txt"};
 		uploader.setFileNames(files);
 		uploader.uploadBasedOnConfiguration();
 		verify(mockView).showErrorMessage(DisplayConstants.ERROR_UPLOAD_TITLE, WebConstants.INVALID_ENTITY_NAME_MESSAGE);


### PR DESCRIPTION
[SWC-5315] The regular exp org.sagebionetworks.repo.model.util.ModelConstants#VALID_ENTITY_NAME_REGEX used in org.sagebionetworks.web.client.widget.entity.download.Uploader#validateFileName() includes "'".
Just changed the name used to trigger the error to include "&" instead of "'"

[SWC-5315]: https://sagebionetworks.jira.com/browse/SWC-5315