### PR TITLE
SWC-6547: move papaparse to sage cdn and monitor in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "sass": "^1.63.6",
     "synapse-react-client": "3.1.53",
     "universal-cookie": "^4.0.4",
-    "spark-md5": "^3.0.2"
+    "spark-md5": "^3.0.2",
+    "papaparse": "^5.4.1"
   },
   "devDependencies": {
     "@playwright/test": "1.37.0",

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,10 @@
                   file="${project.basedir}/node_modules/spark-md5/spark-md5.min.js"
                   tofile="src/main/webapp/generated/spark-md5.min.js"
                 />
+                <copy
+                  file="${project.basedir}/node_modules/papaparse/papaparse.min.js"
+                  tofile="src/main/webapp/generated/papaparse.min.js"
+                />
               </target>
             </configuration>
           </execution>

--- a/src/main/java/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParser.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParser.java
@@ -1,15 +1,11 @@
 package org.sagebionetworks.web.client.widget;
 
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
-import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.resources.ResourceLoader;
-import org.sagebionetworks.web.client.resources.WebResource;
 import org.sagebionetworks.web.client.widget.csv.PapaCSVParser;
 import org.sagebionetworks.web.client.widget.csv.PapaParseResult;
 
@@ -17,44 +13,22 @@ public class CommaSeparatedValuesParser
   implements CommaSeparatedValuesParserView.Presenter {
 
   private CommaSeparatedValuesParserView view;
-  private ResourceLoader resourceLoader;
   private Consumer<List<String>> onAddCallback;
   private PapaCSVParser papaCSVParser;
-  private SynapseJSNIUtils jsniUtils;
 
   @Inject
   public CommaSeparatedValuesParser(
     CommaSeparatedValuesParserView view,
-    ResourceLoader resourceLoader,
-    PapaCSVParser papaCSVParser,
-    SynapseJSNIUtils jsniUtils
+    PapaCSVParser papaCSVParser
   ) {
     this.view = view;
-    this.resourceLoader = resourceLoader;
     this.papaCSVParser = papaCSVParser;
-    this.jsniUtils = jsniUtils;
     view.setPresenter(this);
   }
 
   @Override
   public void configure(Consumer<List<String>> onAddCallback) {
     this.onAddCallback = onAddCallback;
-    this.resourceLoader.requires(
-        new WebResource(
-          "https://cdn.jsdelivr.net/npm/papaparse@5.2.0/papaparse.min.js"
-        ),
-        new AsyncCallback<Void>() {
-          @Override
-          public void onFailure(Throwable caught) {
-            jsniUtils.consoleError(caught);
-          }
-
-          @Override
-          public void onSuccess(Void result) {
-            // Nothing to do. Just want the library to be available for later use.
-          }
-        }
-      );
   }
 
   @Override

--- a/src/main/webapp/Portal.html
+++ b/src/main/webapp/Portal.html
@@ -529,6 +529,7 @@
       head.load(cdnEndpoint + 'css/katex-0.10.1.min.css')
       head.load('//cdn.statuspage.io/se-v2.js')
       // head.load("//kh896k90gyvg.statuspage.io/embed/script.js");
+      head.load(cdnEndpoint + 'generated/papaparse.min.js')
     </script>
   </head>
   <body id="body">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,6 +3541,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
This PR updates the version of papaparse that we are using (from 5.2.0 to ^5.4.1), moves the js to the Synapse CloudFront CDN, and moves the import into package.json where we can be alerted to vulnerabilities and updates.