### PR TITLE
SWC-6377: Fix case where the profile is not loaded when initially signing terms of use

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -103,7 +103,6 @@ public class AuthenticationControllerImpl implements AuthenticationController {
           public void onSuccess(LoginResponse response) {
             storeAuthenticationReceipt(response.getAuthenticationReceipt());
             setNewAccessToken(response.getAccessToken(), callback);
-            clearQueryClientCache();
           }
 
           @Override
@@ -198,6 +197,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
             DateTimeUtilsImpl.getWeekFromNow()
           );
           currentUserAccessToken = accessToken;
+          clearQueryClientCache();
           userAccountService.getMyProfile(
             new AsyncCallback<UserProfile>() {
               @Override
@@ -236,6 +236,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
         public void onFailure(Throwable t) {
           currentUserAccessToken = null;
           currentUserProfile = null;
+          clearQueryClientCache();
           ginInjector.getSessionDetector().initializeAccessTokenState();
           callback.onFailure(t);
         }
@@ -388,7 +389,6 @@ public class AuthenticationControllerImpl implements AuthenticationController {
               ginInjector.getGlobalApplicationState().refreshPage();
             }
             checkForQuarantinedEmail();
-            clearQueryClientCache();
           } else {
             ginInjector.getHeader().refresh();
             // we've determined that the session has not changed

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -283,6 +283,7 @@ public class AuthenticationControllerImplTest {
 
     assertNull(authenticationController.getCurrentUserProfile());
     verify(mockSessionDetector).initializeAccessTokenState();
+    verify(mockQueryClient).clear();
     verify(mockPlaceChanger).goTo(placeCaptor.capture());
     Place place = placeCaptor.getValue();
     assertTrue(place instanceof LoginPlace);
@@ -316,6 +317,7 @@ public class AuthenticationControllerImplTest {
     );
     verify(mockJsClient, never())
       .initSession(anyString(), any(AsyncCallback.class));
+    verify(mockQueryClient).clear();
     Exception scEx = new StatusCodeException(0, "0 ");
     when(mockJsClient.getAccessToken()).thenReturn(getFailedFuture(scEx));
 


### PR DESCRIPTION
- Call clearQueryClientCache when the accessToken changes
- Remove redundant calls