### PR TITLE
SWC-6414

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/oauth2/OAuth2Servlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/oauth2/OAuth2Servlet.java
@@ -34,6 +34,13 @@ public abstract class OAuth2Servlet extends HttpServlet {
       OAuth2Servlet.perThreadRequest.get()
     );
 
+  @Override
+  protected void service(HttpServletRequest arg0, HttpServletResponse arg1)
+    throws ServletException, IOException {
+    OAuth2Servlet.perThreadRequest.set(arg0);
+    super.service(arg0, arg1);
+  }
+
   /**
    * Injected
    *


### PR DESCRIPTION
Fix case where the ThreadLocal was not stored in perThreadRequest. This caused us not to be able to resolve the hostname in OAuth2Servlet and OAuth2SessionServlet, so all requests ended up going to production Synapse.