### PR TITLE
SWC-6070 - Clear react-query entity cache on updated event

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-transition-group": "2.6.0",
     "sanitize-html": "^1.18.4",
     "sass": "1.36.0",
-    "synapse-react-client": "3.0.3",
+    "synapse-react-client": "3.0.4",
     "universal-cookie": "^4.0.3"
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
@@ -3,7 +3,10 @@ package org.sagebionetworks.web.client.context;
 import org.sagebionetworks.web.client.jsinterop.ReactComponentProps;
 import org.sagebionetworks.web.client.jsinterop.ReactFunctionComponent;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextProviderProps;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
 import org.sagebionetworks.web.client.jsni.SynapseContextProviderPropsJSNIObject;
+
+import jsinterop.annotations.JsOverlay;
 
 /**
  * Synapse React Client components must be wrapped in a SynapseContextProvider. A SynapseContextPropsProvider provides the props for the 
@@ -21,4 +24,9 @@ public interface SynapseContextPropsProvider {
      * using JsInterop before using JSNI.
      */
     SynapseContextProviderPropsJSNIObject getJsniContextProps();
+
+	/**
+	 * Returns the global QueryClient
+	 */
+	QueryClient getQueryClient();
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
@@ -28,6 +28,10 @@ public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvi
     @JsProperty(namespace = JsPackage.GLOBAL, name="SynapseQueryClient")
     static native void setQueryClient(QueryClient queryClient);
 
+	public QueryClient getQueryClient() {
+		return queryClientSingleton;
+	}
+
     @Inject
     SynapseContextPropsProviderImpl(final AuthenticationController authController, final GlobalApplicationState globalApplicationState, final CookieProvider cookies) {
         this.authController = authController;

--- a/src/main/java/org/sagebionetworks/web/client/events/EntityUpdatedEvent.java
+++ b/src/main/java/org/sagebionetworks/web/client/events/EntityUpdatedEvent.java
@@ -2,5 +2,26 @@ package org.sagebionetworks.web.client.events;
 
 import com.google.web.bindery.event.shared.binder.GenericEvent;
 
+/**
+ * When fired, refreshes the EntityPresenter and clears the react-query cache for the specified entity, or all entities
+ * if not specified.
+ */
 public class EntityUpdatedEvent extends GenericEvent {
+	private String entityId = null;
+
+	public EntityUpdatedEvent() {
+	}
+
+
+	public EntityUpdatedEvent(String entityId) {
+		this.entityId = entityId;
+	}
+
+	/**
+	 * Gets the ID of the updated entity. May be null.
+	 * @return
+	 */
+	public String getEntityId() {
+		return entityId;
+	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/events/EntityUpdatedEvent.java
+++ b/src/main/java/org/sagebionetworks/web/client/events/EntityUpdatedEvent.java
@@ -10,10 +10,12 @@ public class EntityUpdatedEvent extends GenericEvent {
 	private String entityId = null;
 
 	public EntityUpdatedEvent() {
+		super();
 	}
 
 
 	public EntityUpdatedEvent(String entityId) {
+		super();
 		this.entityId = entityId;
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
@@ -6,4 +6,6 @@ import jsinterop.annotations.JsType;
 public class QueryClient {
 
     public QueryClient(QueryClientOptions config) {}
+
+	public native void invalidateQueries(Object[] queryKey);
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/SynapseReactClientQueryKey.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/SynapseReactClientQueryKey.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.web.client.jsinterop.reactquery;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name="Object")
+public class SynapseReactClientQueryKey {
+
+	public String objectType;
+	@JsNullable
+	public String id;
+
+    @JsOverlay
+    public static SynapseReactClientQueryKey create(String objectType, String id) {
+        SynapseReactClientQueryKey defaultQueryKey = new SynapseReactClientQueryKey();
+		defaultQueryKey.objectType = objectType;
+		defaultQueryKey.id = id;
+        return defaultQueryKey;
+    }
+}
+
+
+

--- a/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
@@ -14,7 +14,10 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
+import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+import org.sagebionetworks.web.client.jsinterop.reactquery.SynapseReactClientQueryKey;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -52,9 +55,10 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 	private GlobalApplicationState globalAppState;
 	private GWTWrapper gwt;
 	private SynapseJavascriptClient jsClient;
+	private QueryClient queryClient;
 
 	@Inject
-	public EntityPresenter(EntityView view, EntityPresenterEventBinder entityPresenterEventBinder, GlobalApplicationState globalAppState, AuthenticationController authenticationController, SynapseJavascriptClient jsClient, StuAlert synAlert, EntityPageTop entityPageTop, Header headerWidget, OpenTeamInvitationsWidget openTeamInvitesWidget, GWTWrapper gwt, EventBus eventBus) {
+	public EntityPresenter(EntityView view, EntityPresenterEventBinder entityPresenterEventBinder, GlobalApplicationState globalAppState, AuthenticationController authenticationController, SynapseJavascriptClient jsClient, StuAlert synAlert, EntityPageTop entityPageTop, Header headerWidget, OpenTeamInvitationsWidget openTeamInvitesWidget, GWTWrapper gwt, EventBus eventBus, SynapseContextPropsProvider synapseContextPropsProvider) {
 		this.headerWidget = headerWidget;
 		this.entityPageTop = entityPageTop;
 		this.globalAppState = globalAppState;
@@ -64,6 +68,7 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 		this.authenticationController = authenticationController;
 		this.jsClient = jsClient;
 		this.gwt = gwt;
+		this.queryClient = synapseContextPropsProvider.getQueryClient();
 		clear();
 		entityPresenterEventBinder.getEventBinder().bindEventHandlers(this, eventBus);
 	}
@@ -268,6 +273,9 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 
 	@EventHandler
 	public void onEntityUpdatedEvent(EntityUpdatedEvent event) {
+		SynapseReactClientQueryKey queryKey = SynapseReactClientQueryKey.create("entity", event.getEntityId());
+		// The query key is an array where the first element is the object we constructed
+		queryClient.invalidateQueries(new Object[]{queryKey});
 		globalAppState.refreshPage();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
@@ -82,7 +82,7 @@ public class DockerRepoWidget {
 		final WikiPageWidget.Callback wikiCallback = new WikiPageWidget.Callback() {
 			@Override
 			public void pageUpdated() {
-				eventBus.fireEvent(new EntityUpdatedEvent());
+				eventBus.fireEvent(new EntityUpdatedEvent(entityId));
 			}
 
 			@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModal.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModal.java
@@ -238,7 +238,7 @@ public class CreateOrUpdateDoiModal implements CreateOrUpdateDoiModalView.Presen
 					toastMessage = "You successfully minted a DOI for this " + EntityTypeUtils.getFriendlyEntityTypeName(entity);
 				}
 				popupUtilsView.notify(toastTitle, toastMessage, DisplayUtils.NotificationVariant.SUCCESS);
-                eventBus.fireEvent(new EntityUpdatedEvent());
+                eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
                 view.setIsLoading(false);
                 view.hide();
             }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/EditAnnotationsDialog.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/annotation/EditAnnotationsDialog.java
@@ -134,7 +134,7 @@ public class EditAnnotationsDialog implements EditAnnotationsDialogView.Presente
 			public void onSuccess(Annotations result) {
 				view.showInfo("Successfully updated the annotations");
 				view.hideEditor();
-				ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent());
+				ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent(entityId));
 			}
 
 			@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -235,7 +235,7 @@ public class EntityActionControllerImpl implements EntityActionController, Actio
 	}
 
 	private void fireEntityUpdatedEvent() {
-		eventBus.fireEvent(new EntityUpdatedEvent());
+		eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
 	}
 
 	private WikiPageDeleteConfirmationDialog getWikiPageDeleteConfirmationDialog() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceEditorWidget.java
@@ -165,7 +165,7 @@ public class ProvenanceEditorWidget implements ProvenanceEditorWidgetView.Presen
 				@Override
 				public void onSuccess(Entity result) {
 					view.hide();
-					eventBus.fireEvent(new EntityUpdatedEvent());
+					eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
 				}
 			});
 		} else {
@@ -179,7 +179,7 @@ public class ProvenanceEditorWidget implements ProvenanceEditorWidgetView.Presen
 				@Override
 				public void onSuccess(Activity result) {
 					view.hide();
-					eventBus.fireEvent(new EntityUpdatedEvent());
+					eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
 				}
 			});
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StorageLocationWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StorageLocationWidget.java
@@ -171,7 +171,7 @@ public class StorageLocationWidget implements StorageLocationWidgetView.Presente
 				@Override
 				public void onSuccess(Void result) {
 					view.hide();
-					eventBus.fireEvent(new EntityUpdatedEvent());
+					eventBus.fireEvent(new EntityUpdatedEvent(entityBundle.getEntity().getId()));
 				}
 			};
 			synapseClient.createStorageLocationSetting(entityBundle.getEntity().getId(), setting, callback);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
@@ -315,7 +315,7 @@ public abstract class AbstractTablesTab implements TablesTabView.Presenter, Quer
 			final WikiPageWidget.Callback wikiCallback = new WikiPageWidget.Callback() {
 				@Override
 				public void pageUpdated() {
-					ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent());
+					ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent(entity.getId()));
 				}
 
 				@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
@@ -277,7 +277,7 @@ public class FilesTab {
 			final WikiPageWidget.Callback wikiCallback = new WikiPageWidget.Callback() {
 				@Override
 				public void pageUpdated() {
-					ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent());
+					ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent(entityBundle.getEntity().getId()));
 				}
 
 				@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/TableEntityPlotsWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/TableEntityPlotsWidget.java
@@ -596,7 +596,7 @@ public class TableEntityPlotsWidget implements TableEntityWidgetView.Presenter, 
 									.setPrimaryButton("Show Schema", () -> this.actionMenu.onAction(Action.SHOW_TABLE_SCHEMA))
 									.build();
 							DisplayUtils.notify("Edit the Dataset Schema to add additional annotation columns to this dataset", DisplayUtils.NotificationVariant.SUCCESS, toastOptions);
-							eventBus.fireEvent(new EntityUpdatedEvent());
+							eventBus.fireEvent(new EntityUpdatedEvent(tableId));
 							closeItemsEditor();
 						},
 						() -> closeItemsEditor()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidget.java
@@ -155,7 +155,7 @@ public class EntityViewScopeWidget implements SynapseWidgetPresenter, EntityView
 			public void onSuccess(Entity entity) {
 				view.setLoading(false);
 				view.hideModal();
-				eventBus.fireEvent(new EntityUpdatedEvent());
+				eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
 			}
 
 			@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/SubmissionViewScopeWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/SubmissionViewScopeWidget.java
@@ -132,7 +132,7 @@ public class SubmissionViewScopeWidget implements SynapseWidgetPresenter, Submis
 			public void onSuccess(Entity entity) {
 				view.setLoading(false);
 				view.hideModal();
-				eventBus.fireEvent(new EntityUpdatedEvent());
+				eventBus.fireEvent(new EntityUpdatedEvent(entity.getId()));
 			}
 
 			@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidget.java
@@ -703,7 +703,7 @@ public class TableEntityWidget implements TableEntityWidgetView.Presenter, IsWid
 									.setPrimaryButton("Show Schema", () -> this.actionMenu.onAction(Action.SHOW_TABLE_SCHEMA))
 									.build();
 							DisplayUtils.notify("Edit the Dataset Schema to add additional annotation columns to this dataset", DisplayUtils.NotificationVariant.SUCCESS, toastOptions);
-							eventBus.fireEvent(new EntityUpdatedEvent());
+							eventBus.fireEvent(new EntityUpdatedEvent(entityBundle.getEntity().getId()));
 							closeItemsEditor();
 						},
 						() -> closeItemsEditor()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorWidget.java
@@ -296,7 +296,7 @@ public class QueryResultEditorWidget implements QueryResultEditorView.Presenter,
 
 			private void fireEntityUpdatedEvent() {
 				doHideEditor();
-				eventBus.fireEvent(new EntityUpdatedEvent());
+				eventBus.fireEvent(new EntityUpdatedEvent(tableId));
 			}
 		});
 	}

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsWidget.java
@@ -239,7 +239,7 @@ public class ColumnModelsWidget implements ColumnModelsViewBase.Presenter, Colum
 		baseView.setJobTrackingWidgetVisible(false);
 		// Hide the dialog
 		baseView.hideEditor();
-		ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent());
+		ginInjector.getEventBus().fireEvent(new EntityUpdatedEvent(bundle.getEntity().getId()));
 	}
 
 	public void startTrackingJob(TableUpdateTransactionRequest request) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
@@ -36,7 +36,9 @@ import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.cache.EntityId2BundleCache;
+import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.place.Synapse.EntityArea;
 import org.sagebionetworks.web.client.presenter.EntityPresenter;
@@ -102,12 +104,17 @@ public class EntityPresenterTest {
 	Synapse mockPlace;
 	@Mock
 	FileEntity mockFileEntity;
+	@Mock
+	SynapseContextPropsProvider mockSynapseContextPropsProvider;
+	@Mock
+	QueryClient mockQueryClient;
 
 	@Before
 	public void setup() throws Exception {
 		when(mockEntityPresenterEventBinder.getEventBinder()).thenReturn(mockEventBinder);
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
-		entityPresenter = new EntityPresenter(mockView, mockEntityPresenterEventBinder, mockGlobalApplicationState, mockAuthenticationController, mockSynapseJavascriptClient, mockSynAlert, mockEntityPageTop, mockHeaderWidget, mockOpenInviteWidget, mockGwtWrapper, mockEventBus);
+		when(mockSynapseContextPropsProvider.getQueryClient()).thenReturn(mockQueryClient);
+		entityPresenter = new EntityPresenter(mockView, mockEntityPresenterEventBinder, mockGlobalApplicationState, mockAuthenticationController, mockSynapseJavascriptClient, mockSynAlert, mockEntityPageTop, mockHeaderWidget, mockOpenInviteWidget, mockGwtWrapper, mockEventBus, mockSynapseContextPropsProvider);
 		Entity testEntity = new Project();
 		eb = new EntityBundle();
 		eb.setEntity(testEntity);
@@ -223,6 +230,7 @@ public class EntityPresenterTest {
 	public void testEntityUpdatedHandler() {
 		entityPresenter.onEntityUpdatedEvent(new EntityUpdatedEvent());
 
+		verify(mockQueryClient).invalidateQueries(any());
 		verify(mockGlobalApplicationState).refreshPage();
 	}
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.web.unitclient.presenter;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -18,6 +20,8 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -39,6 +43,7 @@ import org.sagebionetworks.web.client.cache.EntityId2BundleCache;
 import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+import org.sagebionetworks.web.client.jsinterop.reactquery.SynapseReactClientQueryKey;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.place.Synapse.EntityArea;
 import org.sagebionetworks.web.client.presenter.EntityPresenter;
@@ -108,6 +113,8 @@ public class EntityPresenterTest {
 	SynapseContextPropsProvider mockSynapseContextPropsProvider;
 	@Mock
 	QueryClient mockQueryClient;
+	@Captor
+	ArgumentCaptor<Object[]> reactQueryKeyCaptor;
 
 	@Before
 	public void setup() throws Exception {
@@ -227,12 +234,35 @@ public class EntityPresenterTest {
 	}
 
 	@Test
-	public void testEntityUpdatedHandler() {
+	public void testEntityUpdatedHandlerWithoutId() {
 		entityPresenter.onEntityUpdatedEvent(new EntityUpdatedEvent());
 
-		verify(mockQueryClient).invalidateQueries(any());
+		verify(mockQueryClient).invalidateQueries(reactQueryKeyCaptor.capture());
 		verify(mockGlobalApplicationState).refreshPage();
+
+		Object[] passedQueryKey = reactQueryKeyCaptor.getValue();
+		assertNotNull(passedQueryKey);
+		assertEquals(passedQueryKey.length, 1);
+		SynapseReactClientQueryKey keyObject = (SynapseReactClientQueryKey) passedQueryKey[0];
+		assertEquals(keyObject.objectType, "entity");
+		assertEquals(keyObject.id, null);
 	}
+
+	@Test
+	public void testEntityUpdatedHandlerWithId() {
+		entityPresenter.onEntityUpdatedEvent(new EntityUpdatedEvent(entityId));
+
+		verify(mockQueryClient).invalidateQueries(reactQueryKeyCaptor.capture());
+		verify(mockGlobalApplicationState).refreshPage();
+
+		Object[] passedQueryKey = reactQueryKeyCaptor.getValue();
+		assertNotNull(passedQueryKey);
+		assertEquals(passedQueryKey.length, 1);
+		SynapseReactClientQueryKey keyObject = (SynapseReactClientQueryKey) passedQueryKey[0];
+		assertEquals(keyObject.objectType, "entity");
+		assertEquals(keyObject.id, entityId);
+	}
+
 
 	@Test
 	public void testIsValidEntityId() {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
@@ -170,9 +170,14 @@ public class ProvenanceEditorWidgetTest {
 
 	@Test
 	public void onSaveSuccess() {
-		AsyncMockStubber.callSuccessWith(null).when(mockJsClient).updateActivity(eq(mockActivity), any(AsyncCallback.class));
+		// First configure
+		AsyncMockStubber.callSuccessWith(mockActivity).when(mockJsClient).getActivityForEntityVersion(anyString(), anyLong(), any(AsyncCallback.class));
 		presenter.setActivity(mockActivity);
+
+		AsyncMockStubber.callSuccessWith(null).when(mockJsClient).updateActivity(eq(mockActivity), any(AsyncCallback.class));
+		// call under test
 		presenter.onSave();
+
 		verify(mockUrlProvEntry, times(2)).getURL();
 		verify(mockUrlProvEntry, times(2)).getTitle();
 		verify(mockEntityProvEntry, times(2)).getEntryId();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
@@ -172,10 +172,11 @@ public class ProvenanceEditorWidgetTest {
 	public void onSaveSuccess() {
 		// First configure
 		AsyncMockStubber.callSuccessWith(mockActivity).when(mockJsClient).getActivityForEntityVersion(anyString(), anyLong(), any(AsyncCallback.class));
-		presenter.setActivity(mockActivity);
+		presenter.configure(mockEntityBundle);
 
 		AsyncMockStubber.callSuccessWith(null).when(mockJsClient).updateActivity(eq(mockActivity), any(AsyncCallback.class));
-		// call under test
+		// calls under test
+		presenter.setActivity(mockActivity);
 		presenter.onSave();
 
 		verify(mockUrlProvEntry, times(2)).getURL();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,10 +2311,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-synapse-react-client@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.0.3.tgz#2abdb76767eab2f397cf5549ab2485f6f32a3873"
-  integrity sha512-EJEpvTtfyMWUDwJGy48yyxGC92AEdfRMo6Ndfl3Fe6LVYDcxGEePlodculjLH+9ZMcOcHOE4YSk0kinkMaQjgg==
+synapse-react-client@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.0.4.tgz#cfacdf8ec4df094fdc7ee11b132503f95d119b41"
+  integrity sha512-jVFKemzStHgCxTJPum9wl7mSdmqMYlOpwIVhDTjKYUpb0q/qSRlTboU7jSkyam5/NaC1agYbZk4pXIgclOhzBg==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     "@brainhubeu/react-carousel" "1.19.26"


### PR DESCRIPTION
When we fire an EntityUpdatedEvent, we should clear the entity-related data cached by react-query.