### PR TITLE
SWC-5837

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/table/TableListWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/TableListWidgetView.java
@@ -4,9 +4,19 @@ import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.entity.Direction;
 import org.sagebionetworks.repo.model.entity.SortBy;
 import org.sagebionetworks.web.client.SynapseView;
+import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
+
 import com.google.gwt.user.client.ui.IsWidget;
 
 public interface TableListWidgetView extends IsWidget, SynapseView {
+
+	public enum TableListWidgetViewState {
+		/** Loading the initial rows to show. Should NOT be used to indicate "Load More" */
+		LOADING,
+		EMPTY,
+		POPULATED,
+		ERROR
+	}
 
 	/**
 	 * Set the presenter.
@@ -29,6 +39,8 @@ public interface TableListWidgetView extends IsWidget, SynapseView {
 		void copyIDsToClipboard();
 	}
 
+	void setTableType(TableType tableType);
+
 	void clearTableWidgets();
 
 	void addTableListItem(EntityHeader header);
@@ -41,7 +53,7 @@ public interface TableListWidgetView extends IsWidget, SynapseView {
 
 	void setSortUI(SortBy sortBy, Direction dir);
 
-	void hideLoading();
+	void setState(TableListWidgetViewState state);
 
 	void copyToClipboard(String ids);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.repo.model.table.SortDirection;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.widget.LoadingSpinner;
+import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
 import org.sagebionetworks.web.client.widget.table.v2.results.SortableTableHeaderImpl;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -33,6 +34,8 @@ public class TableListWidgetViewImpl implements TableListWidgetView {
 	Div loadMoreWidgetContainer;
 	@UiField
 	Div synAlertContainer;
+	@UiField
+	Div tableArea;
 	@UiField
 	Span emptyUI;
 	@UiField
@@ -90,7 +93,6 @@ public class TableListWidgetViewImpl implements TableListWidgetView {
 
 	@Override
 	public void addTableListItem(final EntityHeader header) {
-		emptyUI.setVisible(false);
 		TableEntityListGroupItem item = ginInjector.getTableEntityListGroupItem();
 		item.configure(header, event -> {
 			presenter.onTableClicked(header);
@@ -101,7 +103,6 @@ public class TableListWidgetViewImpl implements TableListWidgetView {
 	@Override
 	public void clearTableWidgets() {
 		tablesList.clear();
-		emptyUI.setVisible(true);
 	}
 
 	@Override
@@ -116,13 +117,21 @@ public class TableListWidgetViewImpl implements TableListWidgetView {
 	}
 
 	@Override
-	public void showLoading() {
-		loadingUI.setVisible(true);
+	public void setTableType(TableType tableType) {
+		String emptyUiCopy = "&#8212; There are no " + tableType.getDisplayName() + "s associated with this project. Any " + tableType.getDisplayName() + "s you create in this project will appear here.";
+		emptyUI.setHTML(emptyUiCopy);
 	}
 
 	@Override
-	public void hideLoading() {
-		loadingUI.setVisible(false);
+	public void setState(TableListWidgetViewState state) {
+		loadingUI.setVisible(TableListWidgetViewState.LOADING.equals(state));
+		emptyUI.setVisible(TableListWidgetViewState.EMPTY.equals(state));
+		tableArea.setVisible(TableListWidgetViewState.POPULATED.equals(state));
+	}
+
+	@Override
+	public void showLoading() {
+		setState(TableListWidgetViewState.LOADING);
 	}
 
 	@Override

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.ui.xml
@@ -15,7 +15,7 @@
 			visible="false" marginLeft="15" />
 		<b:TextArea width="1px" ui:field="copyToClipboardTextbox"
 			visible="false" />
-		<bh:Div addStyleNames="highlight-box padding-10" marginTop="0">
+		<bh:Div ui:field="tableArea" addStyleNames="highlight-box padding-10" marginTop="0">
 			<t:Table ui:field="columnHeaders" width="100%">
 				<t:TableRow>
 					<t:TableHeader width="20px" />


### PR DESCRIPTION
* Cleaner "Empty" state for tables and datasets tabs
* View now recieves a state enum so we exclusively show loading vs empty vs populated views. Before we were showing the empty text, the table, and the loading spinner all at the same time. Now, you see the loading spinner only until we finish fetching items, and then only show the empty state or the table depending on the results.

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/17580037/156020596-f54e1930-8bcc-413c-85c8-ab343e1f0a4c.png">
