### PR TITLE
SWC-5749

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,10 @@
 								<copy file="${project.basedir}/node_modules/font-awesome/fonts/fontawesome-webfont.woff" tofile="src/main/webapp/fonts/fontawesome-webfont.woff" />
 								<copy file="${project.basedir}/node_modules/font-awesome/fonts/fontawesome-webfont.woff2" tofile="src/main/webapp/fonts/fontawesome-webfont.woff2" />
 								<copy file="${project.basedir}/node_modules/font-awesome/fonts/fontawesome-webfont.ttf" tofile="src/main/webapp/fonts/fontawesome-webfont.ttf" />
+								<!-- Copy development versions of some key dependencies for devmode debugging -->
+								<copy file="${project.basedir}/node_modules/react/umd/react.development.js" tofile="src/main/webapp/generated/react.development.js" />
+								<copy file="${project.basedir}/node_modules/react-dom/umd/react-dom.development.js" tofile="src/main/webapp/generated/react-dom.development.js" />
+								<copy file="${project.basedir}/node_modules/react-query/dist/react-query.development.js" tofile="src/main/webapp/generated/react-query.development.js" />
 							</target>
 						</configuration>
 					</execution>

--- a/src/main/webapp/Portal.html
+++ b/src/main/webapp/Portal.html
@@ -114,10 +114,16 @@
 			head.load(cdnEndpoint + "js/xss.min.js");
 			head.load(cdnEndpoint + "generated/pica.min.js");
 			head.load("//www.google-analytics.com/analytics.js");
-			head.load(cdnEndpoint + "generated/react.production.min.js");
-			head.load(cdnEndpoint + "generated/react-dom.production.min.js");
+			if (processEnvironment === "production") {
+				head.load(cdnEndpoint + "generated/react.production.min.js");
+				head.load(cdnEndpoint + "generated/react-dom.production.min.js");
+				head.load(cdnEndpoint + "generated/react-query.production.min.js");
+			} else {
+				head.load(cdnEndpoint + "generated/react.development.js");
+				head.load(cdnEndpoint + "generated/react-dom.development.js");
+				head.load(cdnEndpoint + "generated/react-query.development.js");
+			}
 			head.load(cdnEndpoint + "generated/react-transition-group.min.js");
-			head.load(cdnEndpoint + "generated/react-query.production.min.js");
 			head.load(cdnEndpoint + "generated/prop-types.min.js");
 			head.load(cdnEndpoint + "generated/react-measure.js");
 			head.load(cdnEndpoint + "generated/react-tooltip.min.js");


### PR DESCRIPTION
In devmode, use development versions of react, react-dom, react-query. We can easily add more to this list.

We should also emit a development build for SRC and then include it here.