### PR TITLE
SWC-6055

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -1642,8 +1642,6 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 						if (!errors.isEmpty()) {
 							view.showErrorMessage(errors);
 						} else {
-							fireEntityUpdatedEvent();
-
 							ToastMessageOptions.Builder messageBuilder = new ToastMessageOptions.Builder();
 							EntityArea newVersionArea;
 							String toastMsg;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -1151,9 +1151,10 @@ public class EntityActionControllerImplTest {
 		// on success
 		handler.onComplete(mockTableUpdateTransactionResponse);
 		verify(mockView).hideCreateVersionDialog();
-		verify(mockEventBus).fireEvent(any(EntityUpdatedEvent.class));
 		verify(mockPopupUtils).notify(any(), any(), any(ToastMessageOptions.class));
 		verify(mockPlaceChanger).goTo(any());
+		// Don't fire an updated event; we used placeChanger to go to a new place.
+		verify(mockEventBus, never()).fireEvent(any(EntityUpdatedEvent.class));
 	}
 
 	@Test
@@ -1211,9 +1212,10 @@ public class EntityActionControllerImplTest {
 		// on success
 		handler.onComplete(mockTableUpdateTransactionResponse);
 		verify(mockView).hideCreateVersionDialog();
-		verify(mockEventBus).fireEvent(any(EntityUpdatedEvent.class));
 		verify(mockPopupUtils).notify(any(), any(), any(ToastMessageOptions.class));
 		verify(mockPlaceChanger).goTo(any());
+		// Don't fire an updated event; we used placeChanger to go to a new place.
+		verify(mockEventBus, never()).fireEvent(any(EntityUpdatedEvent.class));
 	}
 
 	@Test


### PR DESCRIPTION
Don't fire EntityUpdatedEvent and use placeChanger.goTo at the same time, it causes the page to break.

Merging this into release-399 because we may decide to release Datasets from experimental mode in release-399