### PR TITLE
SWC-6317

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -472,6 +472,8 @@ import org.sagebionetworks.web.client.widget.entity.renderer.ImageWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.ImageWidgetViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.IntendedDataUseReportWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.IntendedDataUseReportWidgetViewImpl;
+import org.sagebionetworks.web.client.widget.entity.renderer.NbConvertPreviewView;
+import org.sagebionetworks.web.client.widget.entity.renderer.NbConvertPreviewViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.PlotlyWidgetView;
 import org.sagebionetworks.web.client.widget.entity.renderer.PlotlyWidgetViewImpl;
 import org.sagebionetworks.web.client.widget.entity.renderer.ReferenceWidgetView;
@@ -1585,6 +1587,7 @@ public class PortalGinModule extends AbstractGinModule {
     bind(SynapseJavascriptFactory.class).in(Singleton.class);
 
     bind(HtmlPreviewView.class).to(HtmlPreviewViewImpl.class);
+    bind(NbConvertPreviewView.class).to(NbConvertPreviewViewImpl.class);
     bind(S3DirectLoginDialog.class).to(S3DirectLoginDialogImpl.class);
 
     bind(WikiPageDeleteConfirmationDialogView.class)

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/HtmlPreviewProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/HtmlPreviewProps.java
@@ -1,0 +1,23 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class HtmlPreviewProps extends ReactComponentProps {
+
+  String createdByUserId;
+  String rawHtml;
+
+  @JsOverlay
+  public static HtmlPreviewProps create(
+    String createdByUserId,
+    String rawHtml
+  ) {
+    HtmlPreviewProps props = new HtmlPreviewProps();
+    props.createdByUserId = createdByUserId;
+    props.rawHtml = rawHtml;
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -51,6 +51,7 @@ public class SRC {
     public static ReactComponentType CertificationQuiz;
     public static ReactComponentType<EntityPageBreadcrumbsProps> EntityPageBreadcrumbs;
     public static ReactComponentType<EntityActionMenuProps> EntityActionMenu;
+    public static ReactComponentType<HtmlPreviewProps> HtmlPreview;
 
     /**
      * Pushes a global toast message. In SWC, you should use {@link DisplayUtils#notify}, rather than calling this method directly.

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewView.java
@@ -3,25 +3,9 @@ package org.sagebionetworks.web.client.widget.entity.renderer;
 import com.google.gwt.user.client.ui.IsWidget;
 
 public interface HtmlPreviewView extends IsWidget {
-  void setHtml(String html);
-
-  void setRawHtml(String rawHtml);
-
   void setSynAlert(IsWidget w);
 
   void setLoadingVisible(boolean visible);
 
-  void openRawHtmlInNewWindow();
-
-  void openInNewWindow(String url);
-
-  void setSanitizedWarningVisible(boolean visible);
-
-  void setShowContentLinkText(String text);
-
-  void setPresenter(Presenter p);
-
-  public interface Presenter {
-    void onShowFullContent();
-  }
+  void configure(String createdBy, String rawHtml);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
@@ -1,28 +1,21 @@
 package org.sagebionetworks.web.client.widget.entity.renderer;
 
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.LoadEvent;
-import com.google.gwt.event.dom.client.LoadHandler;
-import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Frame;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.html.Div;
-import org.gwtbootstrap3.client.ui.html.Span;
-import org.sagebionetworks.web.client.SynapseJSNIUtils;
+import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
+import org.sagebionetworks.web.client.jsinterop.HtmlPreviewProps;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.widget.ReactComponentDiv;
 
 public class HtmlPreviewViewImpl implements HtmlPreviewView {
 
   public interface Binder extends UiBinder<Widget, HtmlPreviewViewImpl> {}
-
-  @UiField
-  Div htmlContainer;
 
   @UiField
   Div synAlertContainer;
@@ -31,25 +24,18 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   Div loadingUI;
 
   @UiField
-  Div htmlSanitizedWarning;
+  ReactComponentDiv container;
 
-  @UiField
-  Anchor showContentLink;
-
-  @UiField
-  Span storeRawHtmlSpan;
-
-  Presenter p;
-  SynapseJSNIUtils jsniUtils;
   Widget w;
+  SynapseContextPropsProvider propsProvider;
 
   @Inject
-  public HtmlPreviewViewImpl(Binder binder, SynapseJSNIUtils jsniUtils) {
+  public HtmlPreviewViewImpl(
+    Binder binder,
+    SynapseContextPropsProvider propsProvider
+  ) {
     w = binder.createAndBindUi(this);
-    this.jsniUtils = jsniUtils;
-    showContentLink.addClickHandler(event -> {
-      p.onShowFullContent();
-    });
+    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -58,9 +44,16 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   }
 
   @Override
-  public void setHtml(String html) {
-    htmlContainer.clear();
-    htmlContainer.add(getFrame(html, jsniUtils));
+  public void configure(String createdBy, String rawHtml) {
+    HtmlPreviewProps props = HtmlPreviewProps.create(createdBy, rawHtml);
+
+    ReactNode element = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.HtmlPreview,
+      props,
+      propsProvider.getJsInteropContextProps()
+    );
+
+    container.render(element);
   }
 
   @Override
@@ -72,126 +65,5 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   public void setSynAlert(IsWidget w) {
     synAlertContainer.clear();
     synAlertContainer.add(w);
-  }
-
-  @Override
-  public void openRawHtmlInNewWindow() {
-    String html = storeRawHtmlSpan.getText();
-    _openHtmlInNewWindow(html);
-  }
-
-  private static final native void _openHtmlInNewWindow(String html) /*-{
-		var wnd = $wnd.open("", "");
-		wnd.document.write(html);
-		// close document, to run scripts inside html string 
-		wnd.document.close();
-	}-*/;
-
-  public static Frame getFrame(
-    final String htmlContent,
-    SynapseJSNIUtils jsniUtils
-  ) {
-    final Frame frame = new Frame("about:blank");
-    frame.getElement().setAttribute("frameborder", "0");
-    frame.setWidth("100%");
-    frame.addLoadHandler(
-      new LoadHandler() {
-        @Override
-        public void onLoad(LoadEvent event) {
-          _autoAdjustFrameHeight(frame.getElement());
-          Scheduler
-            .get()
-            .scheduleFixedDelay(
-              new Scheduler.RepeatingCommand() {
-                @Override
-                public boolean execute() {
-                  _autoAdjustFrameHeight(frame.getElement());
-                  // keep executing as long as frame is attached
-                  return frame.isAttached();
-                }
-              },
-              200
-            );
-        }
-      }
-    );
-
-    frame.addAttachHandler(
-      new AttachEvent.Handler() {
-        @Override
-        public void onAttachOrDetach(AttachEvent event) {
-          if (event.isAttached()) {
-            // use html5 srcdoc if available
-            if (
-              jsniUtils.elementSupportsAttribute(frame.getElement(), "srcdoc")
-            ) {
-              frame.getElement().setAttribute("srcdoc", htmlContent);
-            } else {
-              _setFrameContent(frame.getElement(), htmlContent);
-            }
-          }
-        }
-      }
-    );
-    return frame;
-  }
-
-  public static native void _autoAdjustFrameHeight(Element iframe) /*-{
-		if (iframe && iframe.contentWindow
-				&& iframe.contentWindow.document.body) {
-			var newHeightPx = iframe.contentWindow.document.body.scrollHeight;
-			if (newHeightPx < 450) {
-				newHeightPx = 450;
-			}
-			var frameHeight = parseInt(iframe.height);
-			if (!frameHeight || (Math.abs(newHeightPx - frameHeight) > 70)) {
-				iframe.height = "";
-				iframe.height = (newHeightPx + 50) + "px";
-				// uncomment to auto-scroll to iframe content when height changes (not ideal if html preview is in a wiki)
-				//				if (frameHeight) {
-				//					iframe.scrollIntoView({behavior: 'smooth'});
-				//				}
-			}
-		}
-	}-*/;
-
-  public static native void _setFrameContent(
-    Element iframe,
-    String htmlContent
-  ) /*-{
-		if (iframe) {
-			try {
-				iframe.contentWindow.document.open('text/html', 'replace');
-				iframe.contentWindow.document.write(htmlContent);
-				iframe.contentWindow.document.close();
-			} catch (err) {
-				console.error(err);
-			}
-		}
-	}-*/;
-
-  @Override
-  public void setPresenter(Presenter p) {
-    this.p = p;
-  }
-
-  @Override
-  public void setSanitizedWarningVisible(boolean visible) {
-    htmlSanitizedWarning.setVisible(visible);
-  }
-
-  @Override
-  public void setRawHtml(String rawHtml) {
-    storeRawHtmlSpan.setText(rawHtml);
-  }
-
-  @Override
-  public void openInNewWindow(String url) {
-    Window.open(url, "", "");
-  }
-
-  @Override
-  public void setShowContentLinkText(String text) {
-    showContentLink.setText(text);
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewView.java
@@ -15,10 +15,6 @@ public interface NbConvertPreviewView extends IsWidget {
 
   void openInNewWindow(String url);
 
-  void setSanitizedWarningVisible(boolean visible);
-
-  void setShowContentLinkText(String text);
-
   void setPresenter(Presenter p);
 
   public interface Presenter {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewView.java
@@ -1,0 +1,27 @@
+package org.sagebionetworks.web.client.widget.entity.renderer;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface NbConvertPreviewView extends IsWidget {
+  void setHtml(String html);
+
+  void setRawHtml(String rawHtml);
+
+  void setSynAlert(IsWidget w);
+
+  void setLoadingVisible(boolean visible);
+
+  void openRawHtmlInNewWindow();
+
+  void openInNewWindow(String url);
+
+  void setSanitizedWarningVisible(boolean visible);
+
+  void setShowContentLinkText(String text);
+
+  void setPresenter(Presenter p);
+
+  public interface Presenter {
+    void onShowFullContent();
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.java
@@ -176,11 +176,6 @@ public class NbConvertPreviewViewImpl implements NbConvertPreviewView {
   }
 
   @Override
-  public void setSanitizedWarningVisible(boolean visible) {
-    htmlSanitizedWarning.setVisible(visible);
-  }
-
-  @Override
   public void setRawHtml(String rawHtml) {
     storeRawHtmlSpan.setText(rawHtml);
   }
@@ -188,10 +183,5 @@ public class NbConvertPreviewViewImpl implements NbConvertPreviewView {
   @Override
   public void openInNewWindow(String url) {
     Window.open(url, "", "");
-  }
-
-  @Override
-  public void setShowContentLinkText(String text) {
-    showContentLink.setText(text);
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.java
@@ -1,0 +1,197 @@
+package org.sagebionetworks.web.client.widget.entity.renderer;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.LoadEvent;
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Frame;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import org.gwtbootstrap3.client.ui.Anchor;
+import org.gwtbootstrap3.client.ui.html.Div;
+import org.gwtbootstrap3.client.ui.html.Span;
+import org.sagebionetworks.web.client.SynapseJSNIUtils;
+
+public class NbConvertPreviewViewImpl implements NbConvertPreviewView {
+
+  public interface Binder extends UiBinder<Widget, NbConvertPreviewViewImpl> {}
+
+  @UiField
+  Div htmlContainer;
+
+  @UiField
+  Div synAlertContainer;
+
+  @UiField
+  Div loadingUI;
+
+  @UiField
+  Div htmlSanitizedWarning;
+
+  @UiField
+  Anchor showContentLink;
+
+  @UiField
+  Span storeRawHtmlSpan;
+
+  Presenter p;
+  SynapseJSNIUtils jsniUtils;
+  Widget w;
+
+  @Inject
+  public NbConvertPreviewViewImpl(Binder binder, SynapseJSNIUtils jsniUtils) {
+    w = binder.createAndBindUi(this);
+    this.jsniUtils = jsniUtils;
+    showContentLink.addClickHandler(event -> {
+      p.onShowFullContent();
+    });
+  }
+
+  @Override
+  public Widget asWidget() {
+    return w;
+  }
+
+  @Override
+  public void setHtml(String html) {
+    htmlContainer.clear();
+    htmlContainer.add(getFrame(html, jsniUtils));
+  }
+
+  @Override
+  public void setLoadingVisible(boolean visible) {
+    loadingUI.setVisible(visible);
+  }
+
+  @Override
+  public void setSynAlert(IsWidget w) {
+    synAlertContainer.clear();
+    synAlertContainer.add(w);
+  }
+
+  @Override
+  public void openRawHtmlInNewWindow() {
+    String html = storeRawHtmlSpan.getText();
+    _openHtmlInNewWindow(html);
+  }
+
+  private static final native void _openHtmlInNewWindow(String html) /*-{
+		var wnd = $wnd.open("", "");
+		wnd.document.write(html);
+		// close document, to run scripts inside html string 
+		wnd.document.close();
+	}-*/;
+
+  public static Frame getFrame(
+    final String htmlContent,
+    SynapseJSNIUtils jsniUtils
+  ) {
+    final Frame frame = new Frame("about:blank");
+    frame.getElement().setAttribute("frameborder", "0");
+    frame.setWidth("100%");
+    frame.addLoadHandler(
+      new LoadHandler() {
+        @Override
+        public void onLoad(LoadEvent event) {
+          _autoAdjustFrameHeight(frame.getElement());
+          Scheduler
+            .get()
+            .scheduleFixedDelay(
+              new Scheduler.RepeatingCommand() {
+                @Override
+                public boolean execute() {
+                  _autoAdjustFrameHeight(frame.getElement());
+                  // keep executing as long as frame is attached
+                  return frame.isAttached();
+                }
+              },
+              200
+            );
+        }
+      }
+    );
+
+    frame.addAttachHandler(
+      new AttachEvent.Handler() {
+        @Override
+        public void onAttachOrDetach(AttachEvent event) {
+          if (event.isAttached()) {
+            // use html5 srcdoc if available
+            if (
+              jsniUtils.elementSupportsAttribute(frame.getElement(), "srcdoc")
+            ) {
+              frame.getElement().setAttribute("srcdoc", htmlContent);
+            } else {
+              _setFrameContent(frame.getElement(), htmlContent);
+            }
+          }
+        }
+      }
+    );
+    return frame;
+  }
+
+  public static native void _autoAdjustFrameHeight(Element iframe) /*-{
+		if (iframe && iframe.contentWindow
+				&& iframe.contentWindow.document.body) {
+			var newHeightPx = iframe.contentWindow.document.body.scrollHeight;
+			if (newHeightPx < 450) {
+				newHeightPx = 450;
+			}
+			var frameHeight = parseInt(iframe.height);
+			if (!frameHeight || (Math.abs(newHeightPx - frameHeight) > 70)) {
+				iframe.height = "";
+				iframe.height = (newHeightPx + 50) + "px";
+				// uncomment to auto-scroll to iframe content when height changes (not ideal if html preview is in a wiki)
+				//				if (frameHeight) {
+				//					iframe.scrollIntoView({behavior: 'smooth'});
+				//				}
+			}
+		}
+	}-*/;
+
+  public static native void _setFrameContent(
+    Element iframe,
+    String htmlContent
+  ) /*-{
+		if (iframe) {
+			try {
+				iframe.contentWindow.document.open('text/html', 'replace');
+				iframe.contentWindow.document.write(htmlContent);
+				iframe.contentWindow.document.close();
+			} catch (err) {
+				console.error(err);
+			}
+		}
+	}-*/;
+
+  @Override
+  public void setPresenter(Presenter p) {
+    this.p = p;
+  }
+
+  @Override
+  public void setSanitizedWarningVisible(boolean visible) {
+    htmlSanitizedWarning.setVisible(visible);
+  }
+
+  @Override
+  public void setRawHtml(String rawHtml) {
+    storeRawHtmlSpan.setText(rawHtml);
+  }
+
+  @Override
+  public void openInNewWindow(String url) {
+    Window.open(url, "", "");
+  }
+
+  @Override
+  public void setShowContentLinkText(String text) {
+    showContentLink.setText(text);
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
@@ -5,7 +5,6 @@ import static org.sagebionetworks.web.client.SynapseJavascriptClient.ACCEPT;
 import static org.sagebionetworks.web.shared.WebConstants.NBCONVERT_ENDPOINT_PROPERTY;
 import static org.sagebionetworks.web.shared.WebConstants.TEXT_HTML_CHARSET_UTF8;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -139,7 +138,6 @@ public class NbConvertPreviewWidget
 
         @Override
         public void onSuccess(Boolean trustedUser) {
-          GWT.debugger();
           view.setLoadingVisible(false);
           if (trustedUser) {
             view.setHtml(wrappedRawHtml);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.web.client.SynapseJavascriptClient.ACCEPT;
 import static org.sagebionetworks.web.shared.WebConstants.NBCONVERT_ENDPOINT_PROPERTY;
 import static org.sagebionetworks.web.shared.WebConstants.TEXT_HTML_CHARSET_UTF8;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
@@ -29,8 +30,6 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 public class NbConvertPreviewWidget
   implements IsWidget, NbConvertPreviewView.Presenter {
 
-  public static final String DOWNLOAD_NOTEBOOK_MESSAGE =
-    "Download this Juypter notebook and run in a local notebook server to see the fully interactive version.";
   String nbConvertEndpoint;
   public static final String HTML_PREFIX =
     "<html><head>" +
@@ -77,10 +76,8 @@ public class NbConvertPreviewWidget
       friendlyMaxFileSize =
         gwt.getFriendlySize(HtmlPreviewWidget.MAX_HTML_FILE_SIZE, true);
     }
-
     nbConvertEndpoint =
       synapseProperties.getSynapseProperty(NBCONVERT_ENDPOINT_PROPERTY);
-    view.setShowContentLinkText(DOWNLOAD_NOTEBOOK_MESSAGE);
   }
 
   public void configure(String synapseId, FileHandle fileHandle) {
@@ -142,6 +139,7 @@ public class NbConvertPreviewWidget
 
         @Override
         public void onSuccess(Boolean trustedUser) {
+          GWT.debugger();
           view.setLoadingVisible(false);
           if (trustedUser) {
             view.setHtml(wrappedRawHtml);
@@ -158,7 +156,6 @@ public class NbConvertPreviewWidget
           } else {
             view.setHtml(sanitizedHtml);
             view.setRawHtml(wrappedRawHtml);
-            view.setSanitizedWarningVisible(true);
           }
         }
       }
@@ -166,7 +163,6 @@ public class NbConvertPreviewWidget
   }
 
   public void setPresignedUrl(String url) {
-    view.setSanitizedWarningVisible(true);
     String encodedUrl = gwt.encodeQueryString(url);
     // use lambda endpoint to resolve ipynb file to html
     requestBuilder.configure(

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewWidget.java
@@ -1,12 +1,21 @@
 package org.sagebionetworks.web.client.widget.entity.renderer;
 
+import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEntryPoint;
 import static org.sagebionetworks.web.client.SynapseJavascriptClient.ACCEPT;
 import static org.sagebionetworks.web.shared.WebConstants.NBCONVERT_ENDPOINT_PROPERTY;
 import static org.sagebionetworks.web.shared.WebConstants.TEXT_HTML_CHARSET_UTF8;
 
+import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.Response;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
+import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.file.FileHandleAssociateType;
+import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.file.FileResult;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.PopupUtilsView;
@@ -17,7 +26,8 @@ import org.sagebionetworks.web.client.SynapseProperties;
 import org.sagebionetworks.web.client.widget.asynch.PresignedURLAsyncHandler;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 
-public class NbConvertPreviewWidget extends HtmlPreviewWidget {
+public class NbConvertPreviewWidget
+  implements IsWidget, NbConvertPreviewView.Presenter {
 
   public static final String DOWNLOAD_NOTEBOOK_MESSAGE =
     "Download this Juypter notebook and run in a local notebook server to see the fully interactive version.";
@@ -28,9 +38,21 @@ public class NbConvertPreviewWidget extends HtmlPreviewWidget {
     "</head><body>";
   public static final String HTML_SUFFIX = "</body></html>";
 
+  protected NbConvertPreviewView view;
+  protected PresignedURLAsyncHandler presignedURLAsyncHandler;
+  protected FileHandleAssociation fha;
+  protected SynapseAlert synAlert;
+  protected RequestBuilderWrapper requestBuilder;
+  protected SynapseJSNIUtils jsniUtils;
+  protected String createdBy;
+  protected SynapseClientAsync synapseClient;
+  protected PopupUtilsView popupUtils;
+  protected GWTWrapper gwt;
+  public static String friendlyMaxFileSize = null;
+
   @Inject
   public NbConvertPreviewWidget(
-    HtmlPreviewView view,
+    NbConvertPreviewView view,
     PresignedURLAsyncHandler presignedURLAsyncHandler,
     SynapseJSNIUtils jsniUtils,
     RequestBuilderWrapper requestBuilder,
@@ -40,27 +62,109 @@ public class NbConvertPreviewWidget extends HtmlPreviewWidget {
     SynapseProperties synapseProperties,
     GWTWrapper gwt
   ) {
-    super(
-      view,
-      presignedURLAsyncHandler,
-      jsniUtils,
-      requestBuilder,
-      synAlert,
-      synapseClient,
-      popupUtils,
-      gwt
-    );
+    this.view = view;
+    this.presignedURLAsyncHandler = presignedURLAsyncHandler;
+    this.jsniUtils = jsniUtils;
+    this.requestBuilder = requestBuilder;
+    this.synAlert = synAlert;
+    this.synapseClient = synapseClient;
+    fixServiceEntryPoint(synapseClient);
+    this.popupUtils = popupUtils;
+    this.gwt = gwt;
+    view.setSynAlert(synAlert);
+    view.setPresenter(this);
+    if (friendlyMaxFileSize == null) {
+      friendlyMaxFileSize =
+        gwt.getFriendlySize(HtmlPreviewWidget.MAX_HTML_FILE_SIZE, true);
+    }
+
     nbConvertEndpoint =
       synapseProperties.getSynapseProperty(NBCONVERT_ENDPOINT_PROPERTY);
     view.setShowContentLinkText(DOWNLOAD_NOTEBOOK_MESSAGE);
   }
 
-  @Override
-  public void renderHTML(String rawHtml) {
-    super.renderHTML(HTML_PREFIX + rawHtml + HTML_SUFFIX);
+  public void configure(String synapseId, FileHandle fileHandle) {
+    this.createdBy = fileHandle.getCreatedBy();
+    fha = new FileHandleAssociation();
+    fha.setAssociateObjectId(synapseId);
+    fha.setAssociateObjectType(FileHandleAssociateType.FileEntity);
+    fha.setFileHandleId(fileHandle.getId());
+    if (
+      fileHandle.getContentSize() != null &&
+      fileHandle.getContentSize() < HtmlPreviewWidget.MAX_HTML_FILE_SIZE
+    ) {
+      refreshContent();
+    } else {
+      view.setLoadingVisible(false);
+      synAlert.showError(
+        "The preview was not shown because the size (" +
+        gwt.getFriendlySize(fileHandle.getContentSize().doubleValue(), true) +
+        ") exceeds the maximum preview size (" +
+        friendlyMaxFileSize +
+        ")"
+      );
+    }
   }
 
-  @Override
+  public void refreshContent() {
+    if (fha != null) {
+      synAlert.clear();
+      view.setLoadingVisible(true);
+      presignedURLAsyncHandler.getFileResult(
+        fha,
+        new AsyncCallback<FileResult>() {
+          @Override
+          public void onSuccess(FileResult fileResult) {
+            setPresignedUrl(fileResult.getPreSignedURL());
+          }
+
+          @Override
+          public void onFailure(Throwable ex) {
+            view.setLoadingVisible(false);
+            synAlert.handleException(ex);
+          }
+        }
+      );
+    }
+  }
+
+  public void renderHTML(String rawHtml) {
+    String wrappedRawHtml = HTML_PREFIX + rawHtml + HTML_SUFFIX;
+    synapseClient.isUserAllowedToRenderHTML(
+      createdBy,
+      new AsyncCallback<Boolean>() {
+        @Override
+        public void onFailure(Throwable caught) {
+          view.setLoadingVisible(false);
+          showSanitizedHtml();
+          jsniUtils.consoleError(caught.getMessage());
+        }
+
+        @Override
+        public void onSuccess(Boolean trustedUser) {
+          view.setLoadingVisible(false);
+          if (trustedUser) {
+            view.setHtml(wrappedRawHtml);
+          } else {
+            showSanitizedHtml();
+          }
+        }
+
+        private void showSanitizedHtml() {
+          // is the sanitized version the same as the original??
+          String sanitizedHtml = jsniUtils.sanitizeHtml(wrappedRawHtml);
+          if (wrappedRawHtml.equals(sanitizedHtml)) {
+            view.setHtml(wrappedRawHtml);
+          } else {
+            view.setHtml(sanitizedHtml);
+            view.setRawHtml(wrappedRawHtml);
+            view.setSanitizedWarningVisible(true);
+          }
+        }
+      }
+    );
+  }
+
   public void setPresignedUrl(String url) {
     view.setSanitizedWarningVisible(true);
     String encodedUrl = gwt.encodeQueryString(url);
@@ -97,5 +201,35 @@ public class NbConvertPreviewWidget extends HtmlPreviewWidget {
         }
       }
     );
+  }
+
+  protected RequestCallback getRequestCallback() {
+    return new RequestCallback() {
+      @Override
+      public void onResponseReceived(Request request, Response response) {
+        int statusCode = response.getStatusCode();
+        if (statusCode == Response.SC_OK) {
+          renderHTML(response.getText());
+        } else {
+          onError(
+            null,
+            new IllegalArgumentException(
+              "Unable to retrieve. Reason: " + response.getStatusText()
+            )
+          );
+        }
+      }
+
+      @Override
+      public void onError(Request request, Throwable exception) {
+        view.setLoadingVisible(false);
+        synAlert.handleException(exception);
+      }
+    };
+  }
+
+  @Override
+  public Widget asWidget() {
+    return view.asWidget();
   }
 }

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
@@ -7,11 +7,26 @@
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="margin-5">
+    <bh:Div
+      ui:field="htmlSanitizedWarning"
+      visible="false"
+      addStyleNames="margin-top-20 margin-bottom-10"
+    >
+      <b:Alert type="INFO">
+        <bh:Text text="Limited rendering only." />
+        <b:Anchor
+          ui:field="showContentLink"
+          text="External view available."
+          addStyleNames="margin-left-5"
+        />
+      </b:Alert>
+    </bh:Div>
     <bh:Div ui:field="loadingUI" addStyleNames="center center-block">
       <w:LoadingSpinner size="31px" />
       <bh:Text ui:field="loadingMessage" />
     </bh:Div>
-    <w:ReactComponentDiv ui:field="container" />
+    <bh:Div ui:field="htmlContainer" />
+    <bh:Span ui:field="storeRawHtmlSpan" visible="false" />
     <bh:Div ui:field="synAlertContainer" />
   </bh:Div>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
@@ -9,14 +9,13 @@
   <bh:Div addStyleNames="margin-5">
     <bh:Div
       ui:field="htmlSanitizedWarning"
-      visible="false"
       addStyleNames="margin-top-20 margin-bottom-10"
     >
       <b:Alert type="INFO">
         <bh:Text text="Limited rendering only." />
         <b:Anchor
           ui:field="showContentLink"
-          text="External view available."
+          text="Download this Juypter notebook and run in a local notebook server to see the fully interactive version."
           addStyleNames="margin-left-5"
         />
       </b:Alert>

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/HtmlPreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/HtmlPreviewWidgetTest.java
@@ -131,11 +131,6 @@ public class HtmlPreviewWidgetTest {
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
       .sendRequest(anyString(), any(RequestCallback.class));
-    when(mockSynapseJSNIUtils.sanitizeHtml(HTML)).thenReturn(SANITIZED_HTML);
-    AsyncMockStubber
-      .callSuccessWith(true)
-      .when(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
     AsyncMockStubber
       .callSuccessWith(mockFileResult)
       .when(mockPresignedURLAsyncHandler)
@@ -207,99 +202,6 @@ public class HtmlPreviewWidgetTest {
     verify(mockSynapseAlert).handleException(exceptionCaptor.capture());
     Throwable th = exceptionCaptor.getValue();
     assertTrue(th.getMessage().contains(error));
-  }
-
-  @Test
-  public void testRenderHtmlTrusted() {
-    previewWidget.configure(ENTITY_ID, mockFileHandle);
-
-    verify(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    // user is allowed to render html, so raw html is rendered
-    verify(mockView).setSanitizedWarningVisible(false);
-    verify(mockView).setHtml(HTML);
-    verify(mockView).setLoadingVisible(true);
-    verify(mockView).setLoadingVisible(false);
-  }
-
-  @Test
-  public void testRenderHtmlUntrustedButSafe() {
-    AsyncMockStubber
-      .callSuccessWith(false)
-      .when(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    when(mockSynapseJSNIUtils.sanitizeHtml(HTML)).thenReturn(HTML);
-
-    previewWidget.configure(ENTITY_ID, mockFileHandle);
-
-    verify(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    // user is not allowed to render, but sanitized version is the same as raw
-    verify(mockView).setSanitizedWarningVisible(false);
-    verify(mockSynapseJSNIUtils).sanitizeHtml(HTML);
-    verify(mockView).setHtml(HTML);
-    verify(mockView).setLoadingVisible(true);
-    verify(mockView).setLoadingVisible(false);
-  }
-
-  @Test
-  public void testBlockRenderHtmlUntrusted() {
-    AsyncMockStubber
-      .callSuccessWith(false)
-      .when(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-
-    previewWidget.configure(ENTITY_ID, mockFileHandle);
-
-    verify(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    // user is not allowed to render. show sanitized version
-    verify(mockView).setSanitizedWarningVisible(false);
-    verify(mockSynapseJSNIUtils).sanitizeHtml(HTML);
-    verify(mockView).setHtml(SANITIZED_HTML);
-    verify(mockView).setRawHtml(HTML);
-    verify(mockView).setSanitizedWarningVisible(true);
-    verify(mockView).setLoadingVisible(true);
-    verify(mockView).setLoadingVisible(false);
-  }
-
-  @Test
-  public void testIsTrustedCheckFailure() {
-    String errorMessage = "unable to determine if user is on the team";
-    Exception ex = new Exception(errorMessage);
-    AsyncMockStubber
-      .callFailureWith(ex)
-      .when(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-
-    previewWidget.configure(ENTITY_ID, mockFileHandle);
-
-    verify(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    // user is not allowed to render. show sanitized version
-    verify(mockView).setSanitizedWarningVisible(false);
-    verify(mockSynapseJSNIUtils).sanitizeHtml(HTML);
-    verify(mockView).setHtml(SANITIZED_HTML);
-    verify(mockView).setRawHtml(HTML);
-    verify(mockView).setSanitizedWarningVisible(true);
-    verify(mockView).setLoadingVisible(true);
-    verify(mockView).setLoadingVisible(false);
-    verify(mockSynapseJSNIUtils).consoleError(errorMessage);
-  }
-
-  @Test
-  public void testOnShowFullContent() {
-    previewWidget.onShowFullContent();
-
-    verify(mockPopupUtils)
-      .showConfirmDialog(
-        eq(""),
-        eq(HtmlPreviewWidget.CONFIRM_OPEN_HTML_MESSAGE),
-        callbackCaptor.capture()
-      );
-
-    callbackCaptor.getValue().invoke();
-    verify(mockView).openRawHtmlInNewWindow();
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/NbConvertPreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/NbConvertPreviewWidgetTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.web.client.SynapseJavascriptClient.ACCEPT;
@@ -37,7 +36,7 @@ import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.asynch.PresignedURLAsyncHandler;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
-import org.sagebionetworks.web.client.widget.entity.renderer.HtmlPreviewView;
+import org.sagebionetworks.web.client.widget.entity.renderer.NbConvertPreviewView;
 import org.sagebionetworks.web.client.widget.entity.renderer.NbConvertPreviewWidget;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 import org.sagebionetworks.web.test.helper.RequestBuilderMockStubber;
@@ -53,7 +52,7 @@ public class NbConvertPreviewWidgetTest {
   NbConvertPreviewWidget previewWidget;
 
   @Mock
-  HtmlPreviewView mockView;
+  NbConvertPreviewView mockView;
 
   @Mock
   RequestBuilderWrapper mockRequestBuilder;
@@ -226,7 +225,6 @@ public class NbConvertPreviewWidgetTest {
     verify(mockSynapseClient)
       .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
     // user is allowed to render html, so raw html is rendered
-    verify(mockView).setSanitizedWarningVisible(false);
     verify(mockView).setHtml(WRAPPED_HTML);
     verify(mockView).setLoadingVisible(true);
     verify(mockView).setLoadingVisible(false);
@@ -247,7 +245,6 @@ public class NbConvertPreviewWidgetTest {
     verify(mockSynapseClient)
       .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
     // user is not allowed to render, but sanitized version is the same as raw
-    verify(mockView).setSanitizedWarningVisible(false);
     verify(mockSynapseJSNIUtils).sanitizeHtml(WRAPPED_HTML);
     verify(mockView).setHtml(WRAPPED_HTML);
     verify(mockView).setLoadingVisible(true);
@@ -266,13 +263,9 @@ public class NbConvertPreviewWidgetTest {
     verify(mockSynapseClient)
       .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
     // user is not allowed to render. show sanitized version
-    verify(mockView).setSanitizedWarningVisible(false);
     verify(mockSynapseJSNIUtils).sanitizeHtml(WRAPPED_HTML);
     verify(mockView).setHtml(SANITIZED_HTML);
     verify(mockView).setRawHtml(WRAPPED_HTML);
-    // once because user is not on the html/js team, once because this is an ipynb (need link to
-    // download for fully interactive version)
-    verify(mockView, times(2)).setSanitizedWarningVisible(true);
     verify(mockView).setLoadingVisible(true);
     verify(mockView).setLoadingVisible(false);
   }
@@ -290,12 +283,9 @@ public class NbConvertPreviewWidgetTest {
 
     verify(mockSynapseClient)
       .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
-    // user is not allowed to render. show sanitized version
-    verify(mockView).setSanitizedWarningVisible(false);
     verify(mockSynapseJSNIUtils).sanitizeHtml(WRAPPED_HTML);
     verify(mockView).setHtml(SANITIZED_HTML);
     verify(mockView).setRawHtml(WRAPPED_HTML);
-    verify(mockView, times(2)).setSanitizedWarningVisible(true);
     verify(mockView).setLoadingVisible(true);
     verify(mockView).setLoadingVisible(false);
     verify(mockSynapseJSNIUtils).consoleError(errorMessage);


### PR DESCRIPTION
- Use HtmlPreview from SRC
- Move logic from HtmlPreview to NbConvertPreviewWidget (since it previously extended HtmlPreviewWidget)
- Clean-up after move.  For example, the NbConvertPreviewWidget always needs to show the "limited rendering only" UI because it is non-interactive.   User must download the file and run the server locally to interact with it.  But it may still be sanitized, depending on the createdBy user who uploaded the file.