### PR TITLE
SWC-5572

### DIFF
--- a/src/main/webapp/css/bootstrap-custom-theme.min.css
+++ b/src/main/webapp/css/bootstrap-custom-theme.min.css
@@ -5268,8 +5268,6 @@ button.close {
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 5px;
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   outline: 0;
 }
 .modal-backdrop {
@@ -5328,8 +5326,6 @@ button.close {
     margin: 30px auto;
   }
   .modal-content {
-    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
   .modal-sm {
     width: 300px;

--- a/src/main/webapp/research/bootstrap-3.3.5/css/bootstrap.css
+++ b/src/main/webapp/research/bootstrap-3.3.5/css/bootstrap.css
@@ -5956,8 +5956,6 @@ button.close {
   border: 1px solid rgba(0, 0, 0, .2);
   border-radius: 6px;
   outline: 0;
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
-          box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
 }
 .modal-backdrop {
   position: fixed;
@@ -6020,8 +6018,6 @@ button.close {
     margin: 30px auto;
   }
   .modal-content {
-    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
-            box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
   }
   .modal-sm {
     width: 300px;

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -2213,6 +2213,15 @@ Looks for any child element under .modal-fullscreen that has a class that contai
 	width: 90%;
 }
 
+/*
+ The opaque modal backdrop doesn't work for nested modals i.e. a modal does not obscure another modal.
+  We can simulate the effect with a very large box shadow
+*/
+.modal-content {
+    -webkit-box-shadow: 0px 0px 5000px 5000px rgba(0, 0, 0, .5);
+    box-shadow: 0px 0px 5000px 5000px rgba(0, 0, 0, .5);
+}
+
 .gwt-TreeItem-selected [class*="link"] {
 	text-decoration: underline;
 }


### PR DESCRIPTION
Currently, when we have nested modals (one modal creates another modal), the newer modal doesn't obscure the previous modal. This is because the z-index of all modals is 1050, and the z-index of the modal "screen" is 1040. Rather than changing these (which could be hard to manage), we can add a large box shadow to all modals and get an obscuring effect that layers appropriately.

Before:
![image](https://user-images.githubusercontent.com/17580037/116290393-68644480-a761-11eb-9031-309cbe4cd9fe.png)

After: 
![image](https://user-images.githubusercontent.com/17580037/116290280-508cc080-a761-11eb-8b94-df274c260130.png)
