### PR TITLE
SWC-5819

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadata.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadata.java
@@ -88,8 +88,13 @@ public class EntityMetadata implements Presenter {
 		clear();
 		Entity en = bundle.getEntity();
 		view.setEntityId(en.getId());
-		view.setDescriptionVisible(bundle.getEntity() instanceof Table && en.getDescription() != null && DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider()));
+
+		// See comments on SWC-5763
+		// TL;DR: we plan to show the description at some point, but not until we implement new designs
+		// view.setDescriptionVisible(bundle.getEntity() instanceof Table && en.getDescription() != null && DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider()));
+		view.setDescriptionVisible(false);
 		view.setDescription(en.getDescription());
+
 		boolean canEdit = bundle.getPermissions().getCanCertifiedUserEdit();
 		isShowingAnnotations = false;
 		setAnnotationsVisible(isShowingAnnotations);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -944,7 +944,7 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 	 * @return
 	 */
 	public boolean isWikiableType(Entity entity) {
-		if (entity instanceof Table || entity instanceof Link) {
+		if (entity instanceof Link) {
 			return false;
 		}
 		return true;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabView.java
@@ -39,4 +39,8 @@ public interface TablesTabView extends IsWidget {
 
 	void setActionMenu(IsWidget w);
 
+	void setWikiPage(Widget w);
+
+	void setWikiPageVisible(boolean visible);
+
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
@@ -36,6 +36,8 @@ public class TablesTabViewImpl implements TablesTabView {
 	Div actionMenuContainer;
 	@UiField
 	Heading title;
+	@UiField
+	SimplePanel tableWikiPageContainer;
 
 	public interface TabsViewImplUiBinder extends UiBinder<Widget, TablesTabViewImpl> {
 	}
@@ -137,6 +139,16 @@ public class TablesTabViewImpl implements TablesTabView {
 		w.asWidget().removeFromParent();
 		actionMenuContainer.clear();
 		actionMenuContainer.add(w);
+	}
+
+	@Override
+	public void setWikiPage(Widget w) {
+		tableWikiPageContainer.setWidget(w);
+	}
+
+	@Override
+	public void setWikiPageVisible(boolean visible) {
+		tableWikiPageContainer.setVisible(visible);
 	}
 }
 

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
@@ -19,7 +19,8 @@
 		</bh:Div>
 		<b:Column size="XS_12">
 			<g:SimplePanel ui:field="tableListWidgetContainer" visible="false"/>
-			<g:SimplePanel addStyleNames="margin-top-15" ui:field="tableWidgetContainer"/>
+            <g:SimplePanel ui:field="tableWikiPageContainer" addStyleNames="panel panel-default panel-body margin-bottom-0-imp" visible="false"/>
+            <g:SimplePanel addStyleNames="margin-top-15" ui:field="tableWidgetContainer"/>
 			<g:SimplePanel addStyleNames="padding-bottom-15" ui:field="tableModifiedAndCreatedContainer"/>
 			<b:Row>
 				<b:Column size="XS_12" ui:field="provenanceContainer">

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityMetadataTest.java
@@ -479,7 +479,9 @@ public class EntityMetadataTest {
 		widget.configure(bundle, null, mockActionMenuWidget);
 
 		verify(mockView).setDescription(description);
-		verify(mockView).setDescriptionVisible(true);
+		// For now we don't show description in any circumstance. When we do show descriptions, this condition can be flipped
+		verify(mockView).setDescriptionVisible(false);
+		// verify(mockView).setDescriptionVisible(true);
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -71,6 +71,7 @@ import org.sagebionetworks.repo.model.docker.DockerRepository;
 import org.sagebionetworks.repo.model.doi.v2.DoiAssociation;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.EntityView;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest;
@@ -637,21 +638,28 @@ public class EntityActionControllerImplTest {
 	}
 
 	@Test
-	public void testConfigureWikiNoWikiTable() {
+	public void testConfigureWikiTable() {
 		entityBundle.setEntity(new TableEntity());
 		entityBundle.setRootWikiId(null);
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
-		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, false);
+		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, true);
 	}
 
 	@Test
-	public void testConfigureWikiNoWikiView() {
+	public void testConfigureWikiView() {
 		entityBundle.setEntity(new EntityView());
 		entityBundle.setRootWikiId(null);
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
-		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, false);		
+		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, true);
 	}
 
+	@Test
+	public void testConfigureWikiDataset() {
+		entityBundle.setEntity(new Dataset());
+		entityBundle.setRootWikiId(null);
+		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
+		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, true);
+	}
 
 	@Test
 	public void testConfigureViewWikiSource() {
@@ -677,7 +685,7 @@ public class EntityActionControllerImplTest {
 		entityBundle.setEntity(new TableEntity());
 		entityBundle.setRootWikiId("22");
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
-		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, false);
+		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, true);
 	}
 
 	@Test
@@ -685,7 +693,15 @@ public class EntityActionControllerImplTest {
 		entityBundle.setEntity(new EntityView());
 		entityBundle.setRootWikiId("22");
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
-		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, false);
+		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, true);
+	}
+
+	@Test
+	public void testConfigureViewWikiSourceDataset() {
+		entityBundle.setEntity(new Dataset());
+		entityBundle.setRootWikiId("22");
+		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
+		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, true);
 	}
 
 	@Test
@@ -1221,14 +1237,16 @@ public class EntityActionControllerImplTest {
 		assertTrue(controller.isWikiableConfig(new Project(), EntityArea.WIKI));
 		assertFalse(controller.isWikiableConfig(new Project(), EntityArea.TABLES));
 		assertFalse(controller.isWikiableConfig(new Project(), EntityArea.FILES));
-		assertFalse(controller.isWikiableConfig(new TableEntity(), null));
+		assertTrue(controller.isWikiableConfig(new TableEntity(), null));
 		assertTrue(controller.isWikiableConfig(new FileEntity(), null));
 	}
 
 	@Test
 	public void testIsWikableType() {
 		assertTrue(controller.isWikiableType(new Project()));
-		assertFalse(controller.isWikiableType(new TableEntity()));
+		assertTrue(controller.isWikiableType(new TableEntity()));
+		assertTrue(controller.isWikiableType(new EntityView()));
+		assertTrue(controller.isWikiableType(new Dataset()));
 		assertTrue(controller.isWikiableType(new FileEntity()));
 		assertTrue(controller.isWikiableType(new Folder()));
 		assertFalse(controller.isWikiableType(new Link()));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
@@ -50,6 +50,7 @@ import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.breadcrumb.Breadcrumb;
 import org.sagebionetworks.web.client.widget.entity.EntityMetadata;
 import org.sagebionetworks.web.client.widget.entity.ModifiedCreatedByWidget;
+import org.sagebionetworks.web.client.widget.entity.WikiPageWidget;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
 import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBar;
 import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
@@ -118,6 +119,8 @@ public class DatasetsTabTest {
 	@Mock
 	GlobalApplicationState mockGlobalApplicationState;
 	@Mock
+	WikiPageWidget mockWikiPageWidget;
+	@Mock
 	PlaceChanger mockPlaceChanger;
 	String projectEntityId = "syn666666";
 	String projectName = "a test project";
@@ -151,6 +154,7 @@ public class DatasetsTabTest {
 		when(mockPortalGinInjector.getProvenanceRenderer()).thenReturn(mockProvenanceWidget);
 		when(mockPortalGinInjector.getGlobalApplicationState()).thenReturn(mockGlobalApplicationState);
 		when(mockPortalGinInjector.getSynapseJavascriptClient()).thenReturn(mockJsClient);
+		when(mockPortalGinInjector.getWikiPageWidget()).thenReturn(mockWikiPageWidget);
 
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
 		tab.setEntitySelectedCallback(mockEntitySelectedCallback);
@@ -238,6 +242,8 @@ public class DatasetsTabTest {
 		verify(mockView).setTitlebarVisible(true);
 		verify(mockView).clearTableEntityWidget();
 		verify(mockModifiedCreatedBy).setVisible(false);
+		verify(mockView).setWikiPage(any(Widget.class));
+		verify(mockView).setWikiPageVisible(true);
 
 		ArgumentCaptor<Synapse> captor = ArgumentCaptor.forClass(Synapse.class);
 		verify(mockTab).setEntityNameAndPlace(eq(datasetName), captor.capture());
@@ -273,6 +279,7 @@ public class DatasetsTabTest {
 		verify(mockView).setTableUIVisible(false);
 		verify(mockView, never()).setTableUIVisible(true);
 		verify(mockActionMenuWidget).setTableDownloadOptionsVisible(false);
+		verify(mockView).setWikiPageVisible(false);
 
 		verify(mockTableListWidget).configure(mockProjectEntityBundle, Arrays.asList(EntityType.dataset));
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -50,6 +50,7 @@ import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.breadcrumb.Breadcrumb;
 import org.sagebionetworks.web.client.widget.entity.EntityMetadata;
 import org.sagebionetworks.web.client.widget.entity.ModifiedCreatedByWidget;
+import org.sagebionetworks.web.client.widget.entity.WikiPageWidget;
 import org.sagebionetworks.web.client.widget.entity.controller.StuAlert;
 import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBar;
 import org.sagebionetworks.web.client.widget.entity.menu.v2.ActionMenuWidget;
@@ -108,6 +109,8 @@ public class TablesTabTest {
 	@Mock
 	TableEntityWidget mockTableEntityWidget;
 	@Mock
+	WikiPageWidget mockWikiPageWidget;
+	@Mock
 	ModifiedCreatedByWidget mockModifiedCreatedBy;
 	@Captor
 	ArgumentCaptor<CallbackP> callbackPCaptor;
@@ -151,6 +154,7 @@ public class TablesTabTest {
 		when(mockPortalGinInjector.getProvenanceRenderer()).thenReturn(mockProvenanceWidget);
 		when(mockPortalGinInjector.getGlobalApplicationState()).thenReturn(mockGlobalApplicationState);
 		when(mockPortalGinInjector.getSynapseJavascriptClient()).thenReturn(mockJsClient);
+		when(mockPortalGinInjector.getWikiPageWidget()).thenReturn(mockWikiPageWidget);
 
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
 		tab.setEntitySelectedCallback(mockEntitySelectedCallback);
@@ -255,6 +259,8 @@ public class TablesTabTest {
 		verify(mockView).setTitlebarVisible(true);
 		verify(mockView).clearTableEntityWidget();
 		verify(mockModifiedCreatedBy).setVisible(false);
+		verify(mockView).setWikiPage(any(Widget.class));
+		verify(mockView).setWikiPageVisible(true);
 
 		ArgumentCaptor<Synapse> captor = ArgumentCaptor.forClass(Synapse.class);
 		verify(mockTab).setEntityNameAndPlace(eq(tableName), captor.capture());
@@ -290,6 +296,7 @@ public class TablesTabTest {
 		verify(mockView).setTableUIVisible(false);
 		verify(mockView, never()).setTableUIVisible(true);
 		verify(mockActionMenuWidget).setTableDownloadOptionsVisible(false);
+		verify(mockView).setWikiPageVisible(false);
 
 		verify(mockTableListWidget).configure(mockProjectEntityBundle, Arrays.asList(EntityType.table, EntityType.entityview, EntityType.submissionview));
 


### PR DESCRIPTION
Wiki is editable/viewable for Tables, Views, and Datasets.

Hide the description field that we were showing only in alpha mode because we're only supposed to show it there after implementing other parts of an entity page redesign.

https://user-images.githubusercontent.com/17580037/139943519-b870e8f2-f57c-4e79-b3bb-47fde059463c.mov


