### PR TITLE
SWC-6451

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClient.java
@@ -327,4 +327,7 @@ public interface SynapseClient extends RemoteService {
     String membershipInvitationId,
     String hostPageBaseURL
   ) throws RestServiceException;
+
+  String getDatasetScriptElementContent(String entityId)
+    throws RestServiceException;
 }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseClientAsync.java
@@ -438,4 +438,9 @@ public interface SynapseClientAsync {
     char delimiter,
     AsyncCallback<ArrayList<String[]>> callback
   );
+
+  void getDatasetScriptElementContent(
+    String entityId,
+    AsyncCallback<String> callback
+  );
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/TableEntityWidgetV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/TableEntityWidgetV2.java
@@ -236,6 +236,7 @@ public class TableEntityWidgetV2
     this.entityTypeDisplay =
       EntityTypeUtils.getFriendlyEntityTypeName(bundle.getEntity());
     this.isShowTableOnly = isShowTableOnly;
+    injectJsonLdIfDataset();
     reconfigureState();
     showEditorIfEditableAndEmpty();
   }
@@ -243,6 +244,27 @@ public class TableEntityWidgetV2
   private void reconfigureState() {
     initializeQuery();
     configureActions();
+  }
+
+  public void injectJsonLdIfDataset() {
+    if (TableType.dataset == tableType) {
+      synapseClient.getDatasetScriptElementContent(
+        entityBundle.getEntity().getId(),
+        new AsyncCallback<String>() {
+          @Override
+          public void onFailure(Throwable caught) {
+            view.showErrorMessage(caught.getMessage());
+          }
+
+          @Override
+          public void onSuccess(String jsonLd) {
+            view.injectDatasetJsonLd(jsonLd);
+          }
+        }
+      );
+    } else {
+      view.removeDatasetJsonLdElement();
+    }
   }
 
   /**

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetView.java
@@ -97,4 +97,6 @@ public interface TableEntityWidgetView extends IsWidget {
   void configureTableOnly(String sql);
 
   void setQueryWrapperPlotNavVisible(boolean visible);
+  void injectDatasetJsonLd(String elementContent);
+  void removeDatasetJsonLdElement();
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
@@ -1,5 +1,9 @@
 package org.sagebionetworks.web.client.widget.table.v2;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.ScriptElement;
+import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Button;
@@ -81,6 +85,7 @@ public class TableEntityWidgetViewImpl
   SubmissionViewScopeWidget submissionViewScopeWidget;
   TableEntityWidgetView.Presenter presenter;
   SynapseReactClientFullContextPropsProvider propsProvider;
+  ScriptElement datasetScriptElement;
 
   @Inject
   public TableEntityWidgetViewImpl(
@@ -104,6 +109,16 @@ public class TableEntityWidgetViewImpl
     );
     scopeCollapseCloseButton.addClickHandler(event ->
       this.presenter.toggleScopeCollapse()
+    );
+    addAttachHandler(
+      new AttachEvent.Handler() {
+        @Override
+        public void onAttachOrDetach(AttachEvent event) {
+          if (!event.isAttached()) {
+            removeDatasetJsonLdElement();
+          }
+        }
+      }
     );
   }
 
@@ -231,5 +246,24 @@ public class TableEntityWidgetViewImpl
   @Override
   public void setQueryWrapperPlotNavVisible(boolean visible) {
     plotNavContainer.setVisible(visible);
+  }
+
+  @Override
+  public void removeDatasetJsonLdElement() {
+    if (datasetScriptElement != null) {
+      Element head = Document.get().getElementsByTagName("head").getItem(0);
+      head.removeChild(datasetScriptElement);
+      datasetScriptElement = null;
+    }
+  }
+
+  @Override
+  public void injectDatasetJsonLd(String elementContent) {
+    removeDatasetJsonLdElement();
+    Element head = Document.get().getElementsByTagName("head").getItem(0);
+    datasetScriptElement = Document.get().createScriptElement();
+    datasetScriptElement.setType("application/ld+json");
+    datasetScriptElement.setInnerText(elementContent);
+    head.appendChild(datasetScriptElement);
   }
 }

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientImpl.java
@@ -102,6 +102,7 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.schema.adapter.org.json.AdapterFactoryImpl;
 import org.sagebionetworks.util.SerializationUtils;
 import org.sagebionetworks.web.client.SynapseClient;
+import org.sagebionetworks.web.server.servlet.filter.CrawlFilter;
 import org.sagebionetworks.web.shared.MembershipRequestBundle;
 import org.sagebionetworks.web.shared.OpenTeamInvitationBundle;
 import org.sagebionetworks.web.shared.OpenUserInvitationBundle;
@@ -2108,5 +2109,23 @@ public class SynapseClientImpl
       throw ExceptionUtil.convertSynapseException(e);
     }
     return results;
+  }
+
+  @Override
+  public String getDatasetScriptElementContent(String entityId)
+    throws RestServiceException {
+    String plainTextWiki = CrawlFilter.getPlainTextWiki(entityId, this);
+    EntityBundleRequest bundleRequest = new EntityBundleRequest();
+    bundleRequest.setIncludeEntity(true);
+    bundleRequest.setIncludeAnnotations(true);
+    EntityBundle entityBundle = getEntityBundle(entityId, bundleRequest);
+    try {
+      return CrawlFilter.getDatasetScriptElementContent(
+        entityBundle,
+        plainTextWiki
+      );
+    } catch (Exception e) {
+      throw ExceptionUtil.convertSynapseException(e);
+    }
   }
 }

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/CrawlFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/CrawlFilter.java
@@ -99,16 +99,16 @@ public class CrawlFilter extends OncePerRequestFilter {
   public static final int MAX_CHILD_PAGES = 5;
 
   // Markdown processor
-  Parser parser = Parser.builder().build();
-  String synapseWikiWidgetDefinitionRegex = "[$][{].*[}]";
-  Pattern wikiWidgetPattern = Pattern.compile(
+  private static Parser parser = Parser.builder().build();
+  private static String synapseWikiWidgetDefinitionRegex = "[$][{].*[}]";
+  private static Pattern wikiWidgetPattern = Pattern.compile(
     synapseWikiWidgetDefinitionRegex,
     Pattern.CASE_INSENSITIVE
   );
 
-  DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+  private static DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
 
-  private String removeSynapseWikiWidgets(String markdown) {
+  private static String removeSynapseWikiWidgets(String markdown) {
     return wikiWidgetPattern.matcher(markdown).replaceAll("");
   }
 
@@ -337,6 +337,31 @@ public class CrawlFilter extends OncePerRequestFilter {
     return displayNameBuilder.toString();
   }
 
+  public static String getPlainTextWiki(
+    String entityId,
+    SynapseClientImpl synapseClient
+  ) {
+    String plainTextWiki = null;
+    try {
+      WikiPage rootPage = synapseClient.getV2WikiPageAsV1(
+        new WikiPageKey(entityId, ObjectType.ENTITY.toString(), null)
+      );
+      String markdown = escapeHtml(rootPage.getMarkdown());
+      if (markdown != null) {
+        try {
+          Node document = parser.parse(removeSynapseWikiWidgets(markdown));
+          HtmlRenderer renderer = HtmlRenderer.builder().build();
+          String wikiHtml = renderer.render(document);
+          // extract plain text from wiki html
+          plainTextWiki = Jsoup.parse(wikiHtml).text();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    } catch (Exception e) {}
+    return plainTextWiki;
+  }
+
   private String getEntityHtml(String entityId)
     throws RestServiceException, JSONObjectAdapterException {
     EntityBundleRequest bundleRequest = new EntityBundleRequest();
@@ -371,28 +396,11 @@ public class CrawlFilter extends OncePerRequestFilter {
     String name = escapeHtml(entity.getName());
     String description = escapeHtml(entity.getDescription());
     String createdBy = null;
-    String plainTextWiki = null;
 
     try {
       createdBy = getCreatedByString(entity.getCreatedBy());
     } catch (Exception e) {}
-    try {
-      WikiPage rootPage = synapseClient.getV2WikiPageAsV1(
-        new WikiPageKey(entity.getId(), ObjectType.ENTITY.toString(), null)
-      );
-      String markdown = escapeHtml(rootPage.getMarkdown());
-      if (markdown != null) {
-        try {
-          Node document = parser.parse(removeSynapseWikiWidgets(markdown));
-          HtmlRenderer renderer = HtmlRenderer.builder().build();
-          String wikiHtml = renderer.render(document);
-          // extract plain text from wiki html
-          plainTextWiki = Jsoup.parse(wikiHtml).text();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    } catch (Exception e) {}
+    String plainTextWiki = getPlainTextWiki(entity.getId(), synapseClient);
 
     StringBuilder html = new StringBuilder();
 
@@ -486,10 +494,21 @@ public class CrawlFilter extends OncePerRequestFilter {
     return html.toString();
   }
 
-  public String getDatasetScriptElement(
+  private String getDatasetScriptElement(
     EntityBundle bundle,
     String plainTextWiki
-  ) throws JSONObjectAdapterException, RestServiceException {
+  ) throws JSONObjectAdapterException {
+    StringBuilder html = new StringBuilder();
+    html.append("<script type=\"application/ld+json\">");
+    html.append(getDatasetScriptElementContent(bundle, plainTextWiki));
+    html.append("\"</script>\"");
+    return html.toString();
+  }
+
+  public static String getDatasetScriptElementContent(
+    EntityBundle bundle,
+    String plainTextWiki
+  ) throws JSONObjectAdapterException {
     StringBuilder html = new StringBuilder();
     if (bundle.getEntity() instanceof Dataset) {
       Dataset ds = (Dataset) bundle.getEntity();

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/CrawlFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/CrawlFilter.java
@@ -512,7 +512,6 @@ public class CrawlFilter extends OncePerRequestFilter {
     StringBuilder html = new StringBuilder();
     if (bundle.getEntity() instanceof Dataset) {
       Dataset ds = (Dataset) bundle.getEntity();
-      html.append("<script type=\"application/ld+json\">");
       JSONObjectAdapter json = new JSONObjectAdapterImpl();
       json.put("@context", "http://schema.org/");
       json.put("@type", "Dataset");
@@ -574,7 +573,6 @@ public class CrawlFilter extends OncePerRequestFilter {
       //      json.put("creator", object);
 
       html.append(json.toJSONString());
-      html.append("</script>");
     }
     return html.toString();
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/explore/TableEntityWidgetV2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/explore/TableEntityWidgetV2Test.java
@@ -132,6 +132,8 @@ public class TableEntityWidgetV2Test {
     "select * from syn123 where \"x\" = 'a'";
   public static final String EXPECTED_SQL_FOR_CLIENT =
     "select * from syn123 where \\\"x\\\" = 'a'";
+  public static final String DATASET_JSON_LD =
+    "{\"@context\":\"http://schema.org/\",\"@type\":\"Dataset\",\"name\":\"yet another ds\",\"description\":\"\",\"url\":\"https://www.synapse.org/#!Synapse:syn33748233.2\",\"version\":2,\"keywords\":[],\"includedInDataCatalog\":{\"@type\":\"DataCatalog\",\"name\":\"Synapse\",\"url\":\"https://www.synapse.org\"},\"isAccessibleForFree\":true,\"dateModified\":\"2022-08-26T21:47Z\"}";
 
   @Mock
   FileViewClientsHelp mockFileViewClientsHelp;
@@ -227,6 +229,10 @@ public class TableEntityWidgetV2Test {
     when(mockQueryChangeHandler.getQueryString()).thenReturn(query);
     Header.isShowingPortalAlert = false;
     Header.portalAlertJson = null;
+    AsyncMockStubber
+      .callSuccessWith(DATASET_JSON_LD)
+      .when(mockSynapseClient)
+      .getDatasetScriptElementContent(anyString(), any(AsyncCallback.class));
   }
 
   private void configureBundleWithView(ViewType viewType) {
@@ -1004,5 +1010,34 @@ public class TableEntityWidgetV2Test {
     verify(mockView).setItemsEditorVisible(false);
     verify(mockActionMenu)
       .setActionVisible(Action.EDIT_ENTITYREF_COLLECTION_ITEMS, true);
+  }
+
+  @Test
+  public void testInjectJsonLdIfDataset() {
+    configureBundleWithDataset();
+    widget.configure(
+      entityBundle,
+      versionNumber,
+      true,
+      false,
+      mockQueryChangeHandler,
+      mockActionMenu
+    );
+
+    verify(mockView).injectDatasetJsonLd(DATASET_JSON_LD);
+  }
+
+  @Test
+  public void testInjectJsonLdIfDatasetNotDataset() {
+    widget.configure(
+      entityBundle,
+      versionNumber,
+      true,
+      false,
+      mockQueryChangeHandler,
+      mockActionMenu
+    );
+
+    verify(mockView).removeDatasetJsonLdElement();
   }
 }


### PR DESCRIPTION
- Refactor CrawlFilter to reuse dataset json-ld content
- Expose dataset json-ld content via a new servlet call
- Inject script element into HEAD element if entity is a Dataset
- Remove element on detach (or when it is reconfigured)