### PR TITLE
SWC-6056 - FIx "Show/Hide Version History" update desynchronization

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadata.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityMetadata.java
@@ -116,7 +116,7 @@ public class EntityMetadata implements Presenter {
 
 		boolean isCurrentVersion = en instanceof VersionableEntity ? ((VersionableEntity) en).getIsLatestVersion() : true;
 		if (EntityActionControllerImpl.isVersionSupported(bundle.getEntity(), ginInjector.getCookieProvider())) {
-			getVersionHistoryWidget().setVisible(false);
+			getVersionHistoryWidget().setVisible(!((VersionableEntity) bundle.getEntity()).getIsLatestVersion());
 			getVersionHistoryWidget().setEntityBundle(bundle, versionNumber);
 			view.setRestrictionPanelVisible(true);
 		} else {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidget.java
@@ -211,7 +211,7 @@ public class VersionHistoryWidget implements VersionHistoryWidgetView.Presenter,
 
 	public void setVisible(boolean visible) {
 		view.setVisible(visible);
-		invokeChangeListeners();
+		invokeVisibilityChangeListeners();
 	}
 
 	public boolean isVisible() {
@@ -220,10 +220,10 @@ public class VersionHistoryWidget implements VersionHistoryWidgetView.Presenter,
 
 	public void registerVisibilityChangeListener(Consumer<Boolean> callback) {
 		visibilityChangeListeners.add(callback);
-		invokeChangeListeners();
+		invokeVisibilityChangeListeners();
 	}
 
-	private void invokeChangeListeners() {
+	private void invokeVisibilityChangeListeners() {
 		for (Consumer<Boolean> cb : visibilityChangeListeners) {
 			cb.accept(this.isVisible());
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidget.java
@@ -1,8 +1,12 @@
 package org.sagebionetworks.web.client.widget.entity;
 
 import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEntryPoint;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
+
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.VersionableEntity;
@@ -42,6 +46,8 @@ public class VersionHistoryWidget implements VersionHistoryWidgetView.Presenter,
 	private SynapseJavascriptClient jsClient;
 	int currentOffset;
 	private Request currentRequest;
+
+	private List<Consumer<Boolean>> visibilityChangeListeners = new ArrayList<>();
 
 	@Inject
 	public VersionHistoryWidget(VersionHistoryWidgetView view, SynapseClientAsync synapseClient, SynapseJavascriptClient jsClient, GlobalApplicationState globalApplicationState, PreflightController preflightController, SynapseAlert synAlert) {
@@ -204,11 +210,23 @@ public class VersionHistoryWidget implements VersionHistoryWidgetView.Presenter,
 	}
 
 	public void setVisible(boolean visible) {
-		view.asWidget().setVisible(visible);
+		view.setVisible(visible);
+		invokeChangeListeners();
 	}
 
 	public boolean isVisible() {
-		return view.asWidget().isVisible();
+		return view.isVisible();
+	}
+
+	public void registerVisibilityChangeListener(Consumer<Boolean> callback) {
+		visibilityChangeListeners.add(callback);
+		invokeChangeListeners();
+	}
+
+	private void invokeChangeListeners() {
+		for (Consumer<Boolean> cb : visibilityChangeListeners) {
+			cb.accept(this.isVisible());
+		}
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidgetView.java
@@ -42,4 +42,8 @@ public interface VersionHistoryWidgetView extends IsWidget, SynapseView {
 	void setSynAlert(IsWidget w);
 
 	void showNoResults();
+
+	boolean isVisible();
+
+	void setVisible(boolean visible);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBar.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBar.java
@@ -2,13 +2,11 @@ package org.sagebionetworks.web.client.widget.entity.file;
 
 import java.util.List;
 
-import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.download.AddBatchOfFilesToDownloadListResponse;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.file.CloudProviderFileHandleInterface;
-import org.sagebionetworks.repo.model.file.DownloadList;
 import org.sagebionetworks.repo.model.file.ExternalFileHandle;
 import org.sagebionetworks.repo.model.file.ExternalObjectStoreFileHandle;
 import org.sagebionetworks.repo.model.file.FileHandle;
@@ -107,6 +105,9 @@ public class FileTitleBar implements SynapseWidgetPresenter, FileTitleBarView.Pr
 				configureExternalObjectStore((ExternalObjectStoreFileHandle) fileHandle);
 			}
 		}
+
+		versionHistoryWidget.registerVisibilityChangeListener(visible ->
+				view.setVersionHistoryLinkText((visible ? "Hide" : "Show") + " Version History"));
 	}
 
 	public void getLatestVersion() {
@@ -217,11 +218,6 @@ public class FileTitleBar implements SynapseWidgetPresenter, FileTitleBarView.Pr
 	@Override
 	public void toggleShowVersionHistory() {
 		this.actionMenuWidget.onAction(Action.SHOW_VERSION_HISTORY);
-	}
-
-	@Override
-	public boolean isVersionHistoryVisible() {
-		return this.versionHistoryWidget.isVisible();
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarView.java
@@ -40,6 +40,8 @@ public interface FileTitleBarView extends IsWidget, SynapseView {
 
 	void setActionMenu(IsWidget w);
 
+	void setVersionHistoryLinkText(String text);
+
 	/**
 	 * Presenter interface
 	 */
@@ -49,7 +51,5 @@ public interface FileTitleBarView extends IsWidget, SynapseView {
 		void onAddToDownloadList();
 
 		void toggleShowVersionHistory();
-
-		boolean isVersionHistoryVisible();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarViewImpl.java
@@ -106,11 +106,16 @@ public class FileTitleBarViewImpl extends Composite implements FileTitleBarView 
 			presenter.onProgrammaticDownloadOptions();
 		});
 		showVersionHistoryLink.addClickHandler(event -> {
-			boolean isShown = !presenter.isVersionHistoryVisible();
 			presenter.toggleShowVersionHistory();
-			showVersionHistoryLink.setText((isShown ? "Hide" : "Show") + " Version History");
 		});
 
+
+
+	}
+
+	@Override
+	public void setVersionHistoryLinkText(String text) {
+		showVersionHistoryLink.setText(text);
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/FileTitleBarViewImpl.java
@@ -108,9 +108,6 @@ public class FileTitleBarViewImpl extends Composite implements FileTitleBarView 
 		showVersionHistoryLink.addClickHandler(event -> {
 			presenter.toggleShowVersionHistory();
 		});
-
-
-
 	}
 
 	@Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBar.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBar.java
@@ -34,11 +34,12 @@ public class TableTitleBar implements SynapseWidgetPresenter, TableTitleBarView.
 		this.entityBundle = bundle;
 		this.actionMenuWidget = actionMenu;
 		this.versionHistoryWidget = versionHistoryWidget;
+		this.versionHistoryWidget.registerVisibilityChangeListener((visible) -> view.setVersionHistoryLinkText((visible ? "Hide" : "Show") + " Version History"));
 
 		view.createTitlebar(bundle.getEntity());
 		view.setEntityName(bundle.getEntity().getName());
 		boolean isMaterializedView = bundle.getEntity() instanceof MaterializedView;
-		view.setVersionUIVisible(!isMaterializedView);
+		view.setVersionUIToggleVisible(!isMaterializedView);
 		getLatestVersion();
 	}
 
@@ -86,10 +87,5 @@ public class TableTitleBar implements SynapseWidgetPresenter, TableTitleBarView.
 	@Override
 	public void toggleShowVersionHistory() {
 		this.actionMenuWidget.onAction(Action.SHOW_VERSION_HISTORY);
-	}
-
-	@Override
-	public boolean isVersionHistoryVisible() {
-		return this.versionHistoryWidget.isVisible();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBarView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBarView.java
@@ -14,14 +14,14 @@ public interface TableTitleBarView extends IsWidget, SynapseView {
 
 	void setPresenter(Presenter p);
 
-	void setVersionUIVisible(boolean visible);
-	
+	void setVersionUIToggleVisible(boolean visible);
+
+	void setVersionHistoryLinkText(String text);
+
 	/**
 	 * Presenter interface
 	 */
 	interface Presenter {
 		void toggleShowVersionHistory();
-
-		boolean isVersionHistoryVisible();
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/TableTitleBarViewImpl.java
@@ -56,12 +56,7 @@ public class TableTitleBarViewImpl extends Composite implements TableTitleBarVie
 
 		favoritePanel.addStyleName("inline-block");
 		favoritePanel.setWidget(favoriteWidget.asWidget());
-		showVersionHistoryLink.addClickHandler(event -> {
-			boolean isShown = !presenter.isVersionHistoryVisible();
-			presenter.toggleShowVersionHistory();
-			showVersionHistoryLink.setText((isShown ? "Hide" : "Show") + " Version History");
-		});
-
+		showVersionHistoryLink.addClickHandler(event -> presenter.toggleShowVersionHistory());
 	}
 
 	@Override
@@ -74,6 +69,11 @@ public class TableTitleBarViewImpl extends Composite implements TableTitleBarVie
 		currentEntityId = entity.getId();
 		favoriteWidget.configure(currentEntityId);
 		entityIcon.setType(EntityTypeUtils.getEntityType(entity));
+	}
+
+	@Override
+	public void setVersionHistoryLinkText(String text) {
+		showVersionHistoryLink.setText(text);
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class TableTitleBarViewImpl extends Composite implements TableTitleBarVie
 	}
 	
 	@Override
-	public void setVersionUIVisible(boolean visible) {
+	public void setVersionUIToggleVisible(boolean visible) {
 		versionInfoUI.setVisible(visible);
 	}
 	

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
@@ -60,13 +60,14 @@ public abstract class AbstractTablesTab implements TablesTabView.Presenter, Quer
 	public static final String TABLE_QUERY_PREFIX = "query/";
 
 	private static final String VERSION_ALERT_DRAFT_DATASET_TITLE = "This is a Draft Version of the Dataset";
-	private static final String VERSION_ALERT_DRAFT_DATASET_MESSAGE = "Administrators and Editors can edit this version and create a Stable Version for distribution. Go to the Version History to view the Stable Versions.";
+	private static final String VERSION_ALERT_DRAFT_DATASET_MESSAGE = "Administrators can edit this version and create a Stable Version for distribution. Go to the Version History to view the Stable Versions";
 
 	private static final String VERSION_ALERT_OLD_SNAPSHOT_DATASET_TITLE = "There is a newer Stable Version of this Dataset";
 	private static final String VERSION_ALERT_OLD_SNAPSHOT_DATASET_MESSAGE = "Go to the latest Stable Version, or view the Version History for all versions.";
 	public static final String GO_TO_LATEST_STABLE_VERSION = "Go to Latest Stable Version";
 	public static final String NO_STABLE_VERSIONS_OF_THIS_DATASET = "There are currently no Stable Versions of this Dataset";
 
+	private static final String DATASET_CREATED_BY_HELP_TEXT = "This is the user who created this Dataset. This may not be the same person who generated the files in this Dataset, or who originally uploaded these files to Synapse.";
 
 	Tab tab;
 	TablesTabView view;
@@ -300,7 +301,7 @@ public abstract class AbstractTablesTab implements TablesTabView.Presenter, Quer
 			breadcrumb.configure(bundle.getPath(), getTabArea());
 			titleBar.configure(bundle, tab.getEntityActionMenu(), metadata.getVersionHistoryWidget());
 			modifiedCreatedBy.configure(entity.getCreatedOn(), entity.getCreatedBy(), entity.getModifiedOn(), entity.getModifiedBy());
-			
+
 			if (!DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider())) {
 				v2TableWidget = ginInjector.createNewTableEntityWidget();
 				view.setTableEntityWidget(v2TableWidget.asWidget());
@@ -357,12 +358,8 @@ public abstract class AbstractTablesTab implements TablesTabView.Presenter, Quer
 
 	private void configureVersionAlert() {
 		boolean versionHistoryIsVisible = this.metadata.getVersionHistoryWidget().isVisible();
-		this.view.setVersionAlertPrimaryAction((versionHistoryIsVisible ? "Hide" : "Show") + " Version History",
-				event -> {
-					this.metadata.getVersionHistoryWidget().setVisible(!versionHistoryIsVisible);
-					// Reconfigure the version alert to update the button text.
-					configureVersionAlert();
-				});
+		updateVersionAlertText(versionHistoryIsVisible);
+		this.view.setVersionAlertPrimaryAction(event -> this.metadata.getVersionHistoryWidget().setVisible(!versionHistoryIsVisible));
 		if (!(entityBundle.getEntity() instanceof Dataset)) {
 			// Don't show a version alert if this isn't a dataset
 			this.view.setVersionAlertVisible(false);
@@ -404,6 +401,10 @@ public abstract class AbstractTablesTab implements TablesTabView.Presenter, Quer
 			// Don't show a version alert
 			this.view.setVersionAlertVisible(false);
 		}
+	}
+
+	private void updateVersionAlertText(boolean versionHistoryIsVisible) {
+		this.view.setVersionAlertPrimaryText((versionHistoryIsVisible ? "Hide" : "Show") + " Version History");
 	}
 
 	private FluentFuture<Long> getLatestSnapshotVersionNumber() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabView.java
@@ -48,7 +48,9 @@ public interface TablesTabView extends IsWidget {
 
 	void setVersionAlertCopy(String title, String message);
 
-	void setVersionAlertPrimaryAction(String text, ClickHandler handler);
+	void setVersionAlertPrimaryText(String text);
+
+	void setVersionAlertPrimaryAction(ClickHandler handler);
 
 	void setVersionAlertSecondaryAction(String text, ClickHandler handler, boolean enabled, String tooltipText);
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
@@ -168,8 +168,12 @@ public class TablesTabViewImpl implements TablesTabView {
 	}
 
 	@Override
-	public void setVersionAlertPrimaryAction(String text, ClickHandler handler) {
+	public void setVersionAlertPrimaryText(String text) {
 		versionAlert.setPrimaryCTAText(text);
+	}
+
+	@Override
+	public void setVersionAlertPrimaryAction(ClickHandler handler) {
 		versionAlert.addPrimaryCTAClickHandler(handler);
 	}
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/FileTitleBarTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/FileTitleBarTest.java
@@ -13,10 +13,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -99,6 +102,8 @@ public class FileTitleBarTest {
 	PopupUtilsView mockPopupUtils;
 	@Mock
 	VersionHistoryWidget mockVersionHistoryWidget;
+	@Captor
+	ArgumentCaptor<Consumer<Boolean>> versionHistoryVisibilityListenerCaptor;
 	public static final String DATA_FILE_HANDLE_ID = "872";
 	public static final Long FILE_VERSION = 3L;
 	public static final String FILE_NAME = "afile.txt";
@@ -296,5 +301,20 @@ public class FileTitleBarTest {
 		fileTitleBar.onProgrammaticDownloadOptions();
 
 		verify(mockFileClientsHelp).configureAndShow(ENTITY_ID, FILE_VERSION);
+	}
+
+	@Test
+	public void testOnVersionHistoryVisibilityUpdate() {
+		fileTitleBar.configure(mockBundle, mockActionMenuWidget, mockVersionHistoryWidget);
+
+		verify(mockVersionHistoryWidget).registerVisibilityChangeListener(versionHistoryVisibilityListenerCaptor.capture());
+
+		// Version history updated to be visible
+		versionHistoryVisibilityListenerCaptor.getValue().accept(true);
+		verify(mockView).setVersionHistoryLinkText(eq("Hide Version History"));
+
+		// Version history updated to not be visible
+		versionHistoryVisibilityListenerCaptor.getValue().accept(false);
+		verify(mockView).setVersionHistoryLinkText(eq("Show Version History"));
 	}
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/TableTitleBarTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/TableTitleBarTest.java
@@ -1,11 +1,16 @@
 package org.sagebionetworks.web.unitclient.widget.entity.file;
 
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
@@ -37,6 +42,8 @@ public class TableTitleBarTest {
 	UserEntityPermissions mockPermissions;
 	@Mock
 	VersionHistoryWidget mockVersionHistoryWidget;
+	@Captor
+	ArgumentCaptor<Consumer<Boolean>> versionHistoryVisibilityListenerCaptor;
 	public static final String ENTITY_ID = "syn123";
 	public static final Long TABLE_VERSION = 3L;
 	public static final String TABLE_NAME = "My Table";
@@ -77,7 +84,7 @@ public class TableTitleBarTest {
 
 		verify(mockView).createTitlebar(mockTable);
 		verify(mockView).setEntityName(TABLE_NAME);
-		verify(mockView).setVersionUIVisible(true);
+		verify(mockView).setVersionUIToggleVisible(true);
 	}
 
 	@Test
@@ -105,7 +112,7 @@ public class TableTitleBarTest {
 		tableTitleBar.configure(mockBundle, mockActionMenuWidget, mockVersionHistoryWidget);
 
 		verify(mockView).setVersionLabel("Draft");
-		verify(mockView).setVersionUIVisible(true);
+		verify(mockView).setVersionUIToggleVisible(true);
 	}
 
 
@@ -125,7 +132,22 @@ public class TableTitleBarTest {
 
 		tableTitleBar.configure(mockBundle, mockActionMenuWidget, mockVersionHistoryWidget);
 
-		verify(mockView).setVersionUIVisible(false);
+		verify(mockView).setVersionUIToggleVisible(false);
+	}
+
+	@Test
+	public void testOnVersionHistoryVisibilityUpdate() {
+		tableTitleBar.configure(mockBundle, mockActionMenuWidget, mockVersionHistoryWidget);
+
+		verify(mockVersionHistoryWidget).registerVisibilityChangeListener(versionHistoryVisibilityListenerCaptor.capture());
+
+		// Version history updated to be visible
+		versionHistoryVisibilityListenerCaptor.getValue().accept(true);
+		verify(mockView).setVersionHistoryLinkText(eq("Hide Version History"));
+
+		// Version history updated to not be visible
+		versionHistoryVisibilityListenerCaptor.getValue().accept(false);
+		verify(mockView).setVersionHistoryLinkText(eq("Show Version History"));
 	}
 
 }


### PR DESCRIPTION
Fixes [SWC-6056](https://sagebionetworks.jira.com/browse/SWC-6056).

The bug is demonstrated in the ticket.

Allow other widgets to register listeners on the VersionHistoryWidget which will fire every time the visibility is updated. This way, the copy will always correctly reflect the status of the widget.