### PR TITLE
SWC-6288

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.client;
 
 import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.web.client.context.QueryClientProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.presenter.ACTAccessApprovalsPresenter;
 import org.sagebionetworks.web.client.presenter.ACTDataAccessSubmissionDashboardPresenter;
@@ -895,4 +896,6 @@ public interface PortalGinInjector extends Ginjector {
 	PresignedURLAsyncHandler getPresignedURLAsyncHandler();
 	AddToDownloadListV2 getAddToDownloadListV2();
 	JSONObjectAdapter getJSONObjectAdapter();
+
+	QueryClientProvider getQueryClientProvider();
 }

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -14,6 +14,8 @@ import org.sagebionetworks.web.client.cache.SessionStorage;
 import org.sagebionetworks.web.client.cache.SessionStorageImpl;
 import org.sagebionetworks.web.client.cache.StorageImpl;
 import org.sagebionetworks.web.client.cache.StorageWrapper;
+import org.sagebionetworks.web.client.context.QueryClientProvider;
+import org.sagebionetworks.web.client.context.QueryClientProviderImpl;
 import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
 import org.sagebionetworks.web.client.context.SynapseContextPropsProviderImpl;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
@@ -1452,6 +1454,8 @@ public class PortalGinModule extends AbstractGinModule {
         bind(EntityFinderWidgetView.class).to(EntityFinderWidgetViewImpl.class);
         bind(SynapseContextPropsProvider.class).to(SynapseContextPropsProviderImpl.class);
         bind(AddToDownloadListV2.class).to(AddToDownloadListV2Impl.class);
-        bind(OpenDataView.class).to(OpenDataViewImpl.class);
+		bind(OpenDataView.class).to(OpenDataViewImpl.class);
+
+		bind(QueryClientProvider.class).to(QueryClientProviderImpl.class).in(Singleton.class);
 	}
 }

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -1257,7 +1257,7 @@ public class PortalGinModule extends AbstractGinModule {
 		bind(TableQueryResultWikiWidgetView.class).to(TableQueryResultWikiWidgetViewImpl.class);
 
 		bind(SingleButtonView.class).to(SingleButtonViewImpl.class);
-		
+
 		bind(AnnotationTransformer.class).to(AnnotationTransformerImpl.class).in(Singleton.class);
 		bind(AnnotationEditorView.class).to(AnnotationEditorViewImpl.class);
 		bind(EditAnnotationsDialogView.class).to(EditAnnotationsDialogViewImpl.class);
@@ -1283,7 +1283,7 @@ public class PortalGinModule extends AbstractGinModule {
 		bind(PreviewConfigView.class).to(PreviewConfigViewImpl.class);
 		bind(SynapseFormConfigView.class).to(SynapseFormConfigViewImpl.class);
 		bind(DownloadCartPageView.class).to(DownloadCartPageViewImpl.class);
-		
+
 		bind(EditFileMetadataModalView.class).to(EditFileMetadataModalViewImpl.class);
 		bind(EditFileMetadataModalWidget.class).to(EditFileMetadataModalWidgetImpl.class);
 		bind(EditProjectMetadataModalView.class).to(EditProjectMetadataModalViewImpl.class);
@@ -1454,8 +1454,8 @@ public class PortalGinModule extends AbstractGinModule {
         bind(EntityFinderWidgetView.class).to(EntityFinderWidgetViewImpl.class);
         bind(SynapseContextPropsProvider.class).to(SynapseContextPropsProviderImpl.class);
         bind(AddToDownloadListV2.class).to(AddToDownloadListV2Impl.class);
-		bind(OpenDataView.class).to(OpenDataViewImpl.class);
+        bind(OpenDataView.class).to(OpenDataViewImpl.class);
 
-		bind(QueryClientProvider.class).to(QueryClientProviderImpl.class).in(Singleton.class);
-	}
+        bind(QueryClientProvider.class).to(QueryClientProviderImpl.class).in(Singleton.class);
+    }
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/QueryClientProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/QueryClientProvider.java
@@ -1,0 +1,13 @@
+package org.sagebionetworks.web.client.context;
+
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+
+/**
+ * Provides a singleton react-query QueryClient.
+ */
+public interface QueryClientProvider {
+	/**
+	 * Returns the global QueryClient
+	 */
+	QueryClient getQueryClient();
+}

--- a/src/main/java/org/sagebionetworks/web/client/context/QueryClientProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/QueryClientProviderImpl.java
@@ -1,0 +1,31 @@
+package org.sagebionetworks.web.client.context;
+
+import javax.inject.Inject;
+
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClientOptions;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+
+public class QueryClientProviderImpl implements QueryClientProvider {
+	private static QueryClient queryClientSingleton;
+
+	@Inject
+	public QueryClientProviderImpl() {
+		if (queryClientSingleton == null) {
+			queryClientSingleton = new QueryClient(QueryClientOptions.create());
+			setQueryClient(queryClientSingleton);
+		}
+	}
+
+	// Expose a method to store the queryClient in a global variable so we can access it from JSNI
+	@JsProperty(namespace = JsPackage.GLOBAL, name="SynapseQueryClient")
+	static native void setQueryClient(QueryClient queryClient);
+
+	@Override
+	public QueryClient getQueryClient() {
+		return queryClientSingleton;
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProvider.java
@@ -22,9 +22,4 @@ public interface SynapseContextPropsProvider {
      * using JsInterop before using JSNI.
      */
     SynapseContextProviderPropsJSNIObject getJsniContextProps();
-
-	/**
-	 * Returns the global QueryClient
-	 */
-	QueryClient getQueryClient();
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
@@ -7,37 +7,24 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextJsObject;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextProviderProps;
-import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
-import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClientOptions;
 import org.sagebionetworks.web.client.jsni.QueryClientJSNIObject;
 import org.sagebionetworks.web.client.jsni.SynapseContextJSNIObject;
 import org.sagebionetworks.web.client.jsni.SynapseContextProviderPropsJSNIObject;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 
-import jsinterop.annotations.JsPackage;
-import jsinterop.annotations.JsProperty;
-
 public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvider {
     private AuthenticationController authController;
     private GlobalApplicationState globalApplicationState;
     private CookieProvider cookies;
+	private QueryClientProvider queryClientProvider;
 
-    private static QueryClient queryClientSingleton = new QueryClient(QueryClientOptions.create());
-
-    // We save the queryClient in a global variable so we can access it from JSNI
-    @JsProperty(namespace = JsPackage.GLOBAL, name="SynapseQueryClient")
-    static native void setQueryClient(QueryClient queryClient);
-
-	public QueryClient getQueryClient() {
-		return queryClientSingleton;
-	}
 
     @Inject
-    SynapseContextPropsProviderImpl(final AuthenticationController authController, final GlobalApplicationState globalApplicationState, final CookieProvider cookies) {
+    SynapseContextPropsProviderImpl(final AuthenticationController authController, final GlobalApplicationState globalApplicationState, final CookieProvider cookies, final QueryClientProvider queryClientProvider) {
         this.authController = authController;
         this.globalApplicationState = globalApplicationState;
         this.cookies = cookies;
-        setQueryClient(queryClientSingleton);
+		this.queryClientProvider = queryClientProvider;
     }
 
     @Override
@@ -48,7 +35,7 @@ public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvi
                     DisplayUtils.isInTestWebsite(cookies),
                     globalApplicationState.isShowingUTCTime()
                 ),
-                queryClientSingleton
+                queryClientProvider.getQueryClient()
         );
     }
 

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseContextPropsProviderImpl.java
@@ -16,7 +16,7 @@ public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvi
     private AuthenticationController authController;
     private GlobalApplicationState globalApplicationState;
     private CookieProvider cookies;
-	private QueryClientProvider queryClientProvider;
+    private QueryClientProvider queryClientProvider;
 
 
     @Inject
@@ -24,7 +24,7 @@ public class SynapseContextPropsProviderImpl implements SynapseContextPropsProvi
         this.authController = authController;
         this.globalApplicationState = globalApplicationState;
         this.cookies = cookies;
-		this.queryClientProvider = queryClientProvider;
+        this.queryClientProvider = queryClientProvider;
     }
 
     @Override

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
@@ -10,4 +10,6 @@ public class QueryClient {
     public QueryClient(QueryClientOptions config) {}
 
 	public native void resetQueries(List<SynapseReactClientQueryKey> queryKey);
+
+	public native void clear();
 }

--- a/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/EntityPresenter.java
@@ -14,7 +14,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
-import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
+import org.sagebionetworks.web.client.context.QueryClientProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
 import org.sagebionetworks.web.client.jsinterop.reactquery.SynapseReactClientQueryKey;
@@ -58,7 +58,7 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 	private QueryClient queryClient;
 
 	@Inject
-	public EntityPresenter(EntityView view, EntityPresenterEventBinder entityPresenterEventBinder, GlobalApplicationState globalAppState, AuthenticationController authenticationController, SynapseJavascriptClient jsClient, StuAlert synAlert, EntityPageTop entityPageTop, Header headerWidget, OpenTeamInvitationsWidget openTeamInvitesWidget, GWTWrapper gwt, EventBus eventBus, SynapseContextPropsProvider synapseContextPropsProvider) {
+	public EntityPresenter(EntityView view, EntityPresenterEventBinder entityPresenterEventBinder, GlobalApplicationState globalAppState, AuthenticationController authenticationController, SynapseJavascriptClient jsClient, StuAlert synAlert, EntityPageTop entityPageTop, Header headerWidget, OpenTeamInvitationsWidget openTeamInvitesWidget, GWTWrapper gwt, EventBus eventBus, QueryClientProvider queryClientProvider) {
 		this.headerWidget = headerWidget;
 		this.entityPageTop = entityPageTop;
 		this.globalAppState = globalAppState;
@@ -68,7 +68,7 @@ public class EntityPresenter extends AbstractActivity implements EntityView.Pres
 		this.authenticationController = authenticationController;
 		this.jsClient = jsClient;
 		this.gwt = gwt;
-		this.queryClient = synapseContextPropsProvider.getQueryClient();
+		this.queryClient = queryClientProvider.getQueryClient();
 		clear();
 		entityPresenterEventBinder.getEventBinder().bindEventHandlers(this, eventBus);
 	}

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -37,7 +37,9 @@ import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.UserAccountServiceAsync;
 import org.sagebionetworks.web.client.cache.ClientCache;
 import org.sagebionetworks.web.client.cache.SessionStorage;
+import org.sagebionetworks.web.client.context.QueryClientProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
+import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
 import org.sagebionetworks.web.client.place.LoginPlace;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.QuarantinedEmailModal;
@@ -93,6 +95,10 @@ public class AuthenticationControllerImplTest {
 	EmailQuarantineStatus mockEmailQuarantineStatus;
 	@Mock
 	Place mockPlace;
+	@Mock
+	QueryClientProvider mockQueryClientProvider;
+	@Mock
+	QueryClient mockQueryClient;
 	
 	UserProfile profile;
 	public static final String USER_ID = "98208";
@@ -110,7 +116,8 @@ public class AuthenticationControllerImplTest {
 		AsyncMockStubber.callSuccessWith(profile).when(mockUserAccountService).getMyProfile(any(AsyncCallback.class));
 		AsyncMockStubber.callSuccessWith(mockNotificationEmail).when(mockJsClient).getNotificationEmail(any(AsyncCallback.class));
 		when(mockGinInjector.getSynapseJavascriptClient()).thenReturn(mockJsClient);
-		authenticationController = new AuthenticationControllerImpl(mockUserAccountService, mockClientCache, mockSessionStorage, mockCookieProvider, mockGinInjector, mockSynapseJSNIUtils);
+		when(mockQueryClientProvider.getQueryClient()).thenReturn(mockQueryClient);
+		authenticationController = new AuthenticationControllerImpl(mockUserAccountService, mockClientCache, mockSessionStorage, mockCookieProvider, mockGinInjector, mockSynapseJSNIUtils, mockQueryClientProvider);
 		when(mockGinInjector.getGlobalApplicationState()).thenReturn(mockGlobalApplicationState);
 		when(mockGinInjector.getHeader()).thenReturn(mockHeader);
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
@@ -137,6 +144,7 @@ public class AuthenticationControllerImplTest {
 		verify(mockSessionDetector).initializeAccessTokenState();
 		verify(mockGlobalApplicationState).refreshPage();
 		verify(mockSynapseJSNIUtils).setAnalyticsUserId("");
+		verify(mockQueryClient).clear();
 	}
 
 	@Test
@@ -192,6 +200,7 @@ public class AuthenticationControllerImplTest {
 		verify(loginCallback).onSuccess(any(UserProfile.class));
 		verify(mockSessionDetector).initializeAccessTokenState();
 		verify(mockSynapseJSNIUtils).setAnalyticsUserId(USER_ID);
+		verify(mockQueryClient).clear();
 	}
 
 	@Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
@@ -41,7 +41,7 @@ import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.cache.EntityId2BundleCache;
-import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
+import org.sagebionetworks.web.client.context.QueryClientProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.reactquery.QueryClient;
 import org.sagebionetworks.web.client.jsinterop.reactquery.SynapseReactClientQueryKey;
@@ -111,7 +111,7 @@ public class EntityPresenterTest {
 	@Mock
 	FileEntity mockFileEntity;
 	@Mock
-	SynapseContextPropsProvider mockSynapseContextPropsProvider;
+	QueryClientProvider mockQueryClientProvider;
 	@Mock
 	QueryClient mockQueryClient;
 	@Captor
@@ -121,8 +121,8 @@ public class EntityPresenterTest {
 	public void setup() throws Exception {
 		when(mockEntityPresenterEventBinder.getEventBinder()).thenReturn(mockEventBinder);
 		when(mockGlobalApplicationState.getPlaceChanger()).thenReturn(mockPlaceChanger);
-		when(mockSynapseContextPropsProvider.getQueryClient()).thenReturn(mockQueryClient);
-		entityPresenter = new EntityPresenter(mockView, mockEntityPresenterEventBinder, mockGlobalApplicationState, mockAuthenticationController, mockSynapseJavascriptClient, mockSynAlert, mockEntityPageTop, mockHeaderWidget, mockOpenInviteWidget, mockGwtWrapper, mockEventBus, mockSynapseContextPropsProvider);
+		when(mockQueryClientProvider.getQueryClient()).thenReturn(mockQueryClient);
+		entityPresenter = new EntityPresenter(mockView, mockEntityPresenterEventBinder, mockGlobalApplicationState, mockAuthenticationController, mockSynapseJavascriptClient, mockSynAlert, mockEntityPageTop, mockHeaderWidget, mockOpenInviteWidget, mockGwtWrapper, mockEventBus, mockQueryClientProvider);
 		Entity testEntity = new Project();
 		eb = new EntityBundle();
 		eb.setEntity(testEntity);


### PR DESCRIPTION
Clear the QueryClient cache when the authentication token changes, fixing SWC-6288.

SWC-6288 is caused by the following sequence:

1. A non-ACT user opens the new Governance Dashboard. The authentication token is stored as a cookie, but has not been loaded by the AuthenticationControllerImpl
2. The Governance Dashboard React component is loaded. Since the AuthenticationControllerImpl has not stored the auth token yet, the component does not use an auth token
3. An unauthenticated request is made to get open access submissions. The response is empty, and is stored in the cache
4. The authentication token is loaded by the AuthenticationControllerImpl
5. The authentication token is passed to the React component
6. The access submission hook re-runs and gets a cache hit on the empty response


Now, between (4) and (5), the cache is cleared.

Potential follow up work:
* Figure out why the React component is loaded before the AuthenticationController receives the token--not sure if this is working as intended or how this process is supposed to work.
* In synapse-react-client, make the QueryClient cache sensitive to a changing authentication token