### PR TITLE
SWC-5734 - Hide API key settings unless in experimental mode

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
@@ -213,6 +213,8 @@ public class SettingsPresenter implements SettingsView.Presenter {
 				view.setShowingLocalTime();
 			}
 		}
+		// Only show deprecated API key settings if in experimental mode
+		view.setApiKeySettingsVisible(DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider()));
 		this.view.render();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/view/SettingsView.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/SettingsView.java
@@ -61,6 +61,8 @@ public interface SettingsView extends IsWidget, SynapseView {
 		void unbindOrcId();
 	}
 
+	public void setApiKeySettingsVisible(boolean visible);
+
 	public void setApiKey(String apiKey);
 
 	public void setNotificationSynAlertWidget(IsWidget asWidget);

--- a/src/main/java/org/sagebionetworks/web/client/view/SettingsViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/SettingsViewImpl.java
@@ -417,6 +417,11 @@ public class SettingsViewImpl extends Composite implements SettingsView {
 		emailsPanel.add(w);
 	}
 
+	@Override
+	public void setApiKeySettingsVisible(boolean visible) {
+		apiKeyHighlightBox.setVisible(visible);
+	}
+
 
 	@Override
 	public void setOrcIdVisible(boolean isVisible) {

--- a/src/main/resources/org/sagebionetworks/web/client/view/SettingsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SettingsViewImpl.ui.xml
@@ -215,8 +215,15 @@
 				</bh:Div>
 				<bh:Div ui:field="subscriptionsContainer" />
 			</g:FlowPanel>
-			<g:HTMLPanel ui:field="apiKeyHighlightBox"
-				addStyleNames="highlight-box">
+
+			<g:HTMLPanel ui:field="personalAccessTokensHighlightBox" addStyleNames="highlight-box">
+				<p>You can issue personal access tokens to authenticate your scripts with scoped access
+					to your account. It is important that you treat personal access tokens with	the same security as your password.</p>
+				<b:Button ui:field="managePersonalAccessTokensButton"
+						  addStyleNames="margin-top-10" text="Manage Personal Access Tokens" />
+			</g:HTMLPanel>
+
+			<g:HTMLPanel ui:field="apiKeyHighlightBox" addStyleNames="highlight-box" visible="false">
 				<p>Using an API key allows you to authenticate your scripts for an
 					indefinite amount of time. It is important that you treat your API
 					key with
@@ -235,14 +242,6 @@
 					addStyleNames="margin-top-10" text="Show API Key" />
 				<b:Button ui:field="changeApiKey"
 					addStyleNames="margin-top-10" text="Change API Key" />
-			</g:HTMLPanel>
-
-			<g:HTMLPanel ui:field="personalAccessTokensHighlightBox"
-						 addStyleNames="highlight-box">
-				<p>You can issue personal access tokens to authenticate your scripts with scoped access
-					to your account. It is important that you treat personal access tokens with	the same security as your password.</p>
-				<b:Button ui:field="managePersonalAccessTokensButton"
-						  addStyleNames="margin-top-10" text="Manage Personal Access Tokens" />
 			</g:HTMLPanel>
 
 			<bh:Div addStyleNames="clear"></bh:Div>

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
@@ -41,6 +41,7 @@ import org.sagebionetworks.schema.adapter.AdapterFactory;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.schema.adapter.org.json.AdapterFactoryImpl;
 import org.sagebionetworks.web.client.DisplayConstants;
+import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
@@ -48,6 +49,7 @@ import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseClientAsync;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
+import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.place.LoginPlace;
 import org.sagebionetworks.web.client.place.Profile;
 import org.sagebionetworks.web.client.presenter.SettingsPresenter;
@@ -110,6 +112,8 @@ public class SettingsPresenterTest {
 	VerificationSubmission mockVerificationSubmission;
 	@Mock
 	NotificationEmail mockNotificationEmail;
+	@Mock
+	CookieProvider mockCookieProvider;
 
 	@Before
 	public void setup() throws JSONObjectAdapterException {
@@ -121,6 +125,7 @@ public class SettingsPresenterTest {
 		when(mockAuthenticationController.isLoggedIn()).thenReturn(true);
 		when(mockAuthenticationController.getCurrentUserProfile()).thenReturn(profile);
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
+		when(mockInjector.getCookieProvider()).thenReturn(mockCookieProvider);
 		AsyncMockStubber.callSuccessWith(APIKEY).when(mockSynapseClient).getAPIKey(any(AsyncCallback.class));
 		AsyncMockStubber.callSuccessWith(profile).when(mockSynapseJavascriptClient).getUserProfile(anyString(), any(AsyncCallback.class));
 		AsyncMockStubber.callSuccessWith(mockUserBundle).when(mockSynapseJavascriptClient).getUserBundle(anyLong(), anyInt(), any(AsyncCallback.class));
@@ -520,5 +525,19 @@ public class SettingsPresenterTest {
 		presenter.unbindOrcIdAfterConfirmation();
 		// error is shown
 		verify(mockSynAlert).handleException(ex);
+	}
+
+	@Test
+	public void testApiKeySettingsHidden() {
+		when(mockCookieProvider.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY)).thenReturn(null);
+		presenter.configure();
+		verify(mockView).setApiKeySettingsVisible(false);
+	}
+
+	@Test
+	public void testApiKeySettingsShownInExperimentalMode() {
+		when(mockCookieProvider.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY)).thenReturn("true");
+		presenter.configure();
+		verify(mockView).setApiKeySettingsVisible(true);
 	}
 }


### PR DESCRIPTION
Also, if the user is in experimental mode, show the PAT settings first