### PR TITLE
SWC-6377

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/LoginPresenter.java
@@ -80,6 +80,8 @@ public class LoginPresenter
         public void onSuccess(Void result) {
           // Have to get the UserSessionData again,
           // since it won't contain the UserProfile if the terms haven't been signed
+          // We also need to force-reset the QueryClient so the React components know to refetch
+          boolean forceResetQueryClient = true;
           synAlert.clear();
           authenticationController.initializeFromExistingAccessTokenCookie(
             new AsyncCallback<UserProfile>() {
@@ -94,7 +96,8 @@ public class LoginPresenter
                 // Signed ToU. Check for temp username, passing record, and then forward
                 userAuthenticated();
               }
-            }
+            },
+            forceResetQueryClient
           );
         }
       }

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationController.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationController.java
@@ -37,6 +37,11 @@ public interface AuthenticationController {
     final AsyncCallback<UserProfile> callback
   );
 
+  void initializeFromExistingAccessTokenCookie(
+    final AsyncCallback<UserProfile> callback,
+    boolean forceResetQueryClient
+  );
+
   /**
    * Terminates the session of the current user
    */

--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -5,6 +5,7 @@ import static org.sagebionetworks.web.client.ServiceEntryPointUtils.fixServiceEn
 
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.place.shared.Place;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.rpc.StatusCodeException;
@@ -193,6 +194,18 @@ public class AuthenticationControllerImpl implements AuthenticationController {
   public void initializeFromExistingAccessTokenCookie(
     AsyncCallback<UserProfile> callback
   ) {
+    initializeFromExistingAccessTokenCookie(callback, false);
+  }
+
+  /**
+   * Access token cookie should be set before this call
+   *
+   * @param callback
+   */
+  public void initializeFromExistingAccessTokenCookie(
+    AsyncCallback<UserProfile> callback,
+    boolean forceResetQueryClientCache
+  ) {
     // attempt to detect the current access token.  if found, get the associated user profile.  if forbidden (due to ToU), send to ToU page.
     FluentFuture<String> accessTokenFuture = ginInjector
       .getSynapseJavascriptClient()
@@ -204,6 +217,8 @@ public class AuthenticationControllerImpl implements AuthenticationController {
           if (!Objects.equals(currentUserAccessToken, accessToken)) {
             resetQueryClientCache();
             currentUserAccessToken = accessToken;
+          } else if (forceResetQueryClientCache) {
+            resetQueryClientCache();
           }
           userAccountService.getMyProfile(
             new AsyncCallback<UserProfile>() {

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -391,6 +391,25 @@ public class AuthenticationControllerImplTest {
   }
 
   @Test
+  public void testInitializeFromExistingAccessTokenCookieSameTokenForceQueryClientReset() {
+    verify(mockQueryClient, never()).resetQueries();
+
+    // invoke the method twice, verify that the queryclient is cleared the second time when we force it
+    authenticationController.initializeFromExistingAccessTokenCookie(
+      mockUserProfileCallback
+    );
+
+    verify(mockQueryClient, times(1)).resetQueries();
+
+    authenticationController.initializeFromExistingAccessTokenCookie(
+      mockUserProfileCallback,
+      true
+    );
+
+    verify(mockQueryClient, times(2)).resetQueries();
+  }
+
+  @Test
   public void testCheckForQuarantinedEmailNullStatus() {
     when(mockNotificationEmail.getQuarantineStatus()).thenReturn(null);
 


### PR DESCRIPTION
Fix SWC-6377, where the NavBar was not visible after registering and signing the terms of use. Root cause was the QueryClient was not reset after signing the ToU.