### PR TITLE
SWC-6530

### DIFF
--- a/.github/workflows/build-test-e2e.yml
+++ b/.github/workflows/build-test-e2e.yml
@@ -37,8 +37,7 @@ jobs:
         run: yarn playwright install --with-deps chromium
       - name: Run Playwright tests
         env:
-          ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
-          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+          ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
         run: yarn playwright test
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v3

--- a/e2e/auth.cleanup.ts
+++ b/e2e/auth.cleanup.ts
@@ -1,54 +1,41 @@
-import { Page, test as cleanup, expect } from '@playwright/test'
-import { ADMIN_STORAGE_STATE, USER_STORAGE_STATE } from '../playwright.config'
-import { getEndpoint } from './helpers/http'
+import { Page, test as cleanup } from '@playwright/test'
 import {
-  deleteTestUser,
-  getAdminPAT,
+  cleanupTestUser,
   getUserIdFromLocalStorage,
   goToDashboard,
   logoutTestUser,
 } from './helpers/testUser'
+import { userConfigs } from './helpers/userConfig'
 
-let adminPage: Page
-let userPage: Page
+for (const { testName, storageStatePath, user } of userConfigs) {
+  let userPage: Page
 
-cleanup.describe('Clean up', () => {
-  cleanup.beforeAll(async ({ browser }) => {
-    adminPage = await browser.newPage({
-      storageState: ADMIN_STORAGE_STATE,
-    })
-    userPage = await browser.newPage({
-      storageState: USER_STORAGE_STATE,
-    })
-  })
-
-  cleanup('clean up users', async () => {
-    const { testUserId } = await cleanup.step('get credentials', async () => {
-      const testUserId = await getUserIdFromLocalStorage(userPage)
-
-      return { testUserId }
+  cleanup.describe(`Clean up: ${testName}`, () => {
+    cleanup.beforeAll(async ({ browser }) => {
+      userPage = await browser.newPage({
+        storageState: storageStatePath,
+      })
     })
 
-    await cleanup.step('logout users', async () => {
-      await goToDashboard(userPage)
-      await logoutTestUser(userPage)
+    cleanup('clean up user', async () => {
+      const { testUserId } = await cleanup.step('get credentials', async () => {
+        const testUserId = await getUserIdFromLocalStorage(userPage)
 
-      await goToDashboard(adminPage)
-      await logoutTestUser(adminPage)
+        return { testUserId }
+      })
+
+      await cleanup.step('logout user', async () => {
+        await goToDashboard(userPage)
+        await logoutTestUser(userPage)
+      })
+
+      await cleanup.step('clean up user', async () => {
+        await cleanupTestUser(testUserId, userPage)
+      })
     })
 
-    await cleanup.step('delete test user', async () => {
-      const result = await deleteTestUser(
-        getEndpoint(),
-        testUserId!,
-        getAdminPAT(),
-      )
-      expect(result).toEqual(testUserId)
+    cleanup.afterAll(async () => {
+      await userPage.close()
     })
   })
-
-  cleanup.afterAll(async () => {
-    await adminPage.close()
-    await userPage.close()
-  })
-})
+}

--- a/e2e/auth.cleanup.ts
+++ b/e2e/auth.cleanup.ts
@@ -3,7 +3,7 @@ import { ADMIN_STORAGE_STATE, USER_STORAGE_STATE } from '../playwright.config'
 import { getEndpoint } from './helpers/http'
 import {
   deleteTestUser,
-  getAccessTokenFromCookie,
+  getAdminPAT,
   getUserIdFromLocalStorage,
   goToDashboard,
   logoutTestUser,
@@ -23,15 +23,11 @@ cleanup.describe('Clean up', () => {
   })
 
   cleanup('clean up users', async () => {
-    const { adminAccessToken, testUserId } = await cleanup.step(
-      'get credentials',
-      async () => {
-        const adminAccessToken = await getAccessTokenFromCookie(adminPage)
-        const testUserId = await getUserIdFromLocalStorage(userPage)
+    const { testUserId } = await cleanup.step('get credentials', async () => {
+      const testUserId = await getUserIdFromLocalStorage(userPage)
 
-        return { adminAccessToken, testUserId }
-      },
-    )
+      return { testUserId }
+    })
 
     await cleanup.step('logout users', async () => {
       await goToDashboard(userPage)
@@ -45,7 +41,7 @@ cleanup.describe('Clean up', () => {
       const result = await deleteTestUser(
         getEndpoint(),
         testUserId!,
-        adminAccessToken,
+        getAdminPAT(),
       )
       expect(result).toEqual(testUserId)
     })

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,110 +1,66 @@
 // Required environment variables:
-// - ADMIN_USERNAME: username for admin
-// - ADMIN_PASSWORD: password for admin
+// - ADMIN_PAT: personal access token for admin
 //
 // Environment variables:
 // - in CI: set in repo GitHub secrets, read via env in workflow
 // - locally: set in .env file, read by dotenv
 
 import { Page, expect, test as setup } from '@playwright/test'
-import { v4 as uuidv4 } from 'uuid'
-import { ADMIN_STORAGE_STATE, USER_STORAGE_STATE } from '../playwright.config'
 import { getEndpoint } from './helpers/http'
 import { setLocalStorage } from './helpers/localStorage'
 import {
-  USER_NAME_LOCALSTORAGE_KEY,
+  cleanupTestUser,
   createTestUser,
-  deleteTestUser,
   getAdminPAT,
-  getAdminUserCredentials,
   loginTestUser,
 } from './helpers/testUser'
-import { TestUser } from './helpers/types'
+import { userConfigs } from './helpers/userConfig'
 
-let testUserId: string | undefined
-let adminPage: Page
-let userPage: Page
+for (const {
+  testName,
+  storageStatePath,
+  localStorageKey,
+  user,
+} of userConfigs) {
+  let userId: string | undefined
+  let userPage: Page
 
-setup.describe('Setup', () => {
-  setup.beforeAll(async ({ browser }) => {
-    adminPage = await browser.newPage()
-    userPage = await browser.newPage()
-  })
-
-  setup('authenticate users', async () => {
-    // This may be the first test to run and trigger SWC compilation
-    // ...which may take 15+ seconds. Mark this test as slow,
-    // ...so the test will be given triple timeout.
-    // https://playwright.dev/docs/api/class-test#test-slow-1
-    setup.slow()
-
-    await setup.step('authenticate admin', async () => {
-      const { adminUserName, adminUserPassword } = getAdminUserCredentials()
-
-      await loginTestUser(adminPage, adminUserName!, adminUserPassword!)
-      await adminPage.context().storageState({ path: ADMIN_STORAGE_STATE })
+  setup.describe(`Setup: ${testName}`, () => {
+    setup.beforeAll(async ({ browser }) => {
+      userPage = await browser.newPage()
     })
 
-    const { testUserName, testUserPassword } = await setup.step(
-      'create test user',
-      async () => {
-        /* const testUserName = 'swc-e2e-' + uuidv4()
-        const testUserPassword = 'password-' + uuidv4() */
+    setup('create and authenticate user', async () => {
+      // This may be the first test to run and trigger SWC compilation
+      // ...which may take 15+ seconds. Mark this test as slow,
+      // ...so the test will be given triple timeout.
+      // https://playwright.dev/docs/api/class-test#test-slow-1
+      setup.slow()
 
-        const testUserName = 'swc-e2e-test'
-        const testUserPassword = process.env.USER_PASSWORD!
-        expect(testUserPassword).not.toBeUndefined()
+      await setup.step('create test user', async () => {
+        userId = await createTestUser(getEndpoint(), user, getAdminPAT())
+        expect(userId).not.toBeUndefined()
 
-        const testUserEmail = `${testUserName}@test.com`
-        const testUserIsValidated = false
+        await setLocalStorage(userPage, localStorageKey, user.username)
+        await userPage.context().storageState({ path: storageStatePath })
+      })
 
-        const testUser: TestUser = {
-          username: testUserName,
-          email: testUserEmail,
-          password: testUserPassword,
-          tou: true,
-          validatedUser: testUserIsValidated,
-        }
+      await setup.step('authenticate test user', async () => {
+        await loginTestUser(userPage, user.username, user.password)
+        await userPage.context().storageState({ path: storageStatePath })
+      })
+    })
 
-        testUserId = await createTestUser(
-          getEndpoint(),
-          testUser,
-          getAdminPAT(),
-        )
-        expect(testUserId).not.toBeUndefined()
+    setup.afterAll(async ({}, { expectedStatus, status }) => {
+      // delete test user if setup wasn't successful:
+      // ...cleanup isn't run until after last retry
+      // ...so we delete here, so we can retry setup without leaving behind test users
+      if (status !== expectedStatus && userId !== undefined) {
+        await cleanupTestUser(userId, userPage)
+      }
 
-        await setLocalStorage(
-          userPage,
-          USER_NAME_LOCALSTORAGE_KEY,
-          testUserName,
-        )
-        await userPage.context().storageState({ path: USER_STORAGE_STATE })
-
-        return { testUserName, testUserPassword }
-      },
-    )
-
-    await setup.step('authenticate test user', async () => {
-      await loginTestUser(userPage, testUserName, testUserPassword)
-      await userPage.context().storageState({ path: USER_STORAGE_STATE })
+      // clean up page
+      await userPage.close()
     })
   })
-
-  setup.afterAll(async ({}, { expectedStatus, status }) => {
-    // clean up pages
-    await adminPage.close()
-    await userPage.close()
-
-    // delete test user if setup wasn't successful:
-    // ...cleanup isn't run until after last retry
-    // ...so we delete here, so we can retry setup without leaving behind test users
-    if (status !== expectedStatus && testUserId !== undefined) {
-      const result = await deleteTestUser(
-        getEndpoint(),
-        testUserId!,
-        getAdminPAT(),
-      )
-      expect(result).toEqual(testUserId)
-    }
-  })
-})
+}

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -15,14 +15,13 @@ import {
   USER_NAME_LOCALSTORAGE_KEY,
   createTestUser,
   deleteTestUser,
-  getAccessTokenFromCookie,
+  getAdminPAT,
   getAdminUserCredentials,
   loginTestUser,
 } from './helpers/testUser'
 import { TestUser } from './helpers/types'
 
 let testUserId: string | undefined
-let adminAccessToken: string | undefined
 let adminPage: Page
 let userPage: Page
 
@@ -44,20 +43,17 @@ setup.describe('Setup', () => {
 
       await loginTestUser(adminPage, adminUserName!, adminUserPassword!)
       await adminPage.context().storageState({ path: ADMIN_STORAGE_STATE })
-
-      adminAccessToken = await getAccessTokenFromCookie(adminPage)
     })
 
     const { testUserName, testUserPassword } = await setup.step(
       'create test user',
       async () => {
-        const testUserName = 'swc-e2e-' + uuidv4()
-        const testUserPassword = 'password-' + uuidv4()
-        /* 
+        /* const testUserName = 'swc-e2e-' + uuidv4()
+        const testUserPassword = 'password-' + uuidv4() */
+
         const testUserName = 'swc-e2e-test'
         const testUserPassword = process.env.USER_PASSWORD!
-        expect(testUserPassword).not.toBeUndefined() 
-        */
+        expect(testUserPassword).not.toBeUndefined()
 
         const testUserEmail = `${testUserName}@test.com`
         const testUserIsValidated = false
@@ -73,7 +69,7 @@ setup.describe('Setup', () => {
         testUserId = await createTestUser(
           getEndpoint(),
           testUser,
-          adminAccessToken,
+          getAdminPAT(),
         )
         expect(testUserId).not.toBeUndefined()
 
@@ -106,7 +102,7 @@ setup.describe('Setup', () => {
       const result = await deleteTestUser(
         getEndpoint(),
         testUserId!,
-        adminAccessToken,
+        getAdminPAT(),
       )
       expect(result).toEqual(testUserId)
     }

--- a/e2e/helpers/localStorage.ts
+++ b/e2e/helpers/localStorage.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test'
 
-async function navigateToHomepageIfPageHasNotBeenLoaded(page: Page) {
+export async function navigateToHomepageIfPageHasNotBeenLoaded(page: Page) {
   if (page.url() === 'about:blank') {
     // Navigate to homepage, so that localStorage is available
     await page.goto('/')

--- a/e2e/helpers/testUser.ts
+++ b/e2e/helpers/testUser.ts
@@ -14,6 +14,12 @@ export function getAdminUserCredentials() {
   return { adminUserName, adminUserPassword }
 }
 
+export function getAdminPAT() {
+  const adminPAT = process.env.ADMIN_PAT!
+  expect(adminPAT).not.toBeUndefined()
+  return adminPAT
+}
+
 export async function createTestUser(
   endpoint: string,
   testUser: TestUser,

--- a/e2e/helpers/testUser.ts
+++ b/e2e/helpers/testUser.ts
@@ -1,18 +1,10 @@
 import { Page, expect } from '@playwright/test'
-import { doDelete, doPost, getUserIdFromJwt } from './http'
+import { doDelete, doPost, getEndpoint, getUserIdFromJwt } from './http'
 import { getLocalStorage } from './localStorage'
 import { LoginResponse, TestUser } from './types'
+import { deleteVerificationSubmissionIfExists } from './verification'
 
 const TEST_USER_URI = '/repo/v1/admin/user'
-export const USER_NAME_LOCALSTORAGE_KEY = 'USER_NAME'
-
-export function getAdminUserCredentials() {
-  const adminUserName = process.env.ADMIN_USERNAME
-  const adminUserPassword = process.env.ADMIN_PASSWORD
-  expect(adminUserName).not.toBeUndefined()
-  expect(adminUserPassword).not.toBeUndefined()
-  return { adminUserName, adminUserPassword }
-}
 
 export function getAdminPAT() {
   const adminPAT = process.env.ADMIN_PAT!
@@ -49,6 +41,16 @@ export async function deleteTestUser(
   const uri = `${TEST_USER_URI}/${testUserId}`
   await doDelete(endpoint, uri, accessToken, adminUserName, adminApiKey)
   return testUserId
+}
+
+export async function cleanupTestUser(testUserId: string, userPage: Page) {
+  await deleteVerificationSubmissionIfExists(
+    testUserId,
+    getAdminPAT(),
+    userPage,
+  )
+  const result = await deleteTestUser(getEndpoint(), testUserId, getAdminPAT())
+  expect(result).toEqual(testUserId)
 }
 
 // Use after initially navigating to baseURL
@@ -111,5 +113,5 @@ export async function getAccessTokenFromCookie(page: Page) {
 export async function getUserIdFromLocalStorage(page: Page) {
   const id = await getLocalStorage(page, 'SESSION_MARKER')
   expect(id).not.toBeNull()
-  return id
+  return id!
 }

--- a/e2e/helpers/userConfig.ts
+++ b/e2e/helpers/userConfig.ts
@@ -1,0 +1,65 @@
+import { v4 as uuidv4 } from 'uuid'
+import {
+  USER_STORAGE_STATE,
+  USER_VALIDATED_STORAGE_STATE,
+} from '../../playwright.config'
+import { TestUser } from './types'
+
+const userNamePrefix = 'swc-e2e-user'
+export const USER_NAME_LOCALSTORAGE_KEY = 'USER_NAME'
+
+const userValidatedPrefix = 'swc-e2e-user-validated'
+export const USER_VALIDATED_NAME_LOCALSTORAGE_KEY = 'USER_VALIDATED_NAME'
+
+const generateUserName = (prefix: string) => {
+  // uncomment to use static username for troubleshooting:
+  // return prefix
+
+  return `${prefix}-${uuidv4()}`
+}
+const generateUserPassword = () => {
+  // uncomment to use static password for troubleshooting:
+  // (after setting USER_PASSWORD in the .env file)
+  // return process.env.USER_PASSWORD!
+
+  return `password-${uuidv4()}`
+}
+const generateUserEmail = (prefix: string) => {
+  return `${prefix}-${uuidv4()}@test.com`
+}
+
+type UserConfig = {
+  // used to ensure that dynamically generated tests have static names
+  // ...see https://github.com/microsoft/playwright/issues/24273#issuecomment-1640003150
+  testName: string
+  storageStatePath: string
+  localStorageKey: string
+  user: TestUser
+}
+
+export const userConfigs: UserConfig[] = [
+  {
+    testName: userNamePrefix,
+    storageStatePath: USER_STORAGE_STATE,
+    localStorageKey: USER_NAME_LOCALSTORAGE_KEY,
+    user: {
+      username: generateUserName(userNamePrefix),
+      email: generateUserEmail(userNamePrefix),
+      password: generateUserPassword(),
+      tou: true,
+      validatedUser: false,
+    },
+  },
+  {
+    testName: userValidatedPrefix,
+    storageStatePath: USER_VALIDATED_STORAGE_STATE,
+    localStorageKey: USER_VALIDATED_NAME_LOCALSTORAGE_KEY,
+    user: {
+      username: generateUserName(userValidatedPrefix),
+      email: generateUserEmail(userValidatedPrefix),
+      password: generateUserPassword(),
+      tou: true,
+      validatedUser: true,
+    },
+  },
+]

--- a/e2e/helpers/verification.ts
+++ b/e2e/helpers/verification.ts
@@ -1,0 +1,70 @@
+import { Page, expect } from '@playwright/test'
+import { navigateToHomepageIfPageHasNotBeenLoaded } from './localStorage'
+
+export async function waitForSrcEndpointConfig(page: Page) {
+  // window only available after page has initially loaded
+  await navigateToHomepageIfPageHasNotBeenLoaded(page)
+  // ensure that endpoint config is set,
+  // ...so API calls point to the correct stack
+  await expect(async () => {
+    const response = await page.evaluate('window.SRC.OVERRIDE_ENDPOINT_CONFIG')
+    expect(response).not.toBeUndefined()
+  }).toPass()
+}
+
+export async function getVerificationSubmissionId(
+  userId: string,
+  accessToken: string,
+  page: Page,
+) {
+  await waitForSrcEndpointConfig(page)
+  const bundle = await page.evaluate(
+    async ({ userId, accessToken }) => {
+      const mask = await SRC.SynapseConstants
+        .USER_BUNDLE_MASK_VERIFICATION_SUBMISSION
+      return await SRC.SynapseClient.getUserBundle(userId, mask, accessToken)
+    },
+    { userId, accessToken },
+  )
+  return bundle?.verificationSubmission?.id
+}
+
+// https://rest-docs.synapse.org/rest/DELETE/verificationSubmission/id.html
+export async function deleteVerificationSubmissionById(
+  verificationSubmissionId: string,
+  accessToken: string,
+  page: Page,
+) {
+  await waitForSrcEndpointConfig(page)
+  await page.evaluate(
+    async ({ verificationSubmissionId, accessToken }) => {
+      const endpoint = await SRC.SynapseEnums.BackendDestinationEnum
+        .REPO_ENDPOINT
+      return await SRC.HttpClient.doDelete(
+        `/repo/v1/verificationSubmission/${verificationSubmissionId}`,
+        accessToken,
+        endpoint,
+      )
+    },
+    { verificationSubmissionId, accessToken },
+  )
+}
+
+export async function deleteVerificationSubmissionIfExists(
+  userId: string,
+  accessToken: string,
+  page: Page,
+) {
+  const verificationSubmissionId = await getVerificationSubmissionId(
+    userId,
+    accessToken,
+    page,
+  )
+  if (verificationSubmissionId) {
+    await deleteVerificationSubmissionById(
+      verificationSubmissionId,
+      accessToken,
+      page,
+    )
+  }
+}

--- a/e2e/helpers/verification.ts
+++ b/e2e/helpers/verification.ts
@@ -20,8 +20,10 @@ export async function getVerificationSubmissionId(
   await waitForSrcEndpointConfig(page)
   const bundle = await page.evaluate(
     async ({ userId, accessToken }) => {
+      // @ts-expect-error: Cannot find name 'SRC'
       const mask = await SRC.SynapseConstants
         .USER_BUNDLE_MASK_VERIFICATION_SUBMISSION
+      // @ts-expect-error: Cannot find name 'SRC'
       return await SRC.SynapseClient.getUserBundle(userId, mask, accessToken)
     },
     { userId, accessToken },
@@ -38,8 +40,10 @@ export async function deleteVerificationSubmissionById(
   await waitForSrcEndpointConfig(page)
   await page.evaluate(
     async ({ verificationSubmissionId, accessToken }) => {
+      // @ts-expect-error: Cannot find name 'SRC'
       const endpoint = await SRC.SynapseEnums.BackendDestinationEnum
         .REPO_ENDPOINT
+      // @ts-expect-error: Cannot find name 'SRC'
       return await SRC.HttpClient.doDelete(
         `/repo/v1/verificationSubmission/${verificationSubmissionId}`,
         accessToken,

--- a/e2e/teams.loggedin.spec.ts
+++ b/e2e/teams.loggedin.spec.ts
@@ -88,7 +88,8 @@ test.describe('Teams', () => {
 
       const inviteMessageBox = userPage.getByLabel('Invitation Message')
       await inviteMessageBox.click()
-      await inviteMessageBox.type(INVITATION_MESSAGE)
+      await inviteMessageBox.fill(INVITATION_MESSAGE)
+      await expect(inviteMessageBox).toHaveValue(INVITATION_MESSAGE)
 
       const spinner = userPage.locator('.modal-body > .spinner')
       await userPage.getByRole('button', { name: 'Send Invitation(s)' }).click()

--- a/e2e/teams.loggedin.spec.ts
+++ b/e2e/teams.loggedin.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   USER_NAME_LOCALSTORAGE_KEY,
   getAccessTokenFromCookie,
+  getAdminPAT,
   getAdminUserCredentials,
   getUserIdFromLocalStorage,
   goToDashboard,
@@ -165,7 +166,7 @@ test.describe('Teams', () => {
 
     // get credentials
     const adminUserId = await getUserIdFromLocalStorage(adminPage)
-    const adminAccessToken = await getAccessTokenFromCookie(adminPage)
+    const adminPAT = getAdminPAT()
 
     const userUserId = await getUserIdFromLocalStorage(userPage)
     const userAccessToken = await getAccessTokenFromCookie(userPage)
@@ -178,15 +179,11 @@ test.describe('Teams', () => {
       userName!,
       TEAM_NAME,
       userAccessToken,
-      adminAccessToken,
+      adminPAT,
     )
 
     // delete team acceptance: admin -> user
-    await deleteTeamInviteAcceptanceMessage(
-      [userUserId!],
-      adminAccessToken,
-      adminAccessToken,
-    )
+    await deleteTeamInviteAcceptanceMessage([userUserId!], adminPAT, adminPAT)
 
     // close pages
     await adminPage.close()

--- a/e2e_workflow/README.md
+++ b/e2e_workflow/README.md
@@ -4,7 +4,7 @@
 
 ### Local
 
-1. Create a .env file with the following environment variables: `ADMIN_USERNAME` and `ADMIN_PASSWORD`.
+1. Create a .env file with the following environment variables: `ADMIN_PAT`.
 2. Build SWC: `mvn clean install`
 3. Run Tests\*: `yarn e2e`
 
@@ -16,7 +16,7 @@ When writing a new test, it can be useful to create a static user with known use
 
 ### CI
 
-In your forked repository, create [an Actions secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for both `ADMIN_USERNAME` and `ADMIN_PASSWORD`. The tests will run on each push to your forked repository.
+In your forked repository, create [an Actions secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for `ADMIN_PAT`. The tests will run on each push to your forked repository.
 
 ## Writing Tests
 
@@ -133,8 +133,7 @@ on: workflow_dispatch
 ```yml
 - name: Run Playwright tests
   env:
-    ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
-    ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+    ADMIN_PAT: ${{ secrets.ADMIN_PAT }}
   run: DEBUG="pw:api" yarn playwright test --trace on
 ```
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,8 @@ import { defineConfig, devices } from '@playwright/test'
 import dotenv from 'dotenv'
 
 export const USER_STORAGE_STATE = 'playwright/.auth/user.json'
-export const ADMIN_STORAGE_STATE = 'playwright/.auth/adminUser.json'
+export const USER_VALIDATED_STORAGE_STATE =
+  'playwright/.auth/userValidated.json'
 
 const baseURL = 'http://127.0.0.1:8888'
 


### PR DESCRIPTION
  - use PAT for admin API calls in e2e tests
  - only use admin for API calls, so remove need for secrets with admin username and password
  - create a validated user for tests that require multiple users
