### PR TITLE
SWC-5364

### DIFF
--- a/src/main/webapp/sass/swc.scss
+++ b/src/main/webapp/sass/swc.scss
@@ -227,6 +227,18 @@ end sticky footer
 	input[type="checkbox"], input[type="radio"] {
 		display:none;
 	}
+
+	.radio {
+		display: flex;
+		flex-wrap: nowrap;
+	}
+
+	.checkbox>label {
+		display: flex;
+		flex-wrap: nowrap;
+		margin-bottom: 10px;
+	}
+
 	.checkbox>label::before, .radio::before, .radio-inline::before {
 		content: "";
 		display: inline-block;
@@ -237,6 +249,8 @@ end sticky footer
 		border-radius: 2px;
 		background: radial-gradient(white, #eee);
 		margin-right: 5px;
+		margin-top: 3px;
+		flex-shrink: 0;
 	}
 	
 	.radio::before {
@@ -266,7 +280,6 @@ end sticky footer
 	.radio-inline input[type="radio"]:checked + label::before, .radio-inline input[type="radio"]:checked + span::before {
 		content: "";
 		display: inline-block;
-		vertical-align: middle;
 		width: 10px;
 		height: 10px;
 		border-radius: 50%;


### PR DESCRIPTION
Our custom checkboxes and radio buttons would wrap in such a way that label text would end up below the button, instead of with a 'hanging indent' style. 

This was fixed by converting the checkbox/radio div wrappers to flex containers, preventing flex wrap, and disabling shrink on the buttons. Some other tweaks were added to ensure the "selected" icons still lined up correctly. Checked on FF/Chrome/Safari/Edge

The issue is easiest to see here:

Before:
![image](https://user-images.githubusercontent.com/17580037/103933642-b6413800-50f1-11eb-8176-f4f8d0c3c82b.png)


After:
![image](https://user-images.githubusercontent.com/17580037/103933422-5c407280-50f1-11eb-9c95-6249bcdcb653.png)

