### PR TITLE
SWC-5950

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultView.java
@@ -70,4 +70,8 @@ public interface TableQueryResultView extends IsWidget {
 
 	void scrollTableIntoView();
 
+	void setResultCount(Long resultCount);
+
+	void setResultCountVisible(boolean visible);
+
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.java
@@ -1,8 +1,10 @@
 package org.sagebionetworks.web.client.widget.table.v2.results;
 
+import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.widget.asynch.JobTrackingWidget;
+
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -33,6 +35,8 @@ public class TableQueryResultViewImpl implements TableQueryResultView {
 	Div scrollTarget;
 	@UiField
 	Div facetsWidgetPanel;
+	@UiField
+	Heading resultCountHeader;
 
 	Widget widget;
 
@@ -90,6 +94,22 @@ public class TableQueryResultViewImpl implements TableQueryResultView {
 	@Override
 	public void scrollTableIntoView() {
 		jsniUtils.scrollIntoView(scrollTarget.getElement());
+	}
+
+	@Override
+	public void setResultCount(Long resultCount) {
+		if (resultCount == null || new Long(0).equals(resultCount)) {
+			resultCountHeader.setText("No Results");
+		} else if (new Long(0).equals(resultCount)) {
+			resultCountHeader.setText("1 Result");
+		} else {
+			resultCountHeader.setText(resultCount + " Results");
+		}
+	}
+
+	@Override
+	public void setResultCountVisible(boolean visible) {
+		resultCountHeader.setVisible(visible);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.java
@@ -100,7 +100,7 @@ public class TableQueryResultViewImpl implements TableQueryResultView {
 	public void setResultCount(Long resultCount) {
 		if (resultCount == null || new Long(0).equals(resultCount)) {
 			resultCountHeader.setText("No Results");
-		} else if (new Long(0).equals(resultCount)) {
+		} else if (new Long(1).equals(resultCount)) {
 			resultCountHeader.setText("1 Result");
 		} else {
 			resultCountHeader.setText(resultCount + " Results");

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
@@ -302,7 +302,7 @@ public class TableQueryResultWidget implements TableQueryResultView.Presenter, I
 			showError("No rows returned.");
 		}
 
-		fireFinishEvent( true, isQueryResultEditable());
+		fireFinishEvent(true, isQueryResultEditable());
 	}
 
 	/**

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
@@ -277,7 +277,6 @@ public class TableQueryResultWidget implements TableQueryResultView.Presenter, I
 			// See CACHED_PARTS_MASK for which parts are cached
 			bundle.setQueryCount(cachedFullQueryResultBundle.getQueryCount());
 			bundle.setColumnModels(cachedFullQueryResultBundle.getColumnModels());
-			bundle.setFacets(cachedFullQueryResultBundle.getFacets());
 			bundle.setSelectColumns(cachedFullQueryResultBundle.getSelectColumns());
 		} else {
 			cachedFullQueryResultBundle = bundle;

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWidget.java
@@ -62,7 +62,7 @@ public class TableQueryResultWidget implements TableQueryResultView.Presenter, I
 	public static final long BUNDLE_MASK_QUERY_LAST_UPDATED = 0x80;
 
 	// We cache these parts of the QueryResultBundle
-	public static final long CACHED_PARTS_MASK = BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_COUNT;
+	private static final long CACHED_PARTS_MASK = BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_COUNT;
 
 	private static final Long ALL_PARTS_MASK = new Long(255);
 	SynapseClientAsync synapseClient;

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.ui.xml
@@ -16,8 +16,8 @@
 				<bh:ClearFix />
 				<bh:Div ui:field="facetsWidgetPanel" />
 				<g:SimplePanel ui:field="progressPanel" />
-                <b:Heading size="H4" ui:field="resultCountHeader" visible="false" text="0 Results" />
-                <g:SimplePanel ui:field="tablePanel" />
+				<b:Heading size="H4" ui:field="resultCountHeader" visible="false" text="0 Results" />
+				<g:SimplePanel ui:field="tablePanel" />
 				<g:SimplePanel ui:field="rowEditorModalPanel" />
 			</b:PanelBody>
 		</b:Panel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultViewImpl.ui.xml
@@ -16,7 +16,8 @@
 				<bh:ClearFix />
 				<bh:Div ui:field="facetsWidgetPanel" />
 				<g:SimplePanel ui:field="progressPanel" />
-				<g:SimplePanel ui:field="tablePanel" />
+                <b:Heading size="H4" ui:field="resultCountHeader" visible="false" text="0 Results" />
+                <g:SimplePanel ui:field="tablePanel" />
 				<g:SimplePanel ui:field="rowEditorModalPanel" />
 			</b:PanelBody>
 		</b:Panel>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
@@ -275,7 +275,7 @@ public class TableQueryResultWidgetTest {
 		// only called once (on previous page load) because sql was in the sql2SortItems cache
 		verify(mockView).scrollTableIntoView();
 		verify(mockJobTrackingWidget2).startAndTrackJob(eq(TableQueryResultWidget.RUNNING_QUERY_MESSAGE), eq(false), eq(AsynchType.TableQuery), qbrCaptor.capture(), asyncProgressHandlerCaptor.capture());
-		// verify we are not asking for the cached result values (column models, select columns, facets, query count)
+		// verify we are not asking for the cached result values (column models, select columns, query count)
 		partsMask = qbrCaptor.getValue().getPartMask();
 		expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_LAST_UPDATED;
 		assertEquals(expectedPartsMask, partsMask);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
@@ -4,20 +4,25 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.*;
+import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.BUNDLE_MASK_QUERY_COLUMN_MODELS;
+import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.BUNDLE_MASK_QUERY_COUNT;
+import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.BUNDLE_MASK_QUERY_LAST_UPDATED;
 import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.BUNDLE_MASK_QUERY_RESULTS;
 import static org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWidget.BUNDLE_MASK_QUERY_SELECT_COLUMNS;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,7 +33,6 @@ import org.sagebionetworks.repo.model.ErrorResponseCode;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.FacetColumnRequest;
-import org.sagebionetworks.repo.model.table.FacetColumnResult;
 import org.sagebionetworks.repo.model.table.PartialRowSet;
 import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.QueryBundleRequest;
@@ -59,6 +63,7 @@ import org.sagebionetworks.web.client.widget.table.v2.results.TableQueryResultWi
 import org.sagebionetworks.web.client.widget.table.v2.results.facets.FacetsWidget;
 import org.sagebionetworks.web.shared.asynch.AsynchType;
 import org.sagebionetworks.web.shared.exceptions.BadRequestException;
+
 import com.google.gwt.user.client.ui.Widget;
 
 public class TableQueryResultWidgetTest {
@@ -110,8 +115,6 @@ public class TableQueryResultWidgetTest {
 	@Captor
 	ArgumentCaptor<QueryBundleRequest> qbrCaptor;
 	@Mock
-	FacetColumnResult mockFacetColumnResult;
-	@Mock
 	ColumnModel mockColumnModel;
 	@Mock
 	SelectColumn mockSelectColumn;
@@ -146,7 +149,6 @@ public class TableQueryResultWidgetTest {
 		bundle.setMaxRowsPerPage(123L);
 		bundle.setQueryCount(QUERY_COUNT);
 		bundle.setQueryResult(results);
-		bundle.setFacets(Collections.singletonList(mockFacetColumnResult));
 		bundle.setColumnModels(Collections.singletonList(mockColumnModel));
 		bundle.setSelectColumns(Collections.singletonList(mockSelectColumn));
 		
@@ -281,8 +283,8 @@ public class TableQueryResultWidgetTest {
 		progressHandler2.onComplete(mockNewPageQueryResultBundle);
 		// verify cached results are set on the new result
 		verify(mockNewPageQueryResultBundle).setColumnModels(bundle.getColumnModels());
-		verify(mockNewPageQueryResultBundle).setFacets(bundle.getFacets());
 		verify(mockNewPageQueryResultBundle).setSelectColumns(bundle.getSelectColumns());
+		verify(mockNewPageQueryResultBundle).setQueryCount(bundle.getQueryCount());
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWidgetTest.java
@@ -122,6 +122,7 @@ public class TableQueryResultWidgetTest {
 	@Mock
 	PopupUtilsView mockPopupUtils;
 	public static final String ENTITY_ID = "syn123";
+	public static final Long QUERY_COUNT = 88L;
 
 	@Before
 	public void before() {
@@ -143,7 +144,7 @@ public class TableQueryResultWidgetTest {
 		results.setQueryResults(rowSet);
 		bundle = new QueryResultBundle();
 		bundle.setMaxRowsPerPage(123L);
-		bundle.setQueryCount(88L);
+		bundle.setQueryCount(QUERY_COUNT);
 		bundle.setQueryResult(results);
 		bundle.setFacets(Collections.singletonList(mockFacetColumnResult));
 		bundle.setColumnModels(Collections.singletonList(mockColumnModel));
@@ -195,6 +196,8 @@ public class TableQueryResultWidgetTest {
 		verify(mockListner, times(2)).queryExecutionStarted();
 		// Shown on success.
 		verify(mockPageWidget).setTableVisible(true);
+		verify(mockView).setResultCountVisible(true);
+		verify(mockView).setResultCount(QUERY_COUNT);
 		verify(mockListner).queryExecutionFinished(true, true);
 		verify(mockView).setProgressWidgetVisible(false);
 		verify(mockView).setSynapseAlertWidget(any(Widget.class));
@@ -256,7 +259,7 @@ public class TableQueryResultWidgetTest {
 
 		// verify all parts are initially asked for
 		Long partsMask = qbrCaptor.getValue().getPartMask();
-		Long expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_LAST_UPDATED;
+		Long expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_LAST_UPDATED | BUNDLE_MASK_QUERY_COUNT;
 		assertEquals(expectedPartsMask, partsMask);
 
 		// simulate complete table query async job
@@ -270,7 +273,7 @@ public class TableQueryResultWidgetTest {
 		// only called once (on previous page load) because sql was in the sql2SortItems cache
 		verify(mockView).scrollTableIntoView();
 		verify(mockJobTrackingWidget2).startAndTrackJob(eq(TableQueryResultWidget.RUNNING_QUERY_MESSAGE), eq(false), eq(AsynchType.TableQuery), qbrCaptor.capture(), asyncProgressHandlerCaptor.capture());
-		// verify we are not asking for the cached result values (column models, select columns, facets)
+		// verify we are not asking for the cached result values (column models, select columns, facets, query count)
 		partsMask = qbrCaptor.getValue().getPartMask();
 		expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_LAST_UPDATED;
 		assertEquals(expectedPartsMask, partsMask);
@@ -307,7 +310,7 @@ public class TableQueryResultWidgetTest {
 
 		// verify all parts are initially asked for
 		Long partsMask = qbrCaptor.getValue().getPartMask();
-		Long expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_LAST_UPDATED;
+		Long expectedPartsMask = BUNDLE_MASK_QUERY_RESULTS | BUNDLE_MASK_QUERY_COLUMN_MODELS | BUNDLE_MASK_QUERY_SELECT_COLUMNS | BUNDLE_MASK_QUERY_LAST_UPDATED | BUNDLE_MASK_QUERY_COUNT;
 		assertEquals(expectedPartsMask, partsMask);
 	}
 
@@ -329,6 +332,8 @@ public class TableQueryResultWidgetTest {
 		verify(mockListner).queryExecutionStarted();
 		// Shown on success.
 		verify(mockPageWidget).setTableVisible(true);
+		verify(mockView).setResultCountVisible(true);
+		verify(mockView).setResultCount(QUERY_COUNT);
 		verify(mockListner).queryExecutionFinished(true, true);
 		verify(mockView).setProgressWidgetVisible(false);
 	}
@@ -359,6 +364,7 @@ public class TableQueryResultWidgetTest {
 		asyncProgressHandlerCaptor.getValue().onComplete(bundle);
 
 		verify(mockView, times(2)).setErrorVisible(false);
+		verify(mockView).setResultCountVisible(true);
 		verify(mockView).setProgressWidgetVisible(true);
 		// Hidden while running query.
 		verify(mockPageWidget).setTableVisible(false);
@@ -389,6 +395,7 @@ public class TableQueryResultWidgetTest {
 		verify(mockListner).queryExecutionFinished(false, false);
 		verify(mockView).setProgressWidgetVisible(false);
 		verify(mockView).setErrorVisible(true);
+		verify(mockView).setResultCountVisible(false);
 		verify(mockPageWidget, times(2)).setTableVisible(false);
 		verify(mockSynapseAlert).showError(TableQueryResultWidget.QUERY_CANCELED);
 	}
@@ -412,6 +419,7 @@ public class TableQueryResultWidgetTest {
 		verify(mockListner).queryExecutionStarted();
 		// After a cancel
 		verify(mockListner).queryExecutionFinished(false, false);
+		verify(mockView).setResultCountVisible(false);
 		verify(mockView).setProgressWidgetVisible(false);
 		verify(mockView).setErrorVisible(true);
 		verify(mockPageWidget, times(2)).setTableVisible(false);


### PR DESCRIPTION
We'll now show the total number of results above the Query results for all Tables.

Like the facets and select columns, we'll cache the query count so the backend doesn't need to recompute it unless the Table or View changed.

![image](https://user-images.githubusercontent.com/17580037/153023043-fa918606-a86f-41a1-9500-21e95640800e.png)
