### PR TITLE
SWC-6073 - Add a name so the query count in TopLevelControls renders

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/QueryWrapperPlotNavProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/QueryWrapperPlotNavProps.java
@@ -22,6 +22,7 @@ public class QueryWrapperPlotNavProps extends ReactComponentProps {
 		void run(String newQueryResultBundleJson);
 	}
 
+	String name;
 	String initQueryJson;
 	String sql;
 	@JsNullable
@@ -49,6 +50,7 @@ public class QueryWrapperPlotNavProps extends ReactComponentProps {
 		props.onQueryResultBundleChange = onQueryResultBundleChange;
 		props.tableConfiguration = SynapseTableProps.create();
 		props.shouldDeepLink = true;
+		props.name = "Items";
 		props.downloadCartPageUrl = "#!DownloadCart:0";
 		return props;
 	}


### PR DESCRIPTION
ITEMS (9) ... wouldn't render without providing a name. UI would have been a little weird with just a count (+ occasional warning) there, so just add a generic name

![image](https://user-images.githubusercontent.com/17580037/163818329-eea910c0-e45d-4bd0-98cd-9d3b0fb344a5.png)
