### PR TITLE
SWC-6215: Move OAuthClient settings to Experimental Mode

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SettingsPresenter.java
@@ -215,6 +215,7 @@ public class SettingsPresenter implements SettingsView.Presenter {
 		}
 		// Only show deprecated API key settings if in experimental mode
 		view.setApiKeySettingsVisible(DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider()));
+		view.setOauthClientSettingsVisible(DisplayUtils.isInTestWebsite(ginInjector.getCookieProvider()));
 		this.view.render();
 	}
 

--- a/src/main/java/org/sagebionetworks/web/client/view/SettingsView.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/SettingsView.java
@@ -63,6 +63,8 @@ public interface SettingsView extends IsWidget, SynapseView {
 
 	public void setApiKeySettingsVisible(boolean visible);
 
+	public void setOauthClientSettingsVisible(boolean visible);
+
 	public void setApiKey(String apiKey);
 
 	public void setNotificationSynAlertWidget(IsWidget asWidget);

--- a/src/main/java/org/sagebionetworks/web/client/view/SettingsViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/SettingsViewImpl.java
@@ -429,6 +429,10 @@ public class SettingsViewImpl extends Composite implements SettingsView {
 		apiKeyHighlightBox.setVisible(visible);
 	}
 
+	@Override
+	public void setOauthClientSettingsVisible(boolean visible) {
+		oAuthClientEditorHighlightBox.setVisible(visible);
+	}
 
 	@Override
 	public void setOrcIdVisible(boolean isVisible) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SettingsPresenterTest.java
@@ -540,4 +540,18 @@ public class SettingsPresenterTest {
 		presenter.configure();
 		verify(mockView).setApiKeySettingsVisible(true);
 	}
+
+	@Test
+	public void testOauthClientSettingsHidden() {
+		when(mockCookieProvider.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY)).thenReturn(null);
+		presenter.configure();
+		verify(mockView).setOauthClientSettingsVisible(false);
+	}
+
+	@Test
+	public void testOauthClientSettingsShownInExperimentalMode() {
+		when(mockCookieProvider.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY)).thenReturn("true");
+		presenter.configure();
+		verify(mockView).setOauthClientSettingsVisible(true);
+	}
 }


### PR DESCRIPTION
Feature is not ready, broken in 418 (will be fixed in 419), and should get design sign-off before releasing.