### PR TITLE
SWC-5583

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2Impl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2Impl.java
@@ -113,8 +113,6 @@ public class EntityFinderV2Impl implements EntityFinder, EntityFinderV2View.Pres
         } catch (WebClientConfigurationException e) {
             synAlert.handleException(e);
         }
-
-        renderComponent();
     }
 
     public static class Builder implements EntityFinder.Builder {
@@ -324,7 +322,7 @@ public class EntityFinderV2Impl implements EntityFinder, EntityFinderV2View.Pres
     @Override
     public void show() {
         view.clear();
-        view.show();
+        renderComponent();
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2View.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2View.java
@@ -16,8 +16,6 @@ public interface EntityFinderV2View extends SynapseView {
 	 */
 	void setPresenter(Presenter presenter);
 
-	void show();
-
 	void hide();
 
 	void renderComponent(EntityFinderScope initialScope, EntityFinder.InitialContainer initialContainer, String initialProject, String initialContainerId, boolean showVersions, boolean multiSelect, EntityFilter selectableTypes, EntityFilter visibleTypesInList, EntityFilter visibleTypesInTree, String selectedCopy, boolean treeOnly);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2View.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2View.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.SynapseView;
-import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 
 import com.google.gwt.user.client.ui.Widget;
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2ViewImpl.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.web.client.utils.JavaScriptArrayUtils.convertT
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.gwtbootstrap3.client.ui.Button;
@@ -137,7 +138,8 @@ public class EntityFinderV2ViewImpl implements EntityFinderV2View {
 							presenter.clearSelectedEntities();
 						}
 					}
-				});
+				},
+				() -> modal.show());
 	}
 
 	@Override
@@ -173,8 +175,7 @@ public class EntityFinderV2ViewImpl implements EntityFinderV2View {
 
 	@Override
 	public void show() {
-		// show modal
-		modal.show();
+		// render component will show modal
 		presenter.renderComponent();
 		helpWidget.focus();
 	}
@@ -210,7 +211,7 @@ public class EntityFinderV2ViewImpl implements EntityFinderV2View {
 		this.okButton.setText(confirmButtonCopy);
 	}
 
-	private static native void _showEntityFinderReactComponent(Element el, String sessionToken, String projectId, String initialContainer, String initialScope, JsArrayString selectableTypes, JsArrayString visibleTypesInList, JsArrayString visibleTypesInTree, boolean showVersions, boolean multiSelect, String selectedCopy, boolean treeOnly, OnSelectCallback onSelectedCallback) /*-{
+	private static native void _showEntityFinderReactComponent(Element el, String sessionToken, String projectId, String initialContainer, String initialScope, JsArrayString selectableTypes, JsArrayString visibleTypesInList, JsArrayString visibleTypesInTree, boolean showVersions, boolean multiSelect, String selectedCopy, boolean treeOnly, OnSelectCallback onSelectedCallback, Runnable onRender) /*-{
 		try {
 			var callback = function(selected) {
 				onSelectedCallback.@org.sagebionetworks.web.client.callback.OnSelectCallback::onSelect(Lcom/google/gwt/core/client/JsArray;)(selected)
@@ -231,7 +232,8 @@ public class EntityFinderV2ViewImpl implements EntityFinderV2View {
 			};
 			$wnd.ReactDOM.render(
 				$wnd.React.createElement($wnd.SRC.SynapseComponents.EntityFinder, props, null),
-				el
+				el,
+				function() { onRender.@java.lang.Runnable::run()() }
 			);
 		} catch (err) {
 			console.error(err);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderV2ViewImpl.java
@@ -4,7 +4,6 @@ import static org.sagebionetworks.web.client.utils.JavaScriptArrayUtils.convertT
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.gwtbootstrap3.client.ui.Button;
@@ -171,13 +170,6 @@ public class EntityFinderV2ViewImpl implements EntityFinderV2View {
 	@Override
 	public void clearError() {
 		synAlert.clear();
-	}
-
-	@Override
-	public void show() {
-		// render component will show modal
-		presenter.renderComponent();
-		helpWidget.focus();
 	}
 
 	@Override


### PR DESCRIPTION
Before this, the react component would render after the modal was shown. Because the modal's size depends on its contents, it would appear small and then immediately become large, which was distracting. See clip in [the issue](https://sagebionetworks.jira.com/browse/SWC-5583).

In this change, we show the modal after the ReactDOM.render call completes (via a callback). The modal immediately appears with the final width.