### PR TITLE
SWC-5906 - Allow Datasets in Entity Views in Web Client

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
@@ -12,7 +12,9 @@ import org.sagebionetworks.repo.model.docker.DockerRepository;
 import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.EntityView;
 import org.sagebionetworks.repo.model.table.SubmissionView;
+import org.sagebionetworks.repo.model.table.Table;
 import org.sagebionetworks.repo.model.table.TableEntity;
+import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
 
 public class EntityTypeUtils {
 
@@ -148,4 +150,20 @@ public class EntityTypeUtils {
 		}
 		return friendlyName;
 	}
+
+	/**
+	 * Gets the display name of an Entity. For Views, this method can be specific to the type of view based on the mask.
+	 * @param entity
+	 * @return
+	 */
+	public static String getFriendlyEntityTypeName(Entity entity) {
+		if (entity instanceof Table) {
+			return TableType.getTableType(entity).getDisplayName();
+		} else {
+			return org.sagebionetworks.repo.model.EntityTypeUtils.getDisplayName(
+					org.sagebionetworks.repo.model.EntityTypeUtils.getEntityTypeForClass(entity.getClass())
+			);
+		}
+	}
+
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.client.widget.entity.controller;
 
+import static org.sagebionetworks.web.client.EntityTypeUtils.getFriendlyEntityTypeName;
 import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEntryPoint;
 import static org.sagebionetworks.web.client.widget.entity.browse.EntityFilter.CONTAINER;
 import static org.sagebionetworks.web.client.widget.entity.browse.EntityFilter.PROJECT;
@@ -434,7 +435,7 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 		this.entity = entityBundle.getEntity();
 		this.isUserAuthenticated = authenticationController.isLoggedIn();
 		this.isCurrentVersion = isCurrentVersion;
-		this.entityTypeDisplay = EntityTypeUtils.getDisplayName(EntityTypeUtils.getEntityTypeForClass(entityBundle.getEntity().getClass()));
+		this.entityTypeDisplay = getFriendlyEntityTypeName(entityBundle.getEntity());
 		this.currentArea = currentArea;
 
 		// hide all commands by default
@@ -1196,7 +1197,7 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 
 	public void onAddFileView() {
 		preflightController.checkCreateEntity(entityBundle, EntityView.class.getName(), () -> {
-			postCheckCreateTableOrView(TableType.files);
+			postCheckCreateTableOrView(TableType.file_view);
 		});
 	}
 
@@ -1209,7 +1210,7 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 
 	public void onAddProjectView() {
 		preflightController.checkCreateEntity(entityBundle, EntityView.class.getName(), () -> {
-			postCheckCreateTableOrView(TableType.projects);
+			postCheckCreateTableOrView(TableType.project_view);
 		});
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
@@ -35,7 +35,7 @@ public class CreateTableViewWizard {
 	public void configure(String parentId, TableType type) {
 		this.parentId = parentId;
 		this.type = type;
-		if (TableType.projects.equals(type)) {
+		if (TableType.project_view.equals(type)) {
 			this.modalWizardWidget.setTitle("Create Project View");
 			this.modalWizardWidget.setHelp(PROJECT_VIEW_HELP, VIEW_URL);
 		} else if (TableType.table.equals(type)) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1.java
@@ -65,7 +65,7 @@ public class CreateTableViewWizardStep1 implements ModalPage, CreateTableViewWiz
 
 	@Override
 	public void updateViewTypeMask() {
-		tableType = TableType.getTableType(view.isFileSelected(), view.isFolderSelected(), view.isTableSelected());
+		tableType = TableType.getEntityViewTableType(view.isFileSelected(), view.isFolderSelected(), view.isTableSelected(), view.isDatasetSelected());
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class CreateTableViewWizardStep1 implements ModalPage, CreateTableViewWiz
 			view.setEntityViewScopeWidgetVisible(true);	
 		}
 		
-		if (TableType.table.equals(type) || TableType.dataset.equals(type) || TableType.projects.equals(type) || TableType.submission_view.equals(type)) {
+		if (TableType.table.equals(type) || TableType.dataset.equals(type) || TableType.project_view.equals(type) || TableType.submission_view.equals(type)) {
 			view.setViewTypeOptionsVisible(false);
 		} else {
 			view.setViewTypeOptionsVisible(true);
@@ -94,6 +94,7 @@ public class CreateTableViewWizardStep1 implements ModalPage, CreateTableViewWiz
 			view.setIsFileSelected(type.isIncludeFiles());
 			view.setIsFolderSelected(type.isIncludeFolders());
 			view.setIsTableSelected(type.isIncludeTables());
+			view.setIsDatasetSelected(type.isIncludeDatasets());
 		}
 
 		entityContainerList.configure(new ArrayList<Reference>(), canEdit, type);

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1View.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1View.java
@@ -45,6 +45,10 @@ public interface CreateTableViewWizardStep1View extends IsWidget {
 
 	void setIsFolderSelected(boolean selected);
 
+	boolean isDatasetSelected();
+
+	void setIsDatasetSelected(boolean selected);
+
 	public interface Presenter {
 		void updateViewTypeMask();
 	}

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizardStep1ViewImpl.java
@@ -42,6 +42,7 @@ public class CreateTableViewWizardStep1ViewImpl implements CreateTableViewWizard
 	public CreateTableViewWizardStep1ViewImpl(Binder binder, FileViewOptions viewOptions, CookieProvider cookies) {
 		widget = binder.createAndBindUi(this);
 		this.viewOptions = viewOptions;
+		viewOptions.configure();
 		viewOptionsContainer.add(viewOptions);
 		viewOptions.addClickHandler(event -> {
 			p.updateViewTypeMask();
@@ -68,6 +69,16 @@ public class CreateTableViewWizardStep1ViewImpl implements CreateTableViewWizard
 	@Override
 	public void setIsFolderSelected(boolean value) {
 		viewOptions.setIsIncludeFolders(value);
+	}
+
+	@Override
+	public boolean isDatasetSelected() {
+		return viewOptions.isIncludeDatasets();
+	}
+
+	@Override
+	public void setIsDatasetSelected(boolean value) {
+		viewOptions.setIsIncludeDatasets(value);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityContainerListWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityContainerListWidget.java
@@ -51,11 +51,11 @@ public class EntityContainerListWidget implements EntityContainerListWidgetView.
 		};
 	}
 
-	public void configure(List<Reference> entityContainerIds, boolean canEdit, TableType tableType) {
+	public void configure(List<Reference> entityContainerIds, boolean canEditScope, TableType tableType) {
 		view.clear();
 		references.clear();
-		this.canEdit = canEdit;
-		view.setAddButtonVisible(canEdit);
+		this.canEdit = canEditScope;
+		view.setAddButtonVisible(canEditScope);
 		view.setNoContainers(entityContainerIds.isEmpty());
 		synAlert.clear();
 		if (!entityContainerIds.isEmpty()) {
@@ -78,7 +78,7 @@ public class EntityContainerListWidget implements EntityContainerListWidgetView.
 			});
 		}
 
-		if (TableType.projects.equals(tableType)) {
+		if (TableType.project_view.equals(tableType)) {
 			entityFinderBuilder
 					.setModalTitle("Set " + tableType.getDisplayName() + " Containers")
 					.setInitialScope(EntityFinderScope.ALL_PROJECTS)

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetView.java
@@ -22,11 +22,9 @@ public interface EntityViewScopeWidgetView extends IsWidget {
 
 	void hideModal();
 
-	void setEditButtonVisible(boolean visible);
+	void setEditMaskAndScopeButtonVisible(boolean visible);
 
 	void setLoading(boolean loading);
-
-	void setViewTypeOptionsVisible(boolean visible);
 
 	boolean isFileSelected();
 
@@ -40,10 +38,14 @@ public interface EntityViewScopeWidgetView extends IsWidget {
 
 	void setIsFolderSelected(boolean selected);
 
+	boolean isDatasetSelected();
+
+	void setIsDatasetSelected(boolean selected);
+
 	public interface Presenter {
 		void onSave();
 
-		void onEdit();
+		void onEditScopeAndMask();
 
 		void updateViewTypeMask();
 	}

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetViewImpl.java
@@ -46,7 +46,7 @@ public class EntityViewScopeWidgetViewImpl implements EntityViewScopeWidgetView 
 		editButton.addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
-				presenter.onEdit();
+				presenter.onEditScopeAndMask();
 			}
 		});
 		saveButton.addClickHandler(new ClickHandler() {
@@ -105,18 +105,13 @@ public class EntityViewScopeWidgetViewImpl implements EntityViewScopeWidgetView 
 	}
 
 	@Override
-	public void setEditButtonVisible(boolean visible) {
+	public void setEditMaskAndScopeButtonVisible(boolean visible) {
 		editButton.setVisible(visible);
 	}
 
 	@Override
 	public void setLoading(boolean loading) {
 		DisplayUtils.showLoading(saveButton, loading, originalButtonText);
-	}
-
-	@Override
-	public void setViewTypeOptionsVisible(boolean visible) {
-		viewOptionsContainer.setVisible(visible);
 	}
 
 	@Override
@@ -137,6 +132,16 @@ public class EntityViewScopeWidgetViewImpl implements EntityViewScopeWidgetView 
 	@Override
 	public void setIsFolderSelected(boolean value) {
 		viewOptions.setIsIncludeFolders(value);
+	}
+
+	@Override
+	public boolean isDatasetSelected() {
+		return viewOptions.isIncludeDatasets();
+	}
+
+	@Override
+	public void setIsDatasetSelected(boolean value) {
+		viewOptions.setIsIncludeDatasets(value);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.java
@@ -1,6 +1,9 @@
 package org.sagebionetworks.web.client.widget.table.modal.fileview;
 
 import org.gwtbootstrap3.client.ui.CheckBox;
+import org.sagebionetworks.web.client.DisplayUtils;
+import org.sagebionetworks.web.client.cookie.CookieProvider;
+
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -13,21 +16,31 @@ public class FileViewOptions implements IsWidget {
 	}
 
 	Widget widget;
+	CookieProvider cookieProvider;
+
 	@UiField
 	CheckBox includeFilesCb;
 	@UiField
 	CheckBox includeFoldersCb;
 	@UiField
 	CheckBox includeTablesCb;
+	@UiField
+	CheckBox includeDatasetsCb;
 
 	@Inject
-	public FileViewOptions(Binder binder) {
+	public FileViewOptions(Binder binder, CookieProvider cookies) {
 		widget = binder.createAndBindUi(this);
+		cookieProvider = cookies;
 	}
 
 	@Override
 	public Widget asWidget() {
 		return widget;
+	}
+
+	// TODO: This method can be removed when Datasets is out of experimental mode.
+	public void configure() {
+		includeDatasetsCb.setVisible(DisplayUtils.isInTestWebsite(cookieProvider));
 	}
 
 	public boolean isIncludeFiles() {
@@ -54,9 +67,18 @@ public class FileViewOptions implements IsWidget {
 		includeTablesCb.setValue(value);
 	}
 
+	public boolean isIncludeDatasets() {
+		return includeDatasetsCb.getValue();
+	}
+
+	public void setIsIncludeDatasets(boolean value) {
+		includeDatasetsCb.setValue(value);
+	}
+
 	public void addClickHandler(ClickHandler handler) {
 		includeFilesCb.addClickHandler(handler);
 		includeFoldersCb.addClickHandler(handler);
 		includeTablesCb.addClickHandler(handler);
+		includeDatasetsCb.addClickHandler(handler);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/ViewDefaultColumns.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/ViewDefaultColumns.java
@@ -32,8 +32,8 @@ public class ViewDefaultColumns {
 	}
 
 	public void init() {
-		FluentFuture<List<ColumnModel>> fileViewColumnsFuture = jsClient.getDefaultColumnsForView(TableType.files.getViewTypeMask());
-		FluentFuture<List<ColumnModel>> projectViewColumnsFuture = jsClient.getDefaultColumnsForView(TableType.projects.getViewTypeMask());
+		FluentFuture<List<ColumnModel>> fileViewColumnsFuture = jsClient.getDefaultColumnsForView(TableType.file_view.getViewTypeMask());
+		FluentFuture<List<ColumnModel>> projectViewColumnsFuture = jsClient.getDefaultColumnsForView(TableType.project_view.getViewTypeMask());
 		FluentFuture<List<ColumnModel>> submissionViewColumnsFuture = jsClient.getDefaultColumnsForView(ViewEntityType.submissionview);
 		FluentFuture.from(whenAllComplete(fileViewColumnsFuture, projectViewColumnsFuture, submissionViewColumnsFuture).call(() -> {
 			defaultFileViewColumns = clearIds(fileViewColumnsFuture.get());

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
@@ -6,13 +6,13 @@ import java.util.ArrayList;
 
 import org.gwtbootstrap3.client.ui.constants.AlertType;
 import org.sagebionetworks.repo.model.Entity;
-import org.sagebionetworks.repo.model.EntityTypeUtils;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.QueryFilter;
 import org.sagebionetworks.repo.model.table.SortItem;
 import org.sagebionetworks.repo.model.table.TableBundle;
+import org.sagebionetworks.web.client.EntityTypeUtils;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.cache.SessionStorage;
@@ -168,7 +168,7 @@ public class TableEntityWidget implements TableEntityWidgetView.Presenter, IsWid
 		this.queryChangeHandler = qch;
 		this.view.configure(bundle, this.canEdit && isCurrentVersion);
 		this.actionMenu = actionMenu;
-		this.entityTypeDisplay = EntityTypeUtils.getDisplayName(EntityTypeUtils.getEntityTypeForClass(entityBundle.getEntity().getClass()));
+		this.entityTypeDisplay = EntityTypeUtils.getFriendlyEntityTypeName(bundle.getEntity());
 		reconfigureState();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -303,8 +303,8 @@ public class WebConstants {
 	public static final String AUTH_PUBLIC_SERVICE_URL_KEY = "authPublicServiceUrl";
 	public static final String SYNAPSE_VERSION_KEY = "synapseVersionInfo";
 
-	// View mask constants
-	public static final int FILE = 0x01, PROJECT = 0x02, TABLE = 0x04, FOLDER = 0x08, VIEW = 0x10, DOCKER = 0x20;
+	// View mask constants (See https://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/EntityView.html)
+	public static final int FILE = 0x01, PROJECT = 0x02, TABLE = 0x04, FOLDER = 0x08, VIEW = 0x10, DOCKER = 0x20, SUBMISSION_VIEW = 0x40, DATASET = 0x80;
 
 	/**
 	 * Jira Issue Creation constants

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.ui.xml
@@ -19,7 +19,8 @@
 			<b:CheckBox ui:field="includeFilesCb" text="Files"
 				value="true" />
 			<b:CheckBox ui:field="includeFoldersCb" text="Folders" />
-			<b:CheckBox ui:field="includeTablesCb" text="Tables" />
+            <b:CheckBox ui:field="includeTablesCb" text="Tables" />
+            <b:CheckBox ui:field="includeDatasetsCb" text="Datasets" />
 		</bh:Div>
 	</b:FormGroup>
 </ui:UiBinder>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.web.client.DisplayConstants.FILE_VIEW;
 import static org.sagebionetworks.web.client.widget.entity.controller.EntityActionControllerImpl.ARE_YOU_SURE_YOU_WANT_TO_DELETE;
 import static org.sagebionetworks.web.client.widget.entity.controller.EntityActionControllerImpl.DELETE_FOLDER_EXPLANATION;
 import static org.sagebionetworks.web.client.widget.entity.controller.EntityActionControllerImpl.DELETE_PREFIX;
@@ -129,6 +130,7 @@ import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidge
 import org.sagebionetworks.web.client.widget.team.SelectTeamModal;
 import org.sagebionetworks.web.shared.FormParams;
 import org.sagebionetworks.web.shared.PublicPrincipalIds;
+import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.asynch.AsynchType;
 import org.sagebionetworks.web.shared.exceptions.BadRequestException;
@@ -254,6 +256,8 @@ public class EntityActionControllerImplTest {
 	SnapshotResponse mockSnapshotResponse;
 	@Mock
 	PromptForValuesModalView.Configuration mockPromptModalConfiguration;
+	@Mock
+	EntityView mockEntityView;
 	PromptForValuesModalView.Configuration.Builder mockPromptModalConfigurationBuilder;
 	Set<ResourceAccess> resourceAccessSet;
 
@@ -330,6 +334,10 @@ public class EntityActionControllerImplTest {
 		when(mockPublicPrincipalIds.isPublic(PUBLIC_USER_ID)).thenReturn(true);
 		selected = new Reference();
 		selected.setTargetId("syn9876");
+
+		when(mockEntityView.getId()).thenReturn(entityId);
+		when(mockEntityView.getParentId()).thenReturn(parentId);
+		when(mockEntityView.getViewTypeMask()).thenReturn(new Long(WebConstants.FILE));
 
 		// Setup the mock entity selector to select an entity.
 		Mockito.doAnswer(new Answer<Void>() {
@@ -418,8 +426,7 @@ public class EntityActionControllerImplTest {
 
 	@Test
 	public void testConfigureWithEntityView() {
-		EntityView view = new EntityView();
-		entityBundle.setEntity(view);
+		entityBundle.setEntity(mockEntityView);
 		boolean canCertifiedUserEdit = true;
 		permissions.setCanCertifiedUserEdit(canCertifiedUserEdit);
 
@@ -428,7 +435,7 @@ public class EntityActionControllerImplTest {
 		verify(mockGWT).scheduleExecution(any(Callback.class), anyInt());
 		// delete
 		verify(mockActionMenu).setActionVisible(Action.DELETE_ENTITY, true);
-		verify(mockActionMenu).setActionText(Action.DELETE_ENTITY, DELETE_PREFIX + EntityTypeUtils.getDisplayName(EntityType.entityview));
+		verify(mockActionMenu).setActionText(Action.DELETE_ENTITY, DELETE_PREFIX + FILE_VIEW);
 		verify(mockActionMenu).setActionListener(Action.DELETE_ENTITY, controller);
 		// share
 		verify(mockActionMenu).setActionVisible(Action.SHARE, true);
@@ -739,7 +746,7 @@ public class EntityActionControllerImplTest {
 
 	@Test
 	public void testConfigureWikiView() {
-		entityBundle.setEntity(new EntityView());
+		entityBundle.setEntity(mockEntityView);
 		entityBundle.setRootWikiId(null);
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		verify(mockActionMenu).setActionVisible(Action.EDIT_WIKI_PAGE, true);
@@ -782,7 +789,7 @@ public class EntityActionControllerImplTest {
 
 	@Test
 	public void testConfigureViewWikiSourceWikiView() {
-		entityBundle.setEntity(new EntityView());
+		entityBundle.setEntity(mockEntityView);
 		entityBundle.setRootWikiId("22");
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		verify(mockActionMenu).setActionVisible(Action.VIEW_WIKI_SOURCE, true);
@@ -994,10 +1001,7 @@ public class EntityActionControllerImplTest {
 
 	@Test
 	public void testOnCreateEntityViewSnapshot() {
-		Entity entityView = new EntityView();
-		entityView.setId(entityId);
-		entityView.setParentId(parentId);
-		entityBundle.setEntity(entityView);
+		entityBundle.setEntity(mockEntityView);
 		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 
@@ -1700,7 +1704,7 @@ public class EntityActionControllerImplTest {
 
 	@Test
 	public void testConfigureWikiSubpageView() {
-		entityBundle.setEntity(new EntityView());
+		entityBundle.setEntity(mockEntityView);
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		verify(mockActionMenu).setActionVisible(Action.ADD_WIKI_SUBPAGE, false);
 	}
@@ -1792,7 +1796,7 @@ public class EntityActionControllerImplTest {
 	public void testConfigureCreateOrUpdateDoiView() throws Exception {
 		// Create DOI is now available for Views since they're now versionable (SWC-4062, SWC-5191)
 		entityBundle.setDoiAssociation(null);
-		entityBundle.setEntity(new EntityView());
+		entityBundle.setEntity(mockEntityView);
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		verify(mockActionMenu).setActionVisible(Action.CREATE_OR_UPDATE_DOI, false);
 		verify(mockActionMenu).setActionVisible(Action.CREATE_OR_UPDATE_DOI, true);
@@ -2059,7 +2063,7 @@ public class EntityActionControllerImplTest {
 		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkCreateEntity(any(EntityBundle.class), anyString(), any(Callback.class));
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		controller.onAction(Action.ADD_FILE_VIEW);
-		verify(mockCreateTableViewWizard).configure(entityId, TableType.files);
+		verify(mockCreateTableViewWizard).configure(entityId, TableType.file_view);
 		verify(mockCreateTableViewWizard).showModal(any(WizardCallback.class));
 	}
 
@@ -2068,7 +2072,7 @@ public class EntityActionControllerImplTest {
 		AsyncMockStubber.callWithInvoke().when(mockPreflightController).checkCreateEntity(any(EntityBundle.class), anyString(), any(Callback.class));
 		controller.configure(mockActionMenu, entityBundle, true, wikiPageId, currentEntityArea);
 		controller.onAction(Action.ADD_PROJECT_VIEW);
-		verify(mockCreateTableViewWizard).configure(entityId, TableType.projects);
+		verify(mockCreateTableViewWizard).configure(entityId, TableType.project_view);
 		verify(mockCreateTableViewWizard).showModal(any(WizardCallback.class));
 	}
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/CreateTableViewWizardStep1Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/CreateTableViewWizardStep1Test.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.when;
 import static org.sagebionetworks.web.client.utils.FutureUtils.getDoneFuture;
 import static org.sagebionetworks.web.client.utils.FutureUtils.getFailedFuture;
 import static org.sagebionetworks.web.client.widget.table.modal.fileview.CreateTableViewWizardStep1.EMPTY_SCOPE_MESSAGE;
+import static org.sagebionetworks.web.shared.WebConstants.FILE;
+import static org.sagebionetworks.web.shared.WebConstants.FOLDER;
+import static org.sagebionetworks.web.shared.WebConstants.TABLE;
 
 import java.util.Collections;
 import java.util.List;
@@ -59,6 +62,8 @@ public class CreateTableViewWizardStep1Test {
 	List<String> entityScopeIds;
 	List<String> evaluationScopeIds;
 
+	public static final TableType filesFoldersTablesView = new TableType(EntityView.class, FILE | FOLDER | TABLE);
+
 	@Before
 	public void before() {
 		MockitoAnnotations.initMocks(this);
@@ -73,7 +78,7 @@ public class CreateTableViewWizardStep1Test {
 
 	@Test
 	public void testNullName() {
-		widget.configure(parentId, TableType.files);
+		widget.configure(parentId, TableType.file_view);
 		when(mockView.getName()).thenReturn(null);
 		widget.onPrimary();
 		verify(mockWizardPresenter).setErrorMessage(CreateTableViewWizardStep1.NAME_MUST_INCLUDE_AT_LEAST_ONE_CHARACTER);
@@ -109,7 +114,7 @@ public class CreateTableViewWizardStep1Test {
 	
 	@Test
 	public void testCreateFileView() {
-		widget.configure(parentId, TableType.files);
+		widget.configure(parentId, TableType.file_view);
 		verify(mockView).setName("");
 		verify(mockView).setEntityViewScopeWidgetVisible(true);
 
@@ -127,14 +132,14 @@ public class CreateTableViewWizardStep1Test {
 		assertNull(capturedFileView.getType());
 		assertEquals((Long) ViewTypeMask.File.getMask(), capturedFileView.getViewTypeMask());
 		verify(mockWizardPresenter, never()).setErrorMessage(anyString());
-		verify(mockStep2).configure(table, TableType.files);
+		verify(mockStep2).configure(table, TableType.file_view);
 		verify(mockWizardPresenter).setNextActivePage(mockStep2);
 	}
 
 	@Test
 	public void testCreateFileFolderTableView() {
 		// initially configured with Files only
-		widget.configure(parentId, TableType.files);
+		widget.configure(parentId, TableType.file_view);
 		verify(mockView).setName("");
 		verify(mockView).setEntityViewScopeWidgetVisible(true);
 		verify(mockView).setViewTypeOptionsVisible(true);
@@ -157,15 +162,15 @@ public class CreateTableViewWizardStep1Test {
 		EntityView capturedFileView = (EntityView) captor.getValue();
 		assertEquals(entityScopeIds, capturedFileView.getScopeIds());
 		assertNull(capturedFileView.getType());
-		assertEquals(new Long(TableType.files_folders_tables.getViewTypeMask()), capturedFileView.getViewTypeMask());
+		assertEquals(new Long(filesFoldersTablesView.getViewTypeMask()), capturedFileView.getViewTypeMask());
 		verify(mockWizardPresenter, never()).setErrorMessage(anyString());
-		verify(mockStep2).configure(table, TableType.files_folders_tables);
+		verify(mockStep2).configure(table, filesFoldersTablesView);
 		verify(mockWizardPresenter).setNextActivePage(mockStep2);
 	}
 
 	@Test
 	public void testCreateFileViewEmptyScope() {
-		widget.configure(parentId, TableType.files);
+		widget.configure(parentId, TableType.file_view);
 		String tableName = "a name";
 		EntityView table = new EntityView();
 		table.setName(tableName);
@@ -179,7 +184,7 @@ public class CreateTableViewWizardStep1Test {
 
 	@Test
 	public void testCreateProjectView() {
-		widget.configure(parentId, TableType.projects);
+		widget.configure(parentId, TableType.project_view);
 		verify(mockView).setName("");
 		verify(mockView).setEntityViewScopeWidgetVisible(true);
 		verify(mockView).setViewTypeOptionsVisible(false);
@@ -196,7 +201,7 @@ public class CreateTableViewWizardStep1Test {
 		assertNull(capturedFileView.getType());
 		assertEquals((Long) ViewTypeMask.Project.getMask(), capturedFileView.getViewTypeMask());
 		verify(mockWizardPresenter, never()).setErrorMessage(anyString());
-		verify(mockStep2).configure(table, TableType.projects);
+		verify(mockStep2).configure(table, TableType.project_view);
 		verify(mockWizardPresenter).setNextActivePage(mockStep2);
 	}
 
@@ -257,7 +262,7 @@ public class CreateTableViewWizardStep1Test {
 
 	@Test
 	public void testCreateFailed() {
-		widget.configure(parentId, TableType.files);
+		widget.configure(parentId, TableType.file_view);
 		String tableName = "a name";
 		String error = "name already exists";
 		when(mockJsClient.createEntity(any(Entity.class))).thenReturn(getFailedFuture(new Throwable(error)));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/EntityContainerListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/EntityContainerListWidgetTest.java
@@ -86,7 +86,7 @@ public class EntityContainerListWidgetTest {
 		// configure with pre-defined entity id list
 		AsyncMockStubber.callSuccessWith(entityHeaders).when(mockSynapseJavascriptClient).getEntityHeaderBatchFromReferences(anyList(), any(AsyncCallback.class));
 		boolean canEdit = true;
-		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.files);
+		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.file_view);
 		verify(mockSynapseJavascriptClient).getEntityHeaderBatchFromReferences(anyList(), any(AsyncCallback.class));
 		verify(mockView).setAddButtonVisible(true);
 		verify(mockView).setNoContainers(false);
@@ -111,7 +111,7 @@ public class EntityContainerListWidgetTest {
 		// SWC-3562: old ids should be cleared when widget is re-configured
 		AsyncMockStubber.callSuccessWith(entityHeaders).when(mockSynapseJavascriptClient).getEntityHeaderBatchFromReferences(anyList(), any(AsyncCallback.class));
 		boolean canEdit = true;
-		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.projects);
+		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.project_view);
 		assertTrue(widget.getEntityIds().contains(headerId));
 		assertEquals(1, widget.getEntityIds().size());
 
@@ -121,7 +121,7 @@ public class EntityContainerListWidgetTest {
 		verify(mockEntityFinderBuilder).setSelectableTypes(EntityFilter.PROJECT);
 		verify(mockEntityFinderBuilder).setShowVersions(showVersions);
 
-		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.files);
+		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.file_view);
 		assertTrue(widget.getEntityIds().contains(headerId));
 		assertEquals(1, widget.getEntityIds().size());
 	}
@@ -131,7 +131,7 @@ public class EntityContainerListWidgetTest {
 		entityHeaders.clear();
 		AsyncMockStubber.callSuccessWith(entityHeaders).when(mockSynapseJavascriptClient).getEntityHeaderBatch(anyList(), any(AsyncCallback.class));
 		boolean canEdit = false;
-		widget.configure(Collections.EMPTY_LIST, canEdit, TableType.files);
+		widget.configure(Collections.EMPTY_LIST, canEdit, TableType.file_view);
 		verify(mockSynapseJavascriptClient, never()).getEntityHeaderBatch(anyList(), any(AsyncCallback.class));
 		verify(mockView).setAddButtonVisible(false);
 		verify(mockView).setNoContainers(true);
@@ -147,7 +147,7 @@ public class EntityContainerListWidgetTest {
 		Exception ex = new Exception("error!");
 		AsyncMockStubber.callFailureWith(ex).when(mockSynapseJavascriptClient).getEntityHeaderBatchFromReferences(anyList(), any(AsyncCallback.class));
 		boolean canEdit = false;
-		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.files);
+		widget.configure(Collections.singletonList(entityReference), canEdit, TableType.file_view);
 		verify(mockSynapseJavascriptClient).getEntityHeaderBatchFromReferences(anyList(), any(AsyncCallback.class));
 		verify(mockSynapseAlert).clear();
 		verify(mockSynapseAlert).handleException(ex);
@@ -156,7 +156,7 @@ public class EntityContainerListWidgetTest {
 
 	@Test
 	public void testOnAddProject() {
-		widget.configure(Collections.singletonList(entityReference), true, TableType.projects);
+		widget.configure(Collections.singletonList(entityReference), true, TableType.project_view);
 		widget.onAddEntity();
 		verify(mockEntityFinder).show();
 	}
@@ -165,7 +165,7 @@ public class EntityContainerListWidgetTest {
 	public void testOnAddProjectId() {
 		ArrayList<EntityHeader> returnList = new ArrayList<EntityHeader>();
 		returnList.add(mockEntityHeader);
-		widget.configure(Collections.singletonList(entityReference), true, TableType.projects);
+		widget.configure(Collections.singletonList(entityReference), true, TableType.project_view);
 
 		AsyncMockStubber.callSuccessWith(returnList).when(mockSynapseJavascriptClient).getEntityHeaderBatch(anyList(), any(AsyncCallback.class));
 		widget.onAddEntity(headerId);
@@ -181,7 +181,7 @@ public class EntityContainerListWidgetTest {
 	public void testOnAddProjectIdFailure() {
 		String error = "error during lookup!";
 		Exception ex = new Exception(error);
-		widget.configure(Collections.singletonList(entityReference), true, TableType.projects);
+		widget.configure(Collections.singletonList(entityReference), true, TableType.project_view);
 
 		AsyncMockStubber.callFailureWith(ex).when(mockSynapseJavascriptClient).getEntityHeaderBatch(anyList(), any(AsyncCallback.class));
 		widget.onAddEntity(headerId);
@@ -191,7 +191,7 @@ public class EntityContainerListWidgetTest {
 
 	@Test
 	public void testSetValueInvalidResponse() {
-		widget.configure(Collections.singletonList(entityReference), true, TableType.projects);
+		widget.configure(Collections.singletonList(entityReference), true, TableType.project_view);
 
 		AsyncMockStubber.callSuccessWith(new ArrayList<EntityHeader>()).when(mockSynapseJavascriptClient).getEntityHeaderBatch(anyList(), any(AsyncCallback.class));
 		widget.onAddEntity(headerId);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/TableTypeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/TableTypeTest.java
@@ -4,20 +4,33 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.web.shared.WebConstants.DATASET;
+import static org.sagebionetworks.web.shared.WebConstants.FILE;
+import static org.sagebionetworks.web.shared.WebConstants.FOLDER;
+import static org.sagebionetworks.web.shared.WebConstants.TABLE;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.EntityView;
+import org.sagebionetworks.repo.model.table.SubmissionView;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.sagebionetworks.repo.model.table.ViewType;
 import org.sagebionetworks.repo.model.table.ViewTypeMask;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
+import org.sagebionetworks.web.shared.WebConstants;
 
 public class TableTypeTest {
 
 	@Mock
 	TableEntity mockTableEntity;
+	@Mock
+	SubmissionView mockSubmissionView;
+	@Mock
+	Dataset mockDataset;
 	@Mock
 	EntityView mockEntityView;
 
@@ -29,74 +42,93 @@ public class TableTypeTest {
 	@Test
 	public void testIncludeFiles() {
 		assertFalse(TableType.table.isIncludeFiles());
-		assertFalse(TableType.projects.isIncludeFiles());
-		assertFalse(TableType.tables.isIncludeFiles());
-		assertFalse(TableType.folders.isIncludeFiles());
-		assertFalse(TableType.folders_tables.isIncludeFiles());
-		assertTrue(TableType.files.isIncludeFiles());
-		assertTrue(TableType.files_tables.isIncludeFiles());
-		assertTrue(TableType.files_folders.isIncludeFiles());
-		assertTrue(TableType.files_folders_tables.isIncludeFiles());
+		assertFalse(TableType.project_view.isIncludeFiles());
+		assertFalse(TableType.submission_view.isIncludeFiles());
+		assertTrue(TableType.dataset.isIncludeFiles());
+		assertTrue(TableType.file_view.isIncludeFiles());
+		assertTrue((new TableType(EntityView.class, FILE)).isIncludeFiles());
 	}
 
 	@Test
 	public void testIncludeFolders() {
 		assertFalse(TableType.table.isIncludeFolders());
-		assertFalse(TableType.projects.isIncludeFolders());
-		assertFalse(TableType.tables.isIncludeFolders());
-		assertTrue(TableType.folders.isIncludeFolders());
-		assertTrue(TableType.folders_tables.isIncludeFolders());
-		assertFalse(TableType.files.isIncludeFolders());
-		assertFalse(TableType.files_tables.isIncludeFolders());
-		assertTrue(TableType.files_folders.isIncludeFolders());
-		assertTrue(TableType.files_folders_tables.isIncludeFolders());
+		assertFalse(TableType.project_view.isIncludeFolders());
+		assertFalse(TableType.submission_view.isIncludeFolders());
+		assertFalse(TableType.file_view.isIncludeFolders());
+		assertFalse(TableType.dataset.isIncludeFolders());
+		assertTrue((new TableType(EntityView.class, WebConstants.FOLDER)).isIncludeFolders());
 	}
 
 	@Test
 	public void testIncludeTables() {
 		assertFalse(TableType.table.isIncludeTables());
-		assertFalse(TableType.projects.isIncludeTables());
-		assertTrue(TableType.tables.isIncludeTables());
-		assertFalse(TableType.folders.isIncludeTables());
-		assertTrue(TableType.folders_tables.isIncludeTables());
-		assertFalse(TableType.files.isIncludeTables());
-		assertTrue(TableType.files_tables.isIncludeTables());
-		assertFalse(TableType.files_folders.isIncludeTables());
-		assertTrue(TableType.files_folders_tables.isIncludeTables());
+		assertFalse(TableType.project_view.isIncludeTables());
+		assertFalse(TableType.submission_view.isIncludeTables());
+		assertFalse(TableType.file_view.isIncludeTables());
+		assertFalse(TableType.dataset.isIncludeTables());
+		assertTrue((new TableType(EntityView.class, TABLE)).isIncludeTables());
+	}
+
+	@Test
+	public void testIncludeDatasets() {
+		assertFalse(TableType.table.isIncludeDatasets());
+		assertFalse(TableType.project_view.isIncludeDatasets());
+		assertFalse(TableType.submission_view.isIncludeDatasets());
+		assertFalse(TableType.file_view.isIncludeDatasets());
+		assertFalse(TableType.dataset.isIncludeDatasets());
+		assertTrue((new TableType(EntityView.class, DATASET)).isIncludeDatasets());
 	}
 
 	@Test
 	public void testGetTableTypeFromCheckboxes() {
-		assertEquals(TableType.tables, TableType.getTableType(false, false, true));
-		assertEquals(TableType.folders, TableType.getTableType(false, true, false));
-		assertEquals(TableType.folders_tables, TableType.getTableType(false, true, true));
-		assertEquals(TableType.files, TableType.getTableType(true, false, false));
-		assertEquals(TableType.files_tables, TableType.getTableType(true, false, true));
-		assertEquals(TableType.files_folders, TableType.getTableType(true, true, false));
-		assertEquals(TableType.files_folders_tables, TableType.getTableType(true, true, true));
-		assertEquals(TableType.table, TableType.getTableType((Long) null));
+		TableType noneInMask = TableType.getEntityViewTableType(false, false, false, false);
+		assertFalse(noneInMask.isIncludeFiles());
+		assertFalse(noneInMask.isIncludeFolders());
+		assertFalse(noneInMask.isIncludeTables());
+		assertFalse(noneInMask.isIncludeDatasets());
+
+		TableType allInMask = TableType.getEntityViewTableType(true, true, true, true);
+		assertTrue(allInMask.isIncludeFiles());
+		assertTrue(allInMask.isIncludeFolders());
+		assertTrue(allInMask.isIncludeTables());
+		assertTrue(allInMask.isIncludeDatasets());
 	}
+
+	@Test
+	public void testGetDisplayName() {
+		assertEquals(TableType.table.getDisplayName(), DisplayConstants.TABLE);
+		assertEquals(TableType.submission_view.getDisplayName(), DisplayConstants.SUBMISSION_VIEW);
+		assertEquals(TableType.dataset.getDisplayName(), DisplayConstants.DATASET);
+		assertEquals(TableType.file_view.getDisplayName(), DisplayConstants.FILE_VIEW);
+		assertEquals(TableType.project_view.getDisplayName(), DisplayConstants.PROJECT_VIEW);
+		assertEquals(new TableType(EntityView.class, FILE | FOLDER | TABLE).getDisplayName(), DisplayConstants.VIEW);
+	}
+
 
 	@Test
 	public void testGetTableTypeFromEntity() {
 		assertEquals(TableType.table, TableType.getTableType(mockTableEntity));
 
+		assertEquals(TableType.submission_view, TableType.getTableType(mockSubmissionView));
+
+		assertEquals(TableType.dataset, TableType.getTableType(mockDataset));
+
 		// using old type
 		when(mockEntityView.getViewTypeMask()).thenReturn(null);
 		when(mockEntityView.getType()).thenReturn(ViewType.file);
-		assertEquals(TableType.files, TableType.getTableType(mockEntityView));
+		assertEquals(TableType.file_view, TableType.getTableType(mockEntityView));
 		when(mockEntityView.getType()).thenReturn(ViewType.file_and_table);
-		assertEquals(TableType.files_tables, TableType.getTableType(mockEntityView));
+		assertEquals(new TableType(EntityView.class, FILE | TABLE), TableType.getTableType(mockEntityView));
 		when(mockEntityView.getType()).thenReturn(ViewType.project);
-		assertEquals(TableType.projects, TableType.getTableType(mockEntityView));
+		assertEquals(TableType.project_view, TableType.getTableType(mockEntityView));
 
 		// using new mask
 		when(mockEntityView.getType()).thenReturn(null);
 		when(mockEntityView.getViewTypeMask()).thenReturn(ViewTypeMask.File.getMask());
-		assertEquals(TableType.files, TableType.getTableType(mockEntityView));
+		assertEquals(TableType.file_view, TableType.getTableType(mockEntityView));
 		when(mockEntityView.getViewTypeMask()).thenReturn(ViewTypeMask.Table.getMask());
-		assertEquals(TableType.tables, TableType.getTableType(mockEntityView));
+		assertEquals(new TableType(EntityView.class, TABLE), TableType.getTableType(mockEntityView));
 		when(mockEntityView.getViewTypeMask()).thenReturn(ViewTypeMask.File.getMask() | ViewTypeMask.Table.getMask());
-		assertEquals(TableType.files_tables, TableType.getTableType(mockEntityView));
+		assertEquals(new TableType(EntityView.class, FILE | TABLE), TableType.getTableType(mockEntityView));
 	}
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/ViewDefaultColumnsTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/ViewDefaultColumnsTest.java
@@ -63,16 +63,16 @@ public class ViewDefaultColumnsTest {
 		columns = Collections.singletonList(fileColumn);
 		projectColumns = Collections.singletonList(projectColumn);
 		submissionViewColumns = Collections.singletonList(submissionViewColumn);
-		when(mockJsClient.getDefaultColumnsForView(TableType.files.getViewTypeMask())).thenReturn(getDoneFuture(columns));
-		when(mockJsClient.getDefaultColumnsForView(TableType.projects.getViewTypeMask())).thenReturn(getDoneFuture(projectColumns));
+		when(mockJsClient.getDefaultColumnsForView(TableType.file_view.getViewTypeMask())).thenReturn(getDoneFuture(columns));
+		when(mockJsClient.getDefaultColumnsForView(TableType.project_view.getViewTypeMask())).thenReturn(getDoneFuture(projectColumns));
 		when(mockJsClient.getDefaultColumnsForView(ViewEntityType.submissionview)).thenReturn(getDoneFuture(submissionViewColumns));		
 		fileViewDefaultColumns = new ViewDefaultColumns(mockJsClient, adapterFactory, mockPopupUtils);
 	}
 
 	@Test
 	public void testGetDefaultColumnNames() {
-		Set<String> columnNames = fileViewDefaultColumns.getDefaultViewColumnNames(TableType.files);
-		Set<String> projectColumnNames = fileViewDefaultColumns.getDefaultViewColumnNames(TableType.projects);
+		Set<String> columnNames = fileViewDefaultColumns.getDefaultViewColumnNames(TableType.file_view);
+		Set<String> projectColumnNames = fileViewDefaultColumns.getDefaultViewColumnNames(TableType.project_view);
 		Set<String> submissionViewColumnNames = fileViewDefaultColumns.getDefaultViewColumnNames(TableType.submission_view);
 		assertTrue(columnNames.contains(FILE_COLUMN));
 		assertTrue(projectColumnNames.contains(PROJECT_COLUMN));
@@ -81,19 +81,19 @@ public class ViewDefaultColumnsTest {
 
 	@Test
 	public void testInitFailureFailure() {
-		when(mockJsClient.getDefaultColumnsForView(TableType.files.getViewTypeMask())).thenReturn(getFailedFuture(mockException));
+		when(mockJsClient.getDefaultColumnsForView(TableType.file_view.getViewTypeMask())).thenReturn(getFailedFuture(mockException));
 		fileViewDefaultColumns = new ViewDefaultColumns(mockJsClient, adapterFactory, mockPopupUtils);
 
-		verify(mockJsClient, times(2)).getDefaultColumnsForView(TableType.files.getViewTypeMask());
+		verify(mockJsClient, times(2)).getDefaultColumnsForView(TableType.file_view.getViewTypeMask());
 		verify(mockPopupUtils).showErrorMessage(errorMessage);
 	}
 
 	@Test
 	public void testProjectInitFailure() {
-		when(mockJsClient.getDefaultColumnsForView(TableType.projects.getViewTypeMask())).thenReturn(getFailedFuture(mockException));
+		when(mockJsClient.getDefaultColumnsForView(TableType.project_view.getViewTypeMask())).thenReturn(getFailedFuture(mockException));
 		fileViewDefaultColumns = new ViewDefaultColumns(mockJsClient, adapterFactory, mockPopupUtils);
 
-		verify(mockJsClient, times(2)).getDefaultColumnsForView(TableType.projects.getViewTypeMask());
+		verify(mockJsClient, times(2)).getDefaultColumnsForView(TableType.project_view.getViewTypeMask());
 		verify(mockPopupUtils).showErrorMessage(errorMessage);
 	}
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TableEntityWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TableEntityWidgetTest.java
@@ -426,7 +426,7 @@ public class TableEntityWidgetTest {
 	
 	@Test
 	public void testOnExecuteViewQuery() {
-		TableType tableType = TableType.projects;
+		TableType tableType = TableType.project_view;
 		configureBundleWithView(ViewType.project);
 		boolean canEdit = true;
 		// Start with a query that is not on the first page
@@ -598,7 +598,7 @@ public class TableEntityWidgetTest {
 		verifyAdvancedSearchUI();
 		// SWC-4275: query results widget is not reconfigured when switching to advanced mode (since
 		// currently shown results are the same)
-		verify(mockQueryResultsWidget, never()).configure(any(Query.class), anyBoolean(), eq(TableType.files), eq(widget));
+		verify(mockQueryResultsWidget, never()).configure(any(Query.class), anyBoolean(), eq(TableType.file_view), eq(widget));
 	}
 
 	@Test
@@ -647,7 +647,7 @@ public class TableEntityWidgetTest {
 		callbackCaptor.getValue().invoke();
 		verifySimpleSearchUI();
 		// reset query
-		verify(mockQueryResultsWidget).configure(startQuery, canEdit, TableType.projects, widget);
+		verify(mockQueryResultsWidget).configure(startQuery, canEdit, TableType.project_view, widget);
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/QueryResultEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/QueryResultEditorWidgetTest.java
@@ -185,7 +185,7 @@ public class QueryResultEditorWidgetTest {
 
 	@Test
 	public void testOnEditView() {
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		widget.showEditor(bundle, tableType);
 		verify(mockView).setAddRowButtonVisible(false);
 		verify(mockView).setButtonToolbarVisible(false);
@@ -313,7 +313,7 @@ public class QueryResultEditorWidgetTest {
 
 	@Test
 	public void testOnSaveWithChangesValidJobSuccessfulIsView() {
-		tableType = TableType.projects;
+		tableType = TableType.project_view;
 		widget.showEditor(bundle, tableType);
 		reset(mockView);
 		reset(mockGlobalState);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/RowWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/RowWidgetTest.java
@@ -125,7 +125,7 @@ public class RowWidgetTest {
 	@Test
 	public void testViewSelectNotVisible() {
 		boolean isEditor = true;
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		rowWidget.configure(tableId, types, isEditor, tableType, aRow, mockListner);
 		// selection must be shown when given a listener.
 		verify(mockView).setSelectVisible(false);
@@ -152,7 +152,7 @@ public class RowWidgetTest {
 
 	@Test
 	public void testTakesAddressCellIsView() {
-		tableType = TableType.projects;
+		tableType = TableType.project_view;
 		TakesAddressCell mockTakesAddress = Mockito.mock(TakesAddressCell.class);
 		when(mockCellFactory.createRenderer(any(ColumnModel.class))).thenReturn(mockTakesAddress);
 		boolean isEditor = false;
@@ -163,13 +163,13 @@ public class RowWidgetTest {
 
 	@Test
 	public void testEditDefaultColumnModelsIsView() {
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		boolean isEditor = true;
 		HashSet<String> defaultColumnNames = new HashSet<String>();
 		for (ColumnModel cm : types) {
 			defaultColumnNames.add(cm.getName());
 		}
-		when(mockFileViewDefaultColumns.getDefaultViewColumnNames(TableType.files)).thenReturn(defaultColumnNames);
+		when(mockFileViewDefaultColumns.getDefaultViewColumnNames(TableType.file_view)).thenReturn(defaultColumnNames);
 		rowWidget.configure(tableId, types, isEditor, tableType, aRow, mockListner);
 		verify(mockCellFactory, times(types.size())).createRenderer(any(ColumnModel.class));
 		verify(mockCellFactory, never()).createEditor(any(ColumnModel.class));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
@@ -17,7 +17,6 @@ import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryR
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +39,6 @@ import org.sagebionetworks.repo.model.table.RowSet;
 import org.sagebionetworks.repo.model.table.SelectColumn;
 import org.sagebionetworks.repo.model.table.SortDirection;
 import org.sagebionetworks.repo.model.table.SortItem;
-import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.PortalGinInjector;
@@ -316,7 +314,7 @@ public class TableQueryResultWidgetTest {
 	@Test
 	public void testConfigureSuccessNotEditable() {
 		boolean isEditable = false;
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		// Make the call that changes it all.
 		widget.configure(query, isEditable, tableType, mockListner);
 		verify(mockJobTrackingWidget).startAndTrackJob(eq(TableQueryResultWidget.RUNNING_QUERY_MESSAGE), eq(false), eq(AsynchType.TableQuery), any(QueryBundleRequest.class), asyncProgressHandlerCaptor.capture());
@@ -339,7 +337,7 @@ public class TableQueryResultWidgetTest {
 	public void testConfigureEmptyResults() {
 		// no rows are returned
 		boolean isEditable = false;
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		rowSet.setRows(Collections.EMPTY_LIST);
 
 		widget.configure(query, isEditable, tableType, mockListner);
@@ -469,7 +467,7 @@ public class TableQueryResultWidgetTest {
 		String column1 = "col1", column2 = "col2";
 		// initialize with an empty sort
 		boolean isEditable = false;
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		query.setSort(null);
 
 		widget.configure(query, isEditable, tableType, mockListner);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/FileCellRendererImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/FileCellRendererImplTest.java
@@ -80,7 +80,7 @@ public class FileCellRendererImplTest {
 
 	@Test
 	public void testCreateAnchorHrefView() {
-		tableType = TableType.projects;
+		tableType = TableType.project_view;
 		address = new CellAddress(tableId, column, rowId, rowVersion, tableType);
 		renderer.setCellAddresss(address);
 		renderer.setValue(fileHandleId);
@@ -90,7 +90,7 @@ public class FileCellRendererImplTest {
 
 	@Test
 	public void testCreateAnchorHrefFileViewMissingRowId() {
-		tableType = TableType.files;
+		tableType = TableType.file_view;
 		rowId = null;
 		address = new CellAddress(tableId, column, rowId, rowVersion, tableType);
 		renderer.setCellAddresss(address);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsEditorWidgetTest.java
@@ -161,7 +161,7 @@ public class ColumnModelsEditorWidgetTest {
 	public void testFileView() {
 		// try to add non-editable column
 		when(mockGinInjector.createColumnModelEditorWidget()).thenReturn(mockColumnModelTableRowEditorWidget1, mockColumnModelTableRowEditorWidget2);
-		widget.configure(TableType.files, nonEditableColumns);
+		widget.configure(TableType.file_view, nonEditableColumns);
 		verify(mockGinInjector, times(nonEditableColumns.size())).createColumnModelEditorWidget();
 		verify(mockColumnModelTableRowEditorWidget1).setToBeDefaultFileViewColumn();
 		verify(mockColumnModelTableRowEditorWidget2).setToBeDefaultFileViewColumn();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsWidgetTest.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.unitclient.widget.table.v2.schema;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -12,6 +11,9 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.web.shared.WebConstants.FILE;
+import static org.sagebionetworks.web.shared.WebConstants.TABLE;
+
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -409,13 +411,13 @@ public class ColumnModelsWidgetTest {
 	@Test
 	public void testGetTableType() {
 		when(mockView.getViewTypeMask()).thenReturn(ViewTypeMask.getMaskForDepricatedType(org.sagebionetworks.repo.model.table.ViewType.file));
-		assertEquals(TableType.files, TableType.getTableType(mockView));
+		assertEquals(TableType.file_view, TableType.getTableType(mockView));
 
 		when(mockView.getViewTypeMask()).thenReturn(ViewTypeMask.getMaskForDepricatedType(org.sagebionetworks.repo.model.table.ViewType.file_and_table));
-		assertEquals(TableType.files_tables, TableType.getTableType(mockView));
+		assertEquals(new TableType(EntityView.class, FILE | TABLE), TableType.getTableType(mockView));
 
 		when(mockView.getViewTypeMask()).thenReturn(ViewTypeMask.getMaskForDepricatedType(org.sagebionetworks.repo.model.table.ViewType.project));
-		assertEquals(TableType.projects, TableType.getTableType(mockView));
+		assertEquals(TableType.project_view, TableType.getTableType(mockView));
 
 		assertEquals(TableType.table, TableType.getTableType(table));
 	}


### PR DESCRIPTION
[SWC-5906](https://sagebionetworks.jira.com/browse/SWC-5906)

Adds the 'Dataset' checkbox to the view mask editor.

This also fixes changes (will create/find tickets)
- [SWC-5924](https://sagebionetworks.jira.com/browse/SWC-5924) use "Project View"/"File View"/"View" in place of "Entity View" in action menu
- [SWC-5925](https://sagebionetworks.jira.com/browse/SWC-5925) ability to see views with certain masks (e.g. syn26642421 cannot be opened in Synapse.org, which is Views and Datasets)
- do not open modal for Views that have masks that cannot be edited (e.g. Project Views and any views that have unsupported scopes)