### PR TITLE
SWC-5928 - If only one ActionMenu Action is visible, replace the dropdown with a button

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-transition-group": "2.6.0",
     "sanitize-html": "^1.18.4",
     "sass": "1.36.0",
-    "synapse-react-client": "2.1.4",
+    "synapse-react-client": "2.1.6",
     "universal-cookie": "^4.0.3"
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
@@ -901,6 +901,11 @@ public class SynapseJavascriptClient {
 		doGet(url, OBJECT_TYPE.ChallengePagedResults, callback);
 	}
 
+	public FluentFuture<Challenge> getChallengeForProject(String projectId) {
+		String url = getRepoServiceUrl() + ENTITY + "/" + projectId + "/" + CHALLENGE;
+		return getFuture(cb -> doGet(url, OBJECT_TYPE.Challenge, cb));
+	}
+
 	public void getUserBundle(Long principalId, int mask, AsyncCallback<UserBundle> callback) {
 		String url = getRepoServiceUrl() + USER + "/" + principalId + BUNDLE_MASK_PATH + mask;
 		doGet(url, OBJECT_TYPE.UserBundle, callback);

--- a/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptFactory.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptFactory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.AccessRequirementInstanceFactory;
+import org.sagebionetworks.repo.model.Challenge;
 import org.sagebionetworks.repo.model.ChallengePagedResults;
 import org.sagebionetworks.repo.model.Count;
 import org.sagebionetworks.repo.model.Entity;
@@ -89,7 +90,7 @@ import org.sagebionetworks.web.shared.exceptions.ResultNotReadyException;
 public class SynapseJavascriptFactory {
 	public enum OBJECT_TYPE {
 		ValidationResults, JsonSchemaObjectBinding, PaginatedResultsEvaluations, Evaluation, EntityBundle, Team, RestrictionInformationResponse, EntityChildrenResponse, WikiPageKey, UserGroupHeaderResponsePage, WikiPage, ListWrapperUserProfile, ListWrapperTeam, ListWrapperUploadDestinations, SubscriptionPagedResults, UserGroupHeaderResponse, UserBundle, Count, PaginatedResultsEntityHeader, ProjectHeaderList, PaginatedResultReference, V2WikiPage, V2WikiOrderHint, DockerRepository, PaginatedDockerCommit, FileEntity, Project, Folder, EntityView, TableEntity, Link, Preview, SubmissionPage, Entity, // used for services where we don't know what type of entity is returned (but object has concreteType set)
-		AccessRequirement, EntityId, Forum, DiscussionThreadBundle, DiscussionReplyBundle, MessageURL, ThreadCount, EntityThreadCounts, PaginatedIds, SubscriberPagedResults, SubscriberCount, BatchFileResult, UserProfile, FileHandleResults, AsyncResponse, JSON, MembershipInvitation, TeamMembershipStatus, InviteeVerificationSignedToken, ListWrapperColumnModel, PaginatedTeamIds, AsyncJobId, LoginResponse, ChallengePagedResults, Etag, Activity, Annotations, MultipartUploadStatus, NotificationEmail, BatchPresignedUploadUrlResponse, AddPartResponse, AccessApprovalNotificationResponse, PaginatedResultsTotalNumberOfResults, PrincipalAliasResponse, DownloadList, DownloadOrder, DownloadOrderSummaryResponse, Doi, Subscription, SearchResults, SnapshotResponse, PaginatedColumnModelsResults, 
+		AccessRequirement, EntityId, Forum, DiscussionThreadBundle, DiscussionReplyBundle, MessageURL, ThreadCount, EntityThreadCounts, PaginatedIds, SubscriberPagedResults, SubscriberCount, BatchFileResult, UserProfile, FileHandleResults, AsyncResponse, JSON, MembershipInvitation, TeamMembershipStatus, InviteeVerificationSignedToken, ListWrapperColumnModel, PaginatedTeamIds, AsyncJobId, LoginResponse, Challenge, ChallengePagedResults, Etag, Activity, Annotations, MultipartUploadStatus, NotificationEmail, BatchPresignedUploadUrlResponse, AddPartResponse, AccessApprovalNotificationResponse, PaginatedResultsTotalNumberOfResults, PrincipalAliasResponse, DownloadList, DownloadOrder, DownloadOrderSummaryResponse, Doi, Subscription, SearchResults, SnapshotResponse, PaginatedColumnModelsResults,
 		PaginatedResultsVersionInfo, PaginatedResultsDiscussionThreadBundle, PaginatedResultsDiscussionReplyBundle, PaginatedResultsV2WikiHeader, PaginatedResultsTeamMember, SubmissionInfoPage, UploadDestination, AddBatchOfFilesToDownloadListResponse, None, String
 	}
 
@@ -205,6 +206,8 @@ public class SynapseJavascriptFactory {
 				return new DownloadOrder(json);
 			case DownloadOrderSummaryResponse:
 				return new DownloadOrderSummaryResponse(json);
+			case Challenge:
+				return new Challenge(json);
 			case ChallengePagedResults:
 				return new ChallengePagedResults(json).getResults();
 			case SubscriptionPagedResults:

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -25,6 +25,7 @@ public class SRC {
 		public static ReactFunctionComponent<IconSvgProps> IconSvg;
 		public static ReactFunctionComponent<EntityTypeIconProps> EntityTypeIcon;
 		public static ReactFunctionComponent<UserProfileLinksProps> UserProfileLinks;
+		public static ReactFunctionComponent<SkeletonButtonProps> SkeletonButton;
 		public static ReactFunctionComponent SynapseToastContainer;
 
 		/**

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SkeletonButtonProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SkeletonButtonProps.java
@@ -1,0 +1,19 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class SkeletonButtonProps extends ReactComponentProps {
+	@JsNullable
+	String placeholderText;
+	
+	@JsOverlay
+	public static SkeletonButtonProps create(String placeholderText) {
+		SkeletonButtonProps props = new SkeletonButtonProps();
+		props.placeholderText = placeholderText;
+		return props;
+	}
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/asynch/IsACTMemberAsyncHandler.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/asynch/IsACTMemberAsyncHandler.java
@@ -2,6 +2,8 @@ package org.sagebionetworks.web.client.widget.asynch;
 
 import org.sagebionetworks.web.client.utils.CallbackP;
 
+import com.google.common.util.concurrent.FluentFuture;
+
 public interface IsACTMemberAsyncHandler {
 	/**
 	 * Main call. Returns true if the current user is a member of the ACT, and we are currently showing
@@ -11,12 +13,16 @@ public interface IsACTMemberAsyncHandler {
 	 */
 	void isACTActionAvailable(CallbackP<Boolean> callback);
 
+	FluentFuture<Boolean> isACTActionAvailable();
+
 	/**
 	 * In most cases, isACTActionsAvailable() should be used instead of this method.
 	 * 
 	 * @param callback
 	 */
 	void isACTMember(CallbackP<Boolean> callback);
+
+	FluentFuture<Boolean> isACTMember();
 
 	/**
 	 * If the current user is a member of the ACT, should ACT UI be shown?

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidget.java
@@ -77,4 +77,6 @@ public interface ActionMenuWidget extends IsWidget, ActionListener {
 	void setTableDownloadOptionsVisible(boolean visible);
 
 	void setTableDownloadOptionsEnabled(boolean enabled);
+
+	void setIsLoading(boolean isLoading);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetImpl.java
@@ -138,7 +138,7 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 			view.setSingleActionButton(actionViewMap.get(singleAction).getText(), clickEvent -> onAction(finalSingleAction));
 		}
 
-		view.setActionsVisible(numVisible, isLoading);
+		view.updateVisibleActions(numVisible, isLoading);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetImpl.java
@@ -25,6 +25,8 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 	Map<Action, ActionView> actionViewMap;
 	Map<Action, List<ActionListener>> actionListenerMap;
 
+	private boolean isLoading = false;
+
 	@Inject
 	public ActionMenuWidgetImpl(ActionMenuWidgetView view) {
 		this.view = view;
@@ -54,9 +56,7 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 	@Override
 	public void setActionVisible(Action action, boolean visible) {
 		getActionView(action).setVisible(visible);
-		if (visible) {
-			view.setNoActionsAvailableVisible(false);
-		}
+		updateViewWithNumberOfActionsVisible();
 	}
 
 	@Override
@@ -120,7 +120,25 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 			getActionView(action).setVisible(false);
 		}
 		setACTDividerVisible(false);
-		view.setNoActionsAvailableVisible(true);
+		updateViewWithNumberOfActionsVisible();
+	}
+
+	private void updateViewWithNumberOfActionsVisible() {
+		int numVisible = 0;
+		Action singleAction = null;
+		for (Action action : this.actionListenerMap.keySet()) {
+			if (getActionView(action).isVisible()) {
+				numVisible++;
+				singleAction = action;
+			}
+		}
+
+		if (numVisible == 1) {
+			final Action finalSingleAction = singleAction;
+			view.setSingleActionButton(actionViewMap.get(singleAction).getText(), clickEvent -> onAction(finalSingleAction));
+		}
+
+		view.setActionsVisible(numVisible, isLoading);
 	}
 
 	@Override
@@ -149,7 +167,7 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 	public void setToolsButtonIcon(String text, IconType icon) {
 		view.setToolsButtonIcon(text, icon);
 	}
-	
+
 	@Override
 	public void setTableDownloadOptionsVisible(boolean visible) {
 		view.setTableDownloadOptionsVisible(visible);
@@ -158,5 +176,11 @@ public class ActionMenuWidgetImpl implements ActionMenuWidget, ActionListener {
 	@Override
 	public void setTableDownloadOptionsEnabled(boolean enabled) {
 		view.setDownloadActionsEnabled(enabled);
+	}
+
+	@Override
+	public void setIsLoading(boolean isLoading) {
+		this.isLoading = isLoading;
+		updateViewWithNumberOfActionsVisible();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetView.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.web.client.widget.entity.menu.v2;
 
 import org.gwtbootstrap3.client.ui.constants.IconType;
+
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.IsWidget;
 
 /**
@@ -30,9 +32,11 @@ public interface ActionMenuWidgetView extends IsWidget {
 
 	void setACTDividerVisible(boolean visible);
 
-	void setNoActionsAvailableVisible(boolean visible);
+	void setActionsVisible(int numActions, boolean isLoading);
 
 	void setTableDownloadOptionsVisible(boolean visible);
 
 	void setDownloadActionsEnabled(boolean enabled);
+
+	void setSingleActionButton(String buttonText, ClickHandler handler);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetView.java
@@ -32,7 +32,7 @@ public interface ActionMenuWidgetView extends IsWidget {
 
 	void setACTDividerVisible(boolean visible);
 
-	void setActionsVisible(int numActions, boolean isLoading);
+	void updateVisibleActions(int numActions, boolean isLoading);
 
 	void setTableDownloadOptionsVisible(boolean visible);
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.java
@@ -118,7 +118,7 @@ public class ActionMenuWidgetViewImpl implements ActionMenuWidgetView {
 	}
 
 	@Override
-	public void setActionsVisible(int numActions, boolean isLoading) {
+	public void updateVisibleActions(int numActions, boolean isLoading) {
 		if (isLoading) {
 			ReactElement component = React.createElement(SRC.SynapseComponents.SkeletonButton, SkeletonButtonProps.create("Tools Menu"));
 			ReactDOM.render(component, skeletonButton.getElement());

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.web.client.widget.entity.menu.v2;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Divider;
 import org.gwtbootstrap3.client.ui.DropDown;
@@ -11,7 +12,14 @@ import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Trigger;
 import org.gwtbootstrap3.client.ui.html.Div;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactDOM;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.jsinterop.SkeletonButtonProps;
+import org.sagebionetworks.web.client.widget.ReactComponentDiv;
 
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.ComplexPanel;
@@ -38,6 +46,8 @@ public class ActionMenuWidgetViewImpl implements ActionMenuWidgetView {
 	@UiField
 	Button toolsMenu;
 
+	@UiField
+	Button singleActionButton;
 	FlowPanel widget;
 	@UiField
 	Divider actDivider;
@@ -55,6 +65,8 @@ public class ActionMenuWidgetViewImpl implements ActionMenuWidgetView {
 	Tooltip addToDownloadListMenuItemTooltip;
 	@UiField
 	Tooltip programmaticOptionsMenuItemTooltip;
+	@UiField
+	ReactComponentDiv skeletonButton;
 
 	@Inject
 	public ActionMenuWidgetViewImpl(Binder binder) {
@@ -104,7 +116,51 @@ public class ActionMenuWidgetViewImpl implements ActionMenuWidgetView {
 		actDivider.setVisible(visible);
 		actHeader.setVisible(visible);
 	}
-	
+
+	@Override
+	public void setActionsVisible(int numActions, boolean isLoading) {
+		if (isLoading) {
+			ReactElement component = React.createElement(SRC.SynapseComponents.SkeletonButton, SkeletonButtonProps.create("Tools Menu"));
+			ReactDOM.render(component, skeletonButton.getElement());
+			skeletonButton.setVisible(true);
+			dropdown.setVisible(false);
+			singleActionButton.setVisible(false);
+		} else if (numActions == 0) {
+			setNoActionsVisible();
+		} else if (numActions == 1) {
+			setOneActionVisible();
+		} else {
+			setMultipleActionsVisible();
+		}
+	}
+
+	@Override
+	public void setSingleActionButton(String buttonText, ClickHandler handler) {
+		singleActionButton.setText(buttonText);
+		singleActionButton.addClickHandler(handler);
+	}
+
+	private void setNoActionsVisible() {
+		noActionsAvailable.setVisible(true);
+		dropdown.setVisible(true);
+		singleActionButton.setVisible(false);
+		skeletonButton.setVisible(false);
+	}
+
+	private void setOneActionVisible() {
+		noActionsAvailable.setVisible(false);
+		dropdown.setVisible(false);
+		singleActionButton.setVisible(true);
+		skeletonButton.setVisible(false);
+	}
+
+	private void setMultipleActionsVisible() {
+		noActionsAvailable.setVisible(false);
+		dropdown.setVisible(true);
+		singleActionButton.setVisible(false);
+		skeletonButton.setVisible(false);
+	}
+
 	@Override
 	public void setTableDownloadOptionsVisible(boolean visible) {
 		tableDownloadOptions.setVisible(visible);
@@ -129,15 +185,10 @@ public class ActionMenuWidgetViewImpl implements ActionMenuWidgetView {
 		addToDownloadListMenuItemTooltip.recreate();
 		programmaticOptionsMenuItemTooltip.recreate();
 	}
-	
+
 	@Override
 	public void setToolsButtonIcon(String text, IconType icon) {
 		toolsMenu.setText(text);
 		toolsMenu.setIcon(icon);
-	}
-
-	@Override
-	public void setNoActionsAvailableVisible(boolean visible) {
-		noActionsAvailable.setVisible(visible);
 	}
 }

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/menu/v2/ActionMenuWidgetViewImpl.ui.xml
@@ -3,7 +3,9 @@
 	xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:c="urn:import:com.google.gwt.user.cellview.client"
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
 	xmlns:a="urn:import:org.sagebionetworks.web.client.widget.entity.menu.v2"
-	xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html">
+	xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
+    xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
+    xmlns:w="urn:import:org.sagebionetworks.web.client.widget">
 
 	<g:FlowPanel>
 		<b:Tooltip title="Show advanced search">
@@ -33,6 +35,8 @@
 				</b:Tooltip>
 			</b:DropDownMenu>
 		</b:DropDown>
+        <w:ReactComponentDiv ui:field="skeletonButton"  addStyleNames="displayInlineBlock"></w:ReactComponentDiv>
+        <b:Button ui:field="singleActionButton"  addStyleNames="displayInlineBlock"></b:Button>
 		<b:DropDown ui:field="dropdown" addStyleNames="displayInlineBlock">
 			<b:Button icon="GEARS" ui:field="toolsMenu" addStyleNames="toolsMenuButton" dataToggle="DROPDOWN">Tools</b:Button>
 			<b:DropDownMenu ui:field="toolsDropDown"

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -1978,7 +1978,7 @@ public class EntityActionControllerImplTest {
 	}
 
 	@Test
-	public void testConfigureManageAccessRequirementsAsACTMember() {
+	public void testConfigureManageAccessRequirementsAsNonACTMember() {
 		entityBundle.setEntity(new Folder());
 		entityBundle.setRootWikiId("7890");
 		when(mockIsACTMemberAsyncHandler.isACTActionAvailable()).thenReturn(getDoneFuture(false));
@@ -1992,7 +1992,7 @@ public class EntityActionControllerImplTest {
 	}
 
 	@Test
-	public void testConfigureManageAccessRequirementsAsACTMemberAsNonACTMember() {
+	public void testConfigureManageAccessRequirementsAsACTMemberAsACTMember() {
 		entityBundle.setEntity(new Folder());
 		entityBundle.setRootWikiId("7890");
 		when(mockIsACTMemberAsyncHandler.isACTActionAvailable()).thenReturn(getDoneFuture(true));

--- a/yarn.lock
+++ b/yarn.lock
@@ -11668,10 +11668,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synapse-react-client@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-2.1.4.tgz#df359896be584f9cb343ee2b36e7d1173ab46a80"
-  integrity sha512-w5Ko4oYEUrU2dB3WJo1P+FagcP5QrKAabcAJx9s4nidOR52KKwdktMg6+2KAVwOLDzxqnoa4XLMFloWmZf9uqg==
+synapse-react-client@2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-2.1.6.tgz#7ecc8491024e474ddcee0cefa5d19e0b70cbded5"
+  integrity sha512-9w9ZvCFgNXISvJykfeS3y7eqMc8GvERNRQ3S8chFWfD8EtGYZS/DR/LilRK5OeSIE5KbNWKtxoP5gUJHE0NiXA==
   dependencies:
     "@brainhubeu/react-carousel" "1.19.26"
     "@fortawesome/fontawesome-free" "^5.13.0"


### PR DESCRIPTION
[Jira](https://sagebionetworks.jira.com/browse/SWC-5928)

Loading Skeleton:

https://user-images.githubusercontent.com/17580037/150004701-c45a3f3d-284b-4e89-9128-ec8715ee3e6e.mov

Ignore that the font doesn't load first; I had to throttle my connection in the browser to simulate the loading

Single action:
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/17580037/150004870-39d3359c-fc92-4b08-85bc-86ca29ce00d6.png">

* Add two new states to the action menu
	* Loading, where a skeleton button is shown
	* One visible action, where the dropdown is replaced with a single button with the sole visible action
* Requires exposing the React SkeletonButton from SRC, which has not been done

This is in Draft mode because an upgrade to SRC where SkeletonButton is exposed in the UMD build is required.