### PR TITLE
SWC-6556: when file upload fails, include error text in report to support debugging

### DIFF
--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -137,9 +137,14 @@ const uploadFile = async (
   })
 
   await testAuth.step('ensure there was not an upload error', async () => {
-    await expect(
-      page.getByRole('heading', { name: 'Upload Error' }),
-    ).not.toBeVisible()
+    const uploadError = page.getByRole('heading', { name: 'Upload Error' })
+    if (await uploadError.isVisible()) {
+      const uploadErrorText = await page
+        .getByRole('dialog')
+        .getByText('Unable to upload the file')
+        .textContent()
+      throw new Error(`Upload Error: ${uploadErrorText}`)
+    }
   })
 }
 


### PR DESCRIPTION
File upload via UI is consistently failing in firefox in [Sage runner](https://github.com/Sage-Bionetworks/SynapseWebClient/actions/runs/6590803696/job/17908259037), but consistently passing in firefox in [macos-latest](https://github.com/hallieswan/SynapseWebClient/actions/runs/6620351494/job/17982703532) runner used in my forked repo. Adding text of upload error to the Playwright report to support debugging the failure.