### PR TITLE
IT-2094: Add prod.adknowledgeportal to CORS

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
@@ -36,6 +36,7 @@ public class CORSFilter extends OncePerRequestFilter {
     // Data portals
     "adknowledgeportal",
     "staging.adknowledgeportal",
+    "prod.adknowledgeportal",
     "alzdrugtool",
     "staging.alzdrugtool",
     "arkportal",


### PR DESCRIPTION
This PR adds the internal prod.adknowledgeportal endpoint to the CORS list. To be used for testing the deploy before pointing adknowledgeportal.synapse.org to it.