### PR TITLE
PORTALS-2688: quick accessibility fix for the Files tab after Lighthouse test

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityTree.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityTree.java
@@ -1,11 +1,17 @@
 package org.sagebionetworks.web.client.widget.entity.browse;
 
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Tree;
 
 public class EntityTree extends Tree {
 
   public EntityTree(Resources resources) {
     super(resources);
+    Roles.getTreeRole().set(getElement());
+    Element treeElement = getElement();
+    Element treeContentElem = treeElement.getFirstChildElement();
+    treeContentElem.removeAttribute("role");
   }
 
   @Override


### PR DESCRIPTION
Before:
<img width="1247" alt="Screen Shot 2023-06-08 at 10 59 29 AM" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/1864447/845118b1-100d-4688-bf20-b6fb9f5c697b">

After:
<img width="1252" alt="Screen Shot 2023-06-08 at 10 59 51 AM" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/1864447/cbaeb103-6107-468d-9af0-139c0f64bfa1">
