### PR TITLE
SWC-5754: hide project UI and tabs if project entity cannot be loaded

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
@@ -1,7 +1,7 @@
 package org.sagebionetworks.web.client.widget.entity;
 
 import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEntryPoint;
-import org.gwtbootstrap3.client.ui.constants.IconType;
+
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.FileEntity;
@@ -39,6 +39,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
 import org.sagebionetworks.web.client.widget.entity.tabs.TablesTab;
 import org.sagebionetworks.web.client.widget.entity.tabs.Tabs;
 import org.sagebionetworks.web.client.widget.entity.tabs.WikiTab;
+
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -327,7 +328,7 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget {
 				projectBundle = filesEntityBundle = tablesEntityBundle = dockerEntityBundle = bundle;
 				projectTitleBar.configure(projectBundle);
 				projectMetadata.configure(projectBundle, null, projectActionMenu);
-
+				view.setProjectUIVisible(true);
 				initAreaToken();
 				showSelectedTabs();
 				updateEntityBundle(currentTargetEntityBundle, currentTargetVersionNumber);
@@ -335,10 +336,12 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget {
 
 			@Override
 			public void onFailure(Throwable caught) {
+				projectTitleBar.clearState();
 				view.setProjectLoadingVisible(false);
+				view.setProjectUIVisible(false);
 				projectBundleLoadError = caught;
 				updateEntityBundle(currentTargetEntityBundle, currentTargetVersionNumber);
-				showSelectedTabs();
+				tabs.setNavTabsVisible(false);
 			}
 		};
 		if (projectHeader.getId().equals(currentTargetEntityBundle.getEntity().getId())) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopView.java
@@ -13,6 +13,7 @@ public interface EntityPageTopView extends IsWidget, SynapseView {
 	void setProjectActionMenu(Widget w);
 
 	void setProjectLoadingVisible(boolean visible);
+	void setProjectUIVisible(boolean visible);
 
 	void scrollToTop();
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.client.widget.entity;
 
+import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.DisplayUtils;
@@ -31,6 +32,8 @@ public class EntityPageTopViewImpl extends Composite implements EntityPageTopVie
 	SimplePanel projectMetadataContainer;
 	@UiField
 	Span projectActionMenuContainer;
+	@UiField
+	Row projectUI;
 
 	@Inject
 	public EntityPageTopViewImpl(Binder uiBinder) {
@@ -100,5 +103,9 @@ public class EntityPageTopViewImpl extends Composite implements EntityPageTopVie
 	@Override
 	public EventBinder<EntityPageTop> getEventBinder() {
 		return eventBinder;
+	}
+	@Override
+	public void setProjectUIVisible(boolean visible) {
+		projectUI.setVisible(visible);
 	}
 }

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
@@ -1,3 +1,4 @@
+
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
 	xmlns:g="urn:import:com.google.gwt.user.client.ui"
@@ -8,7 +9,7 @@
 	<g:HTMLPanel>
 		<!--Project level information -->
 		<bh:Div addStyleNames="pageHeader min-height-48 padding-left-15 padding-right-15">
-			<b:Row addStyleNames="projectMetadata">
+			<b:Row addStyleNames="projectMetadata" ui:field="projectUI">
 				<b:Column size="XS_12">
 					<bh:Span ui:field="projectActionMenuContainer"
 						addStyleNames="right" paddingTop="20" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.ui.xml
@@ -7,7 +7,7 @@
 	xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
 
 	<bh:Div>
-		<bh:Div addStyleNames="flexcontainer-row margin-bottom-10">
+		<bh:Div addStyleNames="flexcontainer-row">
 			<bh:Div addStyleNames="flexcontainer-column flexcontainer-column-fill-width font-size-30">
 				<bh:Div addStyleNames="flexcontainer-row flexcontainer-align-items-center overflow-x-auto">
 				 	<b:Icon ui:field="entityIcon" addStyleNames="entityIcon margin-right-5 lightGreyText flexcontainer-column" type="FOLDER"/>


### PR DESCRIPTION
I think this will be better than an infinite spinner, a non-functional project tools menu, and tabs that don't work right.