### PR TITLE
Fix excess negative margin

### DIFF
--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabViewImpl.ui.xml
@@ -18,11 +18,7 @@
         tabIndex="-1"
       />
     </b:ListItem>
-    <b:TabPane
-      ui:field="tabPane"
-      active="true"
-      addStyleNames="row tab-background"
-    >
+    <b:TabPane ui:field="tabPane" active="true" addStyleNames="tab-background">
       <bh:Div
         ui:field="contentDiv"
         addStyleNames="margin-left-15 margin-right-15"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabViewImpl.ui.xml
@@ -19,10 +19,7 @@
       />
     </b:ListItem>
     <b:TabPane ui:field="tabPane" active="true" addStyleNames="tab-background">
-      <bh:Div
-        ui:field="contentDiv"
-        addStyleNames="margin-left-15 margin-right-15"
-      />
+      <bh:Div ui:field="contentDiv" />
     </b:TabPane>
   </bh:Div>
 </ui:UiBinder>


### PR DESCRIPTION
Depends on #5013 

After changes in #5012, the Entity Page tab pane had a negative margin that exceeded the bounds of the `body` tag.