### PR TITLE
Use a global react-query QueryClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
   "dependencies": {
-    "jquery": "3.5.1",    
-    "jsplumb": "2.13.2",
-    "font-awesome": "4.7.0",
-    "pica": "6.0.0",    
     "croppie": "2.6.5",
-  	"react": "16.13.1",
-  	"react-dom": "16.13.1",
-    "sass": "1.32.5",
-    "sanitize-html": "^1.18.4",
-    "synapse-react-client": "2.0.0",
-    "react-transition-group": "2.6.0",
-    "react-measure": "2.2.2",
-    "react-tooltip": "3.11.2",
-    "react-jsonschema-form": "^1.7.0",
-    "universal-cookie": "^4.0.3",
+    "font-awesome": "4.7.0",
+    "jquery": "3.5.1",
+    "jsplumb": "2.13.2",
+    "pica": "6.0.0",
+    "prop-types": "15.6.2",
+    "react": "16.13.1",
     "react-bootstrap": "^1.0.0-beta.12",
-    "prop-types": "15.6.2"
+    "react-dom": "16.13.1",
+    "react-jsonschema-form": "^1.7.0",
+    "react-measure": "2.2.2",
+    "react-query": "^3.17.0",
+    "react-tooltip": "3.11.2",
+    "react-transition-group": "2.6.0",
+    "sanitize-html": "^1.18.4",
+    "sass": "1.32.5",
+    "synapse-react-client": "2.0.0",
+    "universal-cookie": "^4.0.3"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,7 @@
 								<copy file="${project.basedir}/node_modules/react-measure/dist/index.umd.js" tofile="src/main/webapp/generated/react-measure.js" />
 								<copy file="${project.basedir}/node_modules/react-tooltip/standalone/react-tooltip.min.js" tofile="src/main/webapp/generated/react-tooltip.min.js" />
 								<copy file="${project.basedir}/node_modules/react-jsonschema-form/dist/react-jsonschema-form.js" tofile="src/main/webapp/generated/react-jsonschema-form.js" />
+								<copy file="${project.basedir}/node_modules/react-query/dist/react-query.production.min.js" tofile="src/main/webapp/generated/react-query.production.min.js" />
 								<copy file="${project.basedir}/node_modules/universal-cookie/umd/universalCookie.min.js" tofile="src/main/webapp/generated/universalCookie.min.js" />
 								<copy file="${project.basedir}/node_modules/react-bootstrap/dist/react-bootstrap.min.js" tofile="src/main/webapp/generated/react-bootstrap.min.js" />
 								<copy file="${project.basedir}/node_modules/sanitize-html/dist/sanitize-html.min.js" tofile="src/main/webapp/generated/sanitize-html.min.js" />

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.web.client.jsni.SynapseContextProviderPropsJSNIObject
  */
 public interface SynapseContextPropsProvider {
     /**
-     * Provides props for {@link org.sagebionetworks.web.client.jsinterop.SRC.SynapseComponents#SynapseContextProvider}.
+     * Provides props for {@link org.sagebionetworks.web.client.jsinterop.SRC.SynapseContext#SynapseContextProvider}.
      * Typically, props will be supplied to {@link org.sagebionetworks.web.client.jsinterop.React#createElementWithSynapseContext(ReactFunctionComponent, ReactComponentProps, SynapseContextProviderProps)}
      */
     SynapseContextProviderProps getJsInteropContextProps();

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
@@ -7,31 +7,45 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextJsObject;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextProviderProps;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClientOptions;
+import org.sagebionetworks.web.client.jsni.QueryClientJSNIObject;
 import org.sagebionetworks.web.client.jsni.SynapseContextJSNIObject;
 import org.sagebionetworks.web.client.jsni.SynapseContextProviderPropsJSNIObject;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 
-import com.google.gwt.core.client.GWT;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
 
 public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvider {
     private AuthenticationController authController;
     private GlobalApplicationState globalApplicationState;
     private CookieProvider cookies;
 
+    private static QueryClient queryClientSingleton = new QueryClient(QueryClientOptions.create());
+
+    // We save the queryClient in a global variable so we can access it from JSNI
+    @JsProperty(namespace = JsPackage.GLOBAL, name="SynapseQueryClient")
+    static native void setQueryClient(QueryClient queryClient);
+
     @Inject
     SynapseContextPropsProviderImpl(final AuthenticationController authController, final GlobalApplicationState globalApplicationState, final CookieProvider cookies) {
         this.authController = authController;
         this.globalApplicationState = globalApplicationState;
         this.cookies = cookies;
+        setQueryClient(queryClientSingleton);
     }
 
     @Override
     public SynapseContextProviderProps getJsInteropContextProps() {
-        return SynapseContextProviderProps.create(SynapseContextJsObject.create(
-                authController.getCurrentUserAccessToken(),
-                DisplayUtils.isInTestWebsite(cookies),
-                globalApplicationState.isShowingUTCTime()
-        ));
+        return SynapseContextProviderProps.create(
+                SynapseContextJsObject.create(
+                    authController.getCurrentUserAccessToken(),
+                    DisplayUtils.isInTestWebsite(cookies),
+                    globalApplicationState.isShowingUTCTime()
+                ),
+                queryClientSingleton
+        );
     }
 
     @Override
@@ -43,6 +57,7 @@ public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvi
 
         SynapseContextProviderPropsJSNIObject props = SynapseContextProviderPropsJSNIObject.create();
         props.setSynapseContext(synapseContext);
+        props.setQueryClient(QueryClientJSNIObject.getQueryClientSingleton());
         return props;
     }
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseContextProviderProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseContextProviderProps.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.web.client.jsinterop;
 
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
@@ -8,11 +10,13 @@ import jsinterop.annotations.JsType;
 public class SynapseContextProviderProps extends ReactComponentProps {
 
 	public SynapseContextJsObject synapseContext;
+	public QueryClient queryClient;
 
 	@JsOverlay
-	public static SynapseContextProviderProps create(SynapseContextJsObject synapseContext) {
+	public static SynapseContextProviderProps create(SynapseContextJsObject synapseContext, QueryClient queryClient) {
 		SynapseContextProviderProps props = new SynapseContextProviderProps();
 		props.synapseContext = synapseContext;
+		props.queryClient = queryClient;
 		return props;
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/DefaultQueryClientOptions.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/DefaultQueryClientOptions.java
@@ -1,0 +1,21 @@
+package org.sagebionetworks.web.client.jsinterop.reactquery;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name="Object")
+public class DefaultQueryClientOptions {
+    public QueryOptions query;
+
+    @JsOverlay
+    public static DefaultQueryClientOptions create() {
+        DefaultQueryClientOptions defaultQueryClientOptions = new DefaultQueryClientOptions();
+        defaultQueryClientOptions.query = QueryOptions.create();
+        return defaultQueryClientOptions;
+    }
+}
+
+
+

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
@@ -1,0 +1,9 @@
+package org.sagebionetworks.web.client.jsinterop.reactquery;
+
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = "ReactQuery")
+public class QueryClient {
+
+    public QueryClient(QueryClientOptions config) {}
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClientOptions.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClientOptions.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.web.client.jsinterop.reactquery;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name="Object")
+public class QueryClientOptions {
+
+    public DefaultQueryClientOptions defaultOptions;
+
+    @JsOverlay
+    public static QueryClientOptions create() {
+        QueryClientOptions qco = new QueryClientOptions();
+        qco.defaultOptions = DefaultQueryClientOptions.create();
+        return qco;
+    }
+
+}
+

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryOptions.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryOptions.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.web.client.jsinterop.reactquery;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name="Object")
+public class QueryOptions {
+    public Long staleTime;
+    public boolean retry;
+
+    @JsOverlay
+    public static QueryOptions create() {
+        QueryOptions queryOptions = new QueryOptions();
+        // We don't currently need to configure these values
+        queryOptions.staleTime = 30 * 1000L; // 30s
+        queryOptions.retry = false; // SynapseClient knows which queries to retry
+        return queryOptions;
+    }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsni/QueryClientJSNIObject.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsni/QueryClientJSNIObject.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.web.client.jsni;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class QueryClientJSNIObject extends JavaScriptObject {
+
+    protected QueryClientJSNIObject() {
+    }
+
+    public static native QueryClientJSNIObject getQueryClientSingleton() /*-{
+        return $wnd.SynapseQueryClient;
+    }-*/;
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsni/SynapseContextProviderPropsJSNIObject.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsni/SynapseContextProviderPropsJSNIObject.java
@@ -20,5 +20,9 @@ public class SynapseContextProviderPropsJSNIObject extends JavaScriptObject {
         this.synapseContext = context;
     }-*/;
 
+    public final native void setQueryClient(QueryClientJSNIObject queryClient) /*-{
+        this.queryClient = queryClient;
+    }-*/;
+
     // This object also supports setting a react-query query client, but we aren't exposing that for now
 }

--- a/src/main/webapp/Portal.html
+++ b/src/main/webapp/Portal.html
@@ -117,6 +117,7 @@
 			head.load(cdnEndpoint + "generated/react.production.min.js");
 			head.load(cdnEndpoint + "generated/react-dom.production.min.js");
 			head.load(cdnEndpoint + "generated/react-transition-group.min.js");
+			head.load(cdnEndpoint + "generated/react-query.production.min.js");
 			head.load(cdnEndpoint + "generated/prop-types.min.js");
 			head.load(cdnEndpoint + "generated/react-measure.js");
 			head.load(cdnEndpoint + "generated/react-tooltip.min.js");

--- a/yarn.lock
+++ b/yarn.lock
@@ -9781,6 +9781,15 @@ react-plotlyjs-ts@^2.2.1:
   dependencies:
     lodash "^4.17.4"
 
+react-query@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.17.0.tgz#461c0a030044760cd874c7ea8aa9d55c2dceb15d"
+  integrity sha512-/qUNb6ESCz75Z/bR5p/ztp5ipRj8IQSiIpHK3AkCLTT4IqZsceAoD+9B+wbitA0LkxsR3snGrpgKUc9MMYQ/Ow==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-query@^3.9.8:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.12.1.tgz#6d60f32f368734fe03fd7d1a291a7715f4488c12"


### PR DESCRIPTION
Creating a single query client and passing that in to our context object gives us the benefits of a shared query client despite components living in separate component trees.