### PR TITLE
SWC-6249

### DIFF
--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.ui.xml
@@ -16,7 +16,7 @@
 				addStyleNames="margin-left-5" placement="BOTTOM" />
 		</b:ModalHeader>
 		<b:ModalBody>
-			<bh:Paragraph ui:field="promptCopy"></bh:Paragraph>
+			<bh:Paragraph ui:field="promptCopy" addStyleNames="fit-within-parent"></bh:Paragraph>
 			<w:ReactComponentDiv ui:field="entityFinderContainer" />
 			<g:SimplePanel ui:field="synAlertPanel" addStyleNames="synAlertPanel" />
 		</b:ModalBody>

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -3658,3 +3658,9 @@ div.border {
 #body .markdown .SynapseTable {
 	min-height: unset;
 }
+
+// https://stackoverflow.com/a/57599409
+.fit-within-parent {
+  width: 0;
+  min-width: 100%;
+}


### PR DESCRIPTION
Force paragraph above entity finder to wrap instead of stretching modal.

The modal needs to stretch because the entity finder can expand when "search" is clicked.

Confirmed that this "hack" works in Chrome, Firefox, and Safari

![image](https://user-images.githubusercontent.com/17580037/187237154-c83e2dca-096c-42f8-a30c-15fab1e3a059.png)
