### PR TITLE
SWC-6462 - fix 'clear download cart' button color

### DIFF
--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -243,8 +243,9 @@ a:focus {
 
   #rootPanel .DownloadCartPage {
     padding: 0px 0px 50px 0px;
-    .clearDownloadListLink {
+    .pageHeader button {
       color: white;
+      text-decoration-color: white;
     }
   }
 }


### PR DESCRIPTION
To merge into release-456 (staging)

Style was probably lost when it changed from a link to a MUI button