### PR TITLE
SWC-6398 - fix cache issue leading to unusual bugs and excessive refetching

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/reactquery/QueryClient.java
@@ -9,6 +9,11 @@ public class QueryClient {
   public QueryClient(QueryClientOptions config) {}
 
   /**
+   * Removes all cached query data and triggers a refetch.
+   */
+  public native void resetQueries();
+
+  /**
    * Removes the cached query data and triggers a refetch.
    * @param queryKey
    */
@@ -19,6 +24,4 @@ public class QueryClient {
    * @param queryKey
    */
   public native void invalidateQueries(List<?> queryKey);
-
-  public native void clear();
 }

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -61,8 +61,8 @@ public class AuthenticationControllerImpl implements AuthenticationController {
     NIH_NOTIFICATION_DISMISSED,
     COOKIES_ACCEPTED,
   };
-  private static String currentUserAccessToken;
-  private static UserProfile currentUserProfile;
+  private String currentUserAccessToken;
+  private UserProfile currentUserProfile;
   private UserAccountServiceAsync userAccountService;
   private ClientCache localStorage;
   private SessionStorage sessionStorage;
@@ -91,8 +91,8 @@ public class AuthenticationControllerImpl implements AuthenticationController {
     this.queryClient = queryClientProvider.getQueryClient();
   }
 
-  public void clearQueryClientCache() {
-    queryClient.clear();
+  public void resetQueryClientCache() {
+    queryClient.resetQueries();
   }
 
   @Override
@@ -202,8 +202,10 @@ public class AuthenticationControllerImpl implements AuthenticationController {
       new FutureCallback<String>() {
         @Override
         public void onSuccess(String accessToken) {
-          currentUserAccessToken = accessToken;
-          clearQueryClientCache();
+          if (!Objects.equals(currentUserAccessToken, accessToken)) {
+            resetQueryClientCache();
+            currentUserAccessToken = accessToken;
+          }
           userAccountService.getMyProfile(
             new AsyncCallback<UserProfile>() {
               @Override
@@ -242,7 +244,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
         public void onFailure(Throwable t) {
           currentUserAccessToken = null;
           currentUserProfile = null;
-          clearQueryClientCache();
+          resetQueryClientCache();
           ginInjector.getSessionDetector().initializeAccessTokenState();
           callback.onFailure(t);
         }
@@ -327,7 +329,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
           }
 
           private void afterCall() {
-            clearQueryClientCache();
+            resetQueryClientCache();
             ginInjector.getGlobalApplicationState().refreshPage();
           }
         }


### PR DESCRIPTION
Targeting release-442, which is currently staging

- Use `resetQueries` instead of `clearQueries`. `clearQueries` removes subscribers, which is what I suspect caused the unusual state bug in SWC-6398
- don't reset the query cache when the access token doesn't change
- change `AuthenticationControllerImpl.currentUserAccessToken` and `AuthenticationControllerImpl.currentUserProfile` to non-static, which was causing issues in tests. AuthenticationControllerImpl is a singleton, so this should not cause new issues.