### PR TITLE
SWC-6349: Use new CreatedByModifiedBy component

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/CreatedByModifiedByProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/CreatedByModifiedByProps.java
@@ -1,0 +1,34 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class CreatedByModifiedByProps extends ReactComponentProps {
+
+  String entityId;
+
+  @JsNullable
+  long versionNumber;
+
+  @JsOverlay
+  public static CreatedByModifiedByProps create(
+    String targetId,
+    Long targetVersionNumber
+  ) {
+    CreatedByModifiedByProps props = new CreatedByModifiedByProps();
+    props.entityId = targetId;
+    if (targetVersionNumber != null) {
+      props.versionNumber = targetVersionNumber.longValue();
+    }
+    return props;
+  }
+
+  @JsOverlay
+  public static CreatedByModifiedByProps create() {
+    CreatedByModifiedByProps props = new CreatedByModifiedByProps();
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/QueryWrapperPlotNavProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/QueryWrapperPlotNavProps.java
@@ -66,7 +66,7 @@ public class QueryWrapperPlotNavProps extends ReactComponentProps {
     props.shouldDeepLink = false;
     props.name = "Items";
     props.downloadCartPageUrl = "#!DownloadCart:0";
-    props.showLastUpdatedOn = true;
+    props.showLastUpdatedOn = false;
     // SWC-6138 - hide charts by default
     props.defaultShowFacetVisualization = false;
     return props;

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -54,6 +54,7 @@ public class SRC {
 
     public static ReactComponentType<EntityActionMenuPropsJsInterop> EntityActionMenu;
     public static ReactComponentType<HtmlPreviewProps> HtmlPreview;
+    public static ReactComponentType<CreatedByModifiedByProps> CreatedByModifiedBy;
 
     /**
      * Pushes a global toast message. In SWC, you should use {@link DisplayUtils#notify}, rather than calling this method directly.

--- a/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/docker/DockerRepoWidget.java
@@ -74,12 +74,7 @@ public class DockerRepoWidget {
     this.canEdit = bundle.getPermissions().getCanCertifiedUserEdit();
     metadata.configure(bundle, null, actionMenu);
     dockerTitleBar.configure(bundle, actionMenu);
-    modifiedCreatedBy.configure(
-      entity.getCreatedOn(),
-      entity.getCreatedBy(),
-      entity.getModifiedOn(),
-      entity.getModifiedBy()
-    );
+    modifiedCreatedBy.configure(entity.getId(), null);
     configureWikiPage(bundle);
     configureProvenance(entity.getId());
     view.setDockerPullCommand(DOCKER_PULL_COMMAND + entity.getRepositoryName());

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidget.java
@@ -4,60 +4,30 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import java.util.Date;
+import javax.annotation.Nullable;
 import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.help.HelpButton;
+import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
+import org.sagebionetworks.web.client.jsinterop.ReferenceJsObject;
 import org.sagebionetworks.web.client.widget.user.UserBadge;
 
 public class ModifiedCreatedByWidget implements IsWidget {
 
   private ModifiedCreatedByWidgetView view;
-  private UserBadge createdByBadge;
-  private UserBadge modifiedByBadge;
-  private DateTimeUtils dateTimeUtils;
 
   @Inject
-  public ModifiedCreatedByWidget(
-    ModifiedCreatedByWidgetView view,
-    UserBadge createdByBadge,
-    UserBadge modifiedByBadge,
-    DateTimeUtils dateTimeUtils
-  ) {
+  public ModifiedCreatedByWidget(ModifiedCreatedByWidgetView view) {
     this.view = view;
-    this.createdByBadge = createdByBadge;
-    this.modifiedByBadge = modifiedByBadge;
-    this.dateTimeUtils = dateTimeUtils;
-    view.setCreatedBadge(createdByBadge);
-    view.setModifiedBadge(modifiedByBadge);
   }
 
-  public void configure(
-    Date createdOn,
-    String createdBy,
-    Date modifiedOn,
-    String modifiedBy
-  ) {
-    createdByBadge.configure(createdBy);
-    modifiedByBadge.configure(modifiedBy);
-    view.setCreatedOnText(
-      " on " + dateTimeUtils.getLongFriendlyDate(createdOn)
-    );
-    view.setModifiedOnText(
-      " on " + dateTimeUtils.getLongFriendlyDate(modifiedOn)
-    );
+  public void configure(String entityId, @Nullable Long versionNumber) {
     view.setVisible(true);
+    view.setProps(CreatedByModifiedByProps.create(entityId, versionNumber));
   }
 
   @Override
   public Widget asWidget() {
     return view.asWidget();
-  }
-
-  public void setCreatedHelpWidgetVisible(boolean visible) {
-    view.setCreatedHelpWidgetVisible(visible);
-  }
-
-  public void setCreatedHelpWidgetText(String text) {
-    view.setCreatedHelpWidgetText(text);
   }
 
   public void setVisible(boolean isVisible) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetView.java
@@ -1,18 +1,11 @@
 package org.sagebionetworks.web.client.widget.entity;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
+import org.sagebionetworks.web.client.jsinterop.ReferenceJsObject;
 
 public interface ModifiedCreatedByWidgetView extends IsWidget {
-  void setCreatedOnText(String string);
-
-  void setModifiedOnText(String string);
-
-  void setModifiedBadge(IsWidget modifiedBadge);
-
-  void setCreatedBadge(IsWidget createdBadge);
+  void setProps(CreatedByModifiedByProps props);
 
   void setVisible(boolean b);
-  void setCreatedHelpWidgetVisible(boolean visible);
-
-  void setCreatedHelpWidgetText(String text);
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
@@ -7,45 +7,35 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Span;
+import org.sagebionetworks.web.client.context.SynapseContextPropsProvider;
+import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReferenceJsObject;
+import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.HelpWidget;
+import org.sagebionetworks.web.client.widget.ReactComponentDiv;
 
 public class ModifiedCreatedByWidgetViewImpl
   implements ModifiedCreatedByWidgetView {
 
   @UiField
-  Span createdBadgePanel;
-
-  @UiField
-  Span createdOnText;
-
-  @UiField
-  Span modifiedBadgePanel;
-
-  @UiField
-  Span modifiedOnText;
-
-  @UiField
-  Div container;
-
-  @UiField
-  Span createdByUI;
-
-  @UiField
-  Span modifiedByUI;
-
-  @UiField
-  HelpWidget createdHelpWidget;
+  ReactComponentDiv container;
 
   public interface ModifiedCreatedByWidgetViewImplUiBinder
     extends UiBinder<Widget, ModifiedCreatedByWidgetViewImpl> {}
 
   private Widget widget;
 
+  private final SynapseContextPropsProvider propsProvider;
+
   @Inject
   public ModifiedCreatedByWidgetViewImpl(
-    ModifiedCreatedByWidgetViewImplUiBinder binder
+    ModifiedCreatedByWidgetViewImplUiBinder binder,
+    SynapseContextPropsProvider propsProvider
   ) {
     widget = binder.createAndBindUi(this);
+    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -54,39 +44,17 @@ public class ModifiedCreatedByWidgetViewImpl
   }
 
   @Override
-  public void setCreatedOnText(String text) {
-    createdOnText.setText(text);
-  }
-
-  @Override
-  public void setModifiedOnText(String text) {
-    modifiedOnText.setText(text);
-  }
-
-  @Override
-  public void setModifiedBadge(IsWidget modifiedBadge) {
-    modifiedBadgePanel.clear();
-    modifiedBadgePanel.add(modifiedBadge);
-  }
-
-  @Override
-  public void setCreatedBadge(IsWidget createdBadge) {
-    createdBadgePanel.clear();
-    createdBadgePanel.add(createdBadge);
+  public void setProps(CreatedByModifiedByProps props) {
+    ReactNode component = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.CreatedByModifiedBy,
+      props,
+      propsProvider.getJsInteropContextProps()
+    );
+    container.render(component);
   }
 
   @Override
   public void setVisible(boolean isVisible) {
     container.setVisible(isVisible);
-  }
-
-  @Override
-  public void setCreatedHelpWidgetVisible(boolean visible) {
-    createdHelpWidget.setVisible(visible);
-  }
-
-  @Override
-  public void setCreatedHelpWidgetText(String text) {
-    createdHelpWidget.setHelpMarkdown(text);
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
@@ -367,13 +367,7 @@ public abstract class AbstractTablesTab
       updateVersionAndAreaToken(entity.getId(), version, areaToken);
       breadcrumb.configure(bundle.getPath(), getTabArea());
       titleBar.configure(bundle, tab.getEntityActionMenu());
-      modifiedCreatedBy.configure(
-        entity.getCreatedOn(),
-        entity.getCreatedBy(),
-        entity.getModifiedOn(),
-        entity.getModifiedBy()
-      );
-      configureCreatedByHelpWidget();
+      modifiedCreatedBy.configure(entity.getId(), version);
       tableEntityWidget = ginInjector.createNewTableEntityWidgetV2();
       view.setTableEntityWidget(tableEntityWidget.asWidget());
       boolean isShowTableOnly = false;
@@ -524,13 +518,6 @@ public abstract class AbstractTablesTab
     this.view.setVersionAlertPrimaryText(
         (versionHistoryIsVisible ? "Hide" : "Show") + " Version History"
       );
-  }
-
-  private void configureCreatedByHelpWidget() {
-    modifiedCreatedBy.setCreatedHelpWidgetVisible(
-      entityBundle.getEntity() instanceof Dataset
-    );
-    modifiedCreatedBy.setCreatedHelpWidgetText(DATASET_CREATED_BY_HELP_TEXT);
   }
 
   private FluentFuture<Long> getLatestSnapshotVersionNumber() {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
@@ -313,12 +313,7 @@ public class FilesTab {
       }
     }
     // Created By and Modified By
-    modifiedCreatedBy.configure(
-      currentEntity.getCreatedOn(),
-      currentEntity.getCreatedBy(),
-      currentEntity.getModifiedOn(),
-      currentEntity.getModifiedBy()
-    );
+    modifiedCreatedBy.configure(currentEntity.getId(), versionNumber);
 
     // Wiki Page
     boolean isWikiPageVisible = !isProject;

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
@@ -67,13 +67,8 @@
             </g:FlowPanel>
           </b:Column>
         </b:Row>
-        <b:Row>
-          <g:SimplePanel
-            addStyleNames="margin-bottom-15 margin-left-15"
-            ui:field="dockerModifiedAndCreatedContainer"
-          />
-        </b:Row>
       </g:FlowPanel>
+      <g:SimplePanel ui:field="dockerModifiedAndCreatedContainer" />
     </b:Column>
     <g:SimplePanel ui:field="synapseAlertContainer" />
   </b:Row>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
@@ -27,9 +27,5 @@
       </g:FlowPanel>
     </bh:Div>
     <bh:Div ui:field="tabsUI" />
-    <bh:Div
-      addStyleNames="margin-top-10"
-      ui:field="addToDownloadListContainer"
-    />
   </g:HTMLPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.ui.xml
@@ -8,18 +8,5 @@
   xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
-  <bh:Div ui:field="container" visible="false">
-    <bh:Span ui:field="createdByUI">
-      <bh:Span text="Created by" />
-      <bh:Span ui:field="createdBadgePanel" />
-      <bh:Span ui:field="createdOnText" />
-      <w:HelpWidget ui:field="createdHelpWidget" visible="false" />
-    </bh:Span>
-    <bh:Br />
-    <bh:Span ui:field="modifiedByUI">
-      <bh:Span text="Modified by" />
-      <bh:Span ui:field="modifiedBadgePanel" />
-      <bh:Span ui:field="modifiedOnText" />
-    </bh:Span>
-  </bh:Div>
+  <w:ReactComponentDiv ui:field="container" visible="false" />
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
@@ -89,10 +89,7 @@
           </g:FlowPanel>
         </b:Column>
       </b:Row>
-      <g:SimplePanel
-        addStyleNames="padding-bottom-15"
-        ui:field="fileModifiedAndCreatedContainer"
-      />
     </bh:Div>
+    <g:SimplePanel ui:field="fileModifiedAndCreatedContainer" />
   </g:FlowPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
@@ -56,10 +56,6 @@
           addStyleNames="margin-top-15"
           ui:field="tableWidgetContainer"
         />
-        <g:SimplePanel
-          addStyleNames="padding-bottom-15"
-          ui:field="tableModifiedAndCreatedContainer"
-        />
         <b:Row>
           <b:Column size="XS_12" ui:field="provenanceContainer">
             <g:FlowPanel
@@ -80,5 +76,6 @@
         </b:Row>
       </g:FlowPanel>
     </bh:Div>
+    <g:SimplePanel ui:field="tableModifiedAndCreatedContainer" />
   </g:FlowPanel>
 </ui:UiBinder>

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -52,7 +52,12 @@ $synapse-tertiary-color-palette: (
   900: #2f2814,
 );
 
-$full-root-panel-height: calc(100vh - 93px - 130px);
+$page-header-min-height: 93px;
+$footer-height: 160px;
+
+$full-root-panel-height: calc(
+  100vh - #{$page-header-min-height} - #{$footer-height}
+);
 
 @mixin border-radius($radius) {
   -webkit-border-radius: $radius;
@@ -195,7 +200,7 @@ a:focus {
   }
   #rootPanel .pageHeader {
     padding: 24px $entity-page-side-spacing;
-    min-height: 93px;
+    min-height: $page-header-min-height;
     @include synapse-blue-triangles-bg;
     h3.pageHeaderTitle {
       color: white;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
@@ -138,8 +138,7 @@ public class DockerRepoWidgetTest {
     verify(mockView).setDockerPullCommand(DOCKER_PULL_COMMAND + repoName);
     verify(mockMetadata).configure(mockEntityBundle, null, mockActionWidget);
     verify(mockDockerTitleBar).configure(mockEntityBundle, mockActionWidget);
-    verify(mockModifiedCreatedBy)
-      .configure(createdOn, createdBy, modifiedOn, modifiedBy);
+    verify(mockModifiedCreatedBy).configure(entityId, null);
     verify(mockDockerCommitListWidget).configure(entityId, false);
     verify(mockView).setProvenanceWidgetVisible(false);
   }
@@ -161,7 +160,6 @@ public class DockerRepoWidgetTest {
     verify(mockView).setDockerPullCommand(DOCKER_PULL_COMMAND + repoName);
     verify(mockMetadata).configure(mockEntityBundle, null, mockActionWidget);
     verify(mockDockerTitleBar).configure(mockEntityBundle, mockActionWidget);
-    verify(mockModifiedCreatedBy)
-      .configure(createdOn, createdBy, modifiedOn, modifiedBy);
+    verify(mockModifiedCreatedBy).configure(entityId, null);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ModifiedCreatedByWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ModifiedCreatedByWidgetTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.web.client.DateTimeUtils;
+import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
 import org.sagebionetworks.web.client.widget.entity.ModifiedCreatedByWidget;
 import org.sagebionetworks.web.client.widget.entity.ModifiedCreatedByWidgetView;
 import org.sagebionetworks.web.client.widget.user.UserBadge;
@@ -19,41 +20,22 @@ public class ModifiedCreatedByWidgetTest {
   @Mock
   ModifiedCreatedByWidgetView mockView;
 
-  @Mock
-  UserBadge mockCreatedByBadge;
-
-  @Mock
-  UserBadge mockModifiedByBadge;
-
-  @Mock
-  DateTimeUtils mockDateTimeUtils;
-
   ModifiedCreatedByWidget presenter;
+
+  String entityId = "syn123";
+  Long versionNumber = 1L;
 
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    presenter =
-      new ModifiedCreatedByWidget(
-        mockView,
-        mockCreatedByBadge,
-        mockModifiedByBadge,
-        mockDateTimeUtils
-      );
+    presenter = new ModifiedCreatedByWidget(mockView);
   }
 
   @Test
   public void testConfigure() {
-    Date date = new Date();
-    String formattedDate = "a day";
-    when(mockDateTimeUtils.getLongFriendlyDate(any(Date.class)))
-      .thenReturn(formattedDate);
-    presenter.configure(date, "createdBy", date, "modifiedBy");
-    verify(mockCreatedByBadge).configure("createdBy");
-    verify(mockModifiedByBadge).configure("modifiedBy");
+    presenter.configure(entityId, versionNumber);
 
+    verify(mockView).setProps(any(CreatedByModifiedByProps.class));
     verify(mockView).setVisible(true);
-    verify(mockView).setCreatedOnText(" on " + formattedDate);
-    verify(mockView).setModifiedOnText(" on " + formattedDate);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -297,9 +298,7 @@ public class DatasetsTabTest {
         mockActionMenuWidget
       );
     verify(mockView).setTableEntityWidget(any(Widget.class));
-    verify(mockModifiedCreatedBy)
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
-    verify(mockModifiedCreatedBy).setCreatedHelpWidgetVisible(true);
+    verify(mockModifiedCreatedBy).configure(datasetId, version);
     verify(mockProvenanceWidget).configure(mapCaptor.capture());
     // verify configuration
     Map<String, String> provConfig = mapCaptor.getValue();
@@ -347,9 +346,7 @@ public class DatasetsTabTest {
     tab.setProject(projectEntityId, mockProjectEntityBundle, null);
     tab.configure(mockProjectEntityBundle, version, areaToken);
 
-    verify(mockModifiedCreatedBy, never())
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
-    verify(mockModifiedCreatedBy, never()).setCreatedHelpWidgetVisible(true);
+    verify(mockModifiedCreatedBy, never()).configure(anyString(), anyLong());
 
     verify(mockView).setEntityMetadataVisible(false);
     verify(mockView).setBreadcrumbVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
@@ -299,8 +299,7 @@ public class FilesTabTest {
     // show project info
     verify(mockView, times(2)).setProvenanceVisible(false);
     verify(mockView).clearRefreshAlert();
-    verify(mockModifiedCreatedBy)
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
+    verify(mockModifiedCreatedBy).configure(projectEntityId, version);
     verify(mockView).setFileBrowserVisible(true);
     verify(mockFilesBrowser).configure(projectEntityId);
     verify(mockFilesBrowser)
@@ -366,8 +365,7 @@ public class FilesTabTest {
       .configure(any(EntityPath.class), eq(EntityArea.FILES));
 
     verify(mockView).setProvenanceVisible(true);
-    verify(mockModifiedCreatedBy)
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
+    verify(mockModifiedCreatedBy).configure(fileEntityId, version);
     verify(mockView).setWikiPageWidgetVisible(true);
 
     verify(mockView, times(2)).setFileBrowserVisible(false);
@@ -424,8 +422,7 @@ public class FilesTabTest {
       .configure(any(EntityPath.class), eq(EntityArea.FILES));
 
     verify(mockView, times(2)).setProvenanceVisible(false);
-    verify(mockModifiedCreatedBy)
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
+    verify(mockModifiedCreatedBy).configure(folderEntityId, null);
     verify(mockView).setWikiPageWidgetVisible(true);
 
     verify(mockView).setFileBrowserVisible(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -318,9 +319,7 @@ public class TablesTabTest {
         mockActionMenuWidget
       );
     verify(mockView).setTableEntityWidget(any(Widget.class));
-    verify(mockModifiedCreatedBy)
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
-    verify(mockModifiedCreatedBy, never()).setCreatedHelpWidgetVisible(true);
+    verify(mockModifiedCreatedBy).configure(tableEntityId, version);
     verify(mockProvenanceWidget).configure(mapCaptor.capture());
     // verify configuration
     Map<String, String> provConfig = mapCaptor.getValue();
@@ -370,7 +369,7 @@ public class TablesTabTest {
     tab.setProject(projectEntityId, mockProjectEntityBundle, null);
     tab.configure(mockProjectEntityBundle, version, areaToken);
     verify(mockModifiedCreatedBy, Mockito.never())
-      .configure(any(Date.class), anyString(), any(Date.class), anyString());
+      .configure(anyString(), anyLong());
     verify(mockView).setEntityMetadataVisible(false);
     verify(mockView).setBreadcrumbVisible(false);
     verify(mockView).setTableListVisible(true);


### PR DESCRIPTION
- Use new CreatedByModifiedBy component from SRC for ModifiedByCreatedByWidget
- Change `configure` method on ModifiedCreatedByWidget to accomodate props
- SCSS: Use variables and account for changed footer height in determining rootPanel height
- Move ModifiedByCreatedByWidget location to be flush with footer
- Remove unused `addToDownloadListContainer` field