### PR TITLE
SWC-5343: always bump version when uploading a new file/version

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -1090,7 +1090,7 @@ public class SynapseClientImpl extends SynapseClientBase implements SynapseClien
 				fileEntity = (FileEntity) synapseClient.getEntityById(entityId);
 				// update data file handle id
 				fileEntity.setDataFileHandleId(fileHandleId);
-				fileEntity = synapseClient.putEntity(fileEntity);
+				fileEntity = synapseClient.putEntity(fileEntity, null, true);
 			}
 			return fileEntity.getId();
 		} catch (SynapseException e) {


### PR DESCRIPTION
Leaving as a draft PR since attempting to upload the same file (renamed) results in an error like:
org.springframework.dao.DuplicateKeyException: PreparedStatementCallback; SQL [INSERT INTO JDOREVISION(`OWNER_NODE_ID`, `NUMBER`, `ACTIVITY_ID`, `LABEL`, `COMMENT`, `MODIFIED_BY`, `MODIFIED_ON`, `FILE_HANDLE_ID`, `COLUMN_MODEL_IDS`, `SCOPE_IDS`, `ENTITY_PROPERTY_ANNOTATIONS`, `REFERENCE`, `USER_ANNOTATIONS`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]; Duplicate entry '12973407-1' for key 'UNIQUE_REVISION_LABEL'; nested exception is java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '12973407-1' for key 'UNIQUE_REVISION_LABEL'
