### PR TITLE
SWC-6605

### DIFF
--- a/.github/workflows/build-test-e2e.yml
+++ b/.github/workflows/build-test-e2e.yml
@@ -81,8 +81,8 @@ jobs:
         run: colima stop
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
-    # But skip this job if the previous job was cancelled
-    if: ${{ !cancelled() }}
+    # But skip this job if the previous job was cancelled or skipped
+    if: ${{ !cancelled() && needs.playwright-tests.result != 'skipped' }}
     needs: [playwright-tests]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test-e2e.yml
+++ b/.github/workflows/build-test-e2e.yml
@@ -9,9 +9,9 @@ env:
   PW_ALL_BLOBS_DIR: all-blob-reports
 jobs:
   build:
-    # Run in Sage repo on develop or release- branches
+    # Run in Sage repo on release- branches
     # and on all branches in user-owned forks
-    if: ${{ github.ref_name == 'develop' || startsWith(github.ref_name, 'release-') || github.actor == github.repository_owner }}
+    if: ${{ startsWith(github.ref_name, 'release-') || github.actor == github.repository_owner }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,9 +25,10 @@ jobs:
           retention-days: 1
   playwright-tests:
     needs: [build]
-    runs-on: ${{ github.repository_owner == 'Sage-Bionetworks' && 'ubuntu-22.04-4core-16GBRAM-150GBSSD' || 'macos-latest' }}
+    runs-on: 'macos-latest'
     timeout-minutes: 60
     strategy:
+      max-parallel: ${{ github.repository_owner == 'Sage-Bionetworks' && 1 || 3 }}
       fail-fast: false
       matrix:
         shard: [1/3, 2/3, 3/3]

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -8,6 +8,7 @@ import {
 import {
   dismissAlert,
   expectDiscussionPageLoaded,
+  expectDiscussionThreadLoaded,
   getDefaultDiscussionPath,
 } from './helpers/testUser'
 import { Project } from './helpers/types'
@@ -55,38 +56,6 @@ const expectThreadTableLoaded = async (
     await expect(threadCells.nth(4), 'Should have correct views').toHaveText(
       views,
     )
-  })
-}
-
-const expectDiscussionThreadLoaded = async (
-  page: Page,
-  threadId: number,
-  threadTitle: string,
-  threadBody: string,
-) => {
-  await testAuth.step('Discussion thread has loaded', async () => {
-    await page.waitForURL(
-      `${entityUrlPathname(userProject.id)}/discussion/threadId=${threadId}`,
-    )
-    await expect(
-      page.getByRole('heading', { name: 'Discussion' }),
-    ).toBeVisible()
-
-    await expect(
-      page.getByRole('button', { name: /show all threads/i }),
-    ).toBeVisible({ timeout: 60_000 })
-    await expect(
-      page.getByRole('button', { name: 'Date Posted' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('button', { name: 'Most Recent' }),
-    ).toBeVisible()
-
-    const discussionThread = page.locator(discussionThreadSelector)
-    await expect(discussionThread.getByText(threadTitle)).toBeVisible()
-    await expect(discussionThread.getByText(threadBody)).toBeVisible({
-      timeout: 60_000,
-    })
   })
 }
 
@@ -226,6 +195,7 @@ test.describe('Discussions', () => {
               threadId,
               threadTitle,
               threadBody,
+              userProject.id,
             )
           })
 
@@ -288,6 +258,7 @@ test.describe('Discussions', () => {
           threadId,
           threadTitle,
           threadBody,
+          userProject.id,
         )
       })
 
@@ -384,6 +355,7 @@ test.describe('Discussions', () => {
               threadId,
               threadTitle,
               threadBody,
+              userProject.id,
             )
           })
 

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -1,6 +1,6 @@
 import { Page, expect, test } from '@playwright/test'
+import { defaultExpectTimeout } from '../playwright.config'
 import { testAuth } from './fixtures/authenticatedUserPages'
-import { entityUrlPathname } from './helpers/entities'
 import {
   setupProjectWithPermissions,
   teardownProjectsAndFileHandles,
@@ -228,7 +228,11 @@ test.describe('Discussions', () => {
         await expect(async () => {
           // reload is necessary for view count to update
           await userPage.reload()
-          await expectDiscussionPageLoaded(userPage, userProject.id)
+          await expectDiscussionPageLoaded(
+            userPage,
+            userProject.id,
+            defaultExpectTimeout * 0.5, // use shorter expect timeout, so reload is tried earlier
+          )
           await expectThreadTableLoaded(
             userPage,
             threadTitle,

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -126,6 +126,7 @@ test.describe('Discussions', () => {
   })
 
   testAuth.afterAll(async ({ browser }) => {
+    test.slow()
     if (userProject.id) {
       await teardownProjectsAndFileHandles(
         browser,

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -10,6 +10,8 @@ import {
   expectDiscussionPageLoaded,
   expectDiscussionThreadLoaded,
   getDefaultDiscussionPath,
+  goToDashboardPage,
+  reloadDashboardPage,
 } from './helpers/testUser'
 import { Project } from './helpers/types'
 import { UserPrefix, userConfigs } from './helpers/userConfig'
@@ -71,7 +73,9 @@ const expectThreadReplyVisible = async (
         name: `@${userConfigs[replierPrefix].username}`,
       }),
     ).toBeVisible()
-    await expect(discussionReply.getByText(threadReply)).toBeVisible()
+    await expect(discussionReply.getByText(threadReply)).toBeVisible({
+      timeout: defaultExpectTimeout * 2, // allow extra time for reply to become visible
+    })
   })
 }
 
@@ -142,7 +146,11 @@ test.describe('Discussions', () => {
       const threadReplyEdited = 'An edited reply to the Thread'
 
       await testAuth.step('First user goes to Project', async () => {
-        await userPage.goto(getDefaultDiscussionPath(userProject.id))
+        await goToDashboardPage(
+          userPage,
+          getDefaultDiscussionPath(userProject.id),
+        )
+
         await expectDiscussionPageLoaded(userPage, userProject.id)
       })
 
@@ -227,7 +235,7 @@ test.describe('Discussions', () => {
         // retry if the view count hasn't updated
         await expect(async () => {
           // reload is necessary for view count to update
-          await userPage.reload()
+          await reloadDashboardPage(userPage)
           await expectDiscussionPageLoaded(
             userPage,
             userProject.id,
@@ -244,7 +252,10 @@ test.describe('Discussions', () => {
       })
 
       await testAuth.step('Second user can view discussion', async () => {
-        await validatedUserPage.goto(getDefaultDiscussionPath(userProject.id))
+        await goToDashboardPage(
+          validatedUserPage,
+          getDefaultDiscussionPath(userProject.id),
+        )
         await expectDiscussionPageLoaded(validatedUserPage, userProject.id)
         await expectThreadTableLoaded(
           userPage,

--- a/e2e/favorites.spec.ts
+++ b/e2e/favorites.spec.ts
@@ -1,9 +1,13 @@
 import { Page, expect, test } from '@playwright/test'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import { entityUrlPathname } from './helpers/entities'
-import { expectDiscussionPageLoaded, goToDashboard } from './helpers/testUser'
+import {
+  expectDiscussionPageLoaded,
+  goToDashboard,
+  goToDashboardPage,
+  reloadDashboardPage,
+} from './helpers/testUser'
 import { Project } from './helpers/types'
-import { waitForInitialPageLoad } from './helpers/utils'
 
 // Public project owned by swc-e2e-admin on backend dev stack.
 // In the future, consider creating/deleting a new public project within the test instead.
@@ -29,7 +33,6 @@ async function expectProjectPageLoaded(
   projectName: string,
   projectId: string,
 ) {
-  await page.waitForURL(entityUrlPathname(projectId))
   await expect(page.getByRole('heading', { name: projectName })).toBeVisible()
   await expectDiscussionPageLoaded(page, projectId)
 }
@@ -58,8 +61,7 @@ test.describe('Favorites', () => {
       })
 
       await testAuth.step('user goes to public project', async () => {
-        await userPage.goto(entityUrlPathname(PUBLIC_PROJECT.id))
-        await waitForInitialPageLoad(userPage)
+        await goToDashboardPage(userPage, entityUrlPathname(PUBLIC_PROJECT.id))
         await expectProjectPageLoaded(
           userPage,
           PUBLIC_PROJECT.name,
@@ -118,7 +120,7 @@ test.describe('Favorites', () => {
           await goToFavorites(userPage)
 
           // The page needs to be reloaded for the favorites list to update
-          await userPage.reload()
+          await reloadDashboardPage(userPage)
           await expectFavoritesPageLoaded(userPage)
 
           await expect(projectLink).not.toBeVisible()

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -422,20 +422,18 @@ test.describe('Files', () => {
       await testAuth.step('upload a new file', async () => {
         await uploadFile(userPage, updatedFilePath, 'newVersion')
         await expectFilePageLoaded(fileName, fileEntityId, userPage)
-        await dismissFileUploadAlert(userPage)
+        // Upload success alert intermittently appears when uploading a new version of the same file
+        await testAuth.step(
+          'dismiss file upload alert for new version of file, if visible',
+          async () => {
+            if (
+              await userPage.getByText('File successfully uploaded').isVisible()
+            ) {
+              await dismissFileUploadAlert(userPage)
+            }
+          },
+        )
       })
-
-      // Upload success alert intermittently appears when uploading a new version of the same file
-      await testAuth.step(
-        'dismiss file upload alert for new version of file, if visible',
-        async () => {
-          if (
-            await userPage.getByText('File successfully uploaded').isVisible()
-          ) {
-            await dismissFileUploadAlert(userPage)
-          }
-        },
-      )
 
       await testAuth.step(
         'confirm uploading new file changed md5 and version',

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -184,6 +184,7 @@ test.describe('Files', () => {
   })
 
   testAuth.afterAll(async ({ browser }) => {
+    test.slow()
     if (userProject.id) {
       await teardownProjectsAndFileHandles(
         browser,
@@ -196,8 +197,6 @@ test.describe('Files', () => {
   testAuth(
     'File sharing',
     async ({ userPage, validatedUserPage, browserName }) => {
-      test.slow()
-
       // Use test.fixme because test.fail doesn't mark test as expected to fail
       // when there is a test timeout. Since test timeouts are expensive,
       // Playwright recommends skipping the test entirely with test.fixme.

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -350,14 +350,6 @@ test.describe('Files', () => {
     async ({ userPage, browserName }) => {
       test.slow()
 
-      test.fail(
-        browserName === 'webkit',
-        `Playwright is not preserving the File's lastModified time in webkit, so 
-        file upload fails because it seems like the file was modified during 
-        upload. See https://github.com/microsoft/playwright/issues/27452. Fix 
-        planned for Playwright v1.40.`,
-      )
-
       const fileName = 'test_file.csv'
       const filePath = `data/${fileName}`
       const updatedFilePath = `data/test_file2.csv`

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -17,10 +17,11 @@ import {
   dismissAlert,
   getAccessTokenFromCookie,
   getAdminPAT,
+  goToDashboardPage,
+  reloadDashboardPage,
 } from './helpers/testUser'
 import { Project } from './helpers/types'
 import { userConfigs } from './helpers/userConfig'
-import { waitForInitialPageLoad } from './helpers/utils'
 
 const expectFilePageLoaded = async (
   fileName: string,
@@ -229,8 +230,10 @@ test.describe('Files', () => {
       )
 
       await testAuth.step('First user can view a private file', async () => {
-        await userPage.goto(`${entityUrlPathname(userProject.id)}/files`)
-        await waitForInitialPageLoad(userPage)
+        await goToDashboardPage(
+          userPage,
+          `${entityUrlPathname(userProject.id)}/files`,
+        )
 
         const fileLink = userPage.getByRole('link', { name: fileName })
         await expect(fileLink).toBeVisible({
@@ -245,9 +248,10 @@ test.describe('Files', () => {
       await confirmSharingSettings(userPage, userName, validatedUserName, false)
 
       await testAuth.step('Second user cannot access the file', async () => {
-        await validatedUserPage.goto(entityUrlPathname(fileEntityId))
-        await waitForInitialPageLoad(validatedUserPage)
-
+        await goToDashboardPage(
+          validatedUserPage,
+          entityUrlPathname(fileEntityId),
+        )
         await expectNoAccessPage(validatedUserPage)
       })
 
@@ -291,7 +295,7 @@ test.describe('Files', () => {
       await confirmSharingSettings(userPage, userName, validatedUserName, true)
 
       await testAuth.step('Second user accesses the file', async () => {
-        await validatedUserPage.reload()
+        await reloadDashboardPage(validatedUserPage)
         await expectFilePageLoaded(fileName, fileEntityId, validatedUserPage)
       })
 
@@ -329,7 +333,7 @@ test.describe('Files', () => {
 
       await testAuth.step('Second user cannot access the file', async () => {
         await expect(async () => {
-          await validatedUserPage.reload()
+          await reloadDashboardPage(validatedUserPage)
           await expectNoAccessPage(
             validatedUserPage,
             defaultExpectTimeout * 0.5, // use shorter expect timeout, so reload is tried earlier
@@ -355,8 +359,7 @@ test.describe('Files', () => {
       const updatedFilePath = `data/test_file2.csv`
 
       await testAuth.step('go to files tab', async () => {
-        await userPage.goto(entityUrlPathname(userProject.id))
-        await waitForInitialPageLoad(userPage)
+        await goToDashboardPage(userPage, entityUrlPathname(userProject.id))
         await expect(
           userPage.getByRole('heading', { name: userProject.name }),
         ).toBeVisible()
@@ -500,7 +503,7 @@ test.describe('Files', () => {
 
           // reload page if trash can deferred js does not load
           await expect(async () => {
-            await userPage.reload()
+            await reloadDashboardPage(userPage)
 
             const trashCanHeading = userPage.getByRole('heading', {
               name: 'Trash Can',

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -195,7 +195,9 @@ test.describe('Files', () => {
 
   testAuth(
     'File sharing',
-    async ({ userPage, validatedUserPage, browserName }, testInfo) => {
+    async ({ userPage, validatedUserPage, browserName }) => {
+      test.slow()
+
       // Use test.fixme because test.fail doesn't mark test as expected to fail
       // when there is a test timeout. Since test timeouts are expensive,
       // Playwright recommends skipping the test entirely with test.fixme.
@@ -346,6 +348,8 @@ test.describe('Files', () => {
   testAuth(
     'should create and delete a file',
     async ({ userPage, browserName }) => {
+      test.slow()
+
       test.fail(
         browserName === 'webkit',
         `Playwright is not preserving the File's lastModified time in webkit, so 

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -426,6 +426,18 @@ test.describe('Files', () => {
         await dismissFileUploadAlert(userPage)
       })
 
+      // Upload success alert intermittently appears when uploading a new version of the same file
+      await testAuth.step(
+        'dismiss file upload alert for new version of file, if visible',
+        async () => {
+          if (
+            await userPage.getByText('File successfully uploaded').isVisible()
+          ) {
+            await dismissFileUploadAlert(userPage)
+          }
+        },
+      )
+
       await testAuth.step(
         'confirm uploading new file changed md5 and version',
         async () => {

--- a/e2e/fixtures/authenticatedUserPages.ts
+++ b/e2e/fixtures/authenticatedUserPages.ts
@@ -1,6 +1,6 @@
 import { test as base, Browser, expect, type Page } from '@playwright/test'
 import { unlinkSync } from 'fs'
-import { baseURL } from '../../playwright.config'
+import { baseURL, defaultTestTimeout } from '../../playwright.config'
 import { setCertifiedUserStatus } from '../helpers/certification'
 import {
   cleanupTestUser,
@@ -100,7 +100,7 @@ export const testAuth = base.extend<
     },
     // specify timeout so worker fixture duration doesn't skew test duration
     // ...see https://github.com/microsoft/playwright/issues/15338
-    { scope: 'worker', timeout: 2 * 60 * 1000 },
+    { scope: 'worker', timeout: defaultTestTimeout },
   ],
   // stores auth state for each user in userConfig in storageState file, then deletes file
   // ...per worker + browserName
@@ -144,7 +144,7 @@ export const testAuth = base.extend<
     },
     // specify timeout so worker fixture duration doesn't skew test duration
     // ...see https://github.com/microsoft/playwright/issues/15338
-    { scope: 'worker', timeout: 2 * 60 * 1000 },
+    { scope: 'worker', timeout: defaultTestTimeout },
   ],
   userPage: createUserPageFixture(userPrefix),
   validatedUserPage: createUserPageFixture(userValidatedPrefix),

--- a/e2e/fixtures/authenticatedUserPages.ts
+++ b/e2e/fixtures/authenticatedUserPages.ts
@@ -100,7 +100,7 @@ export const testAuth = base.extend<
     },
     // specify timeout so worker fixture duration doesn't skew test duration
     // ...see https://github.com/microsoft/playwright/issues/15338
-    { scope: 'worker', timeout: defaultTestTimeout },
+    { scope: 'worker', timeout: defaultTestTimeout * 2 },
   ],
   // stores auth state for each user in userConfig in storageState file, then deletes file
   // ...per worker + browserName

--- a/e2e/fixtures/authenticatedUserPages.ts
+++ b/e2e/fixtures/authenticatedUserPages.ts
@@ -144,7 +144,8 @@ export const testAuth = base.extend<
     },
     // specify timeout so worker fixture duration doesn't skew test duration
     // ...see https://github.com/microsoft/playwright/issues/15338
-    { scope: 'worker', timeout: defaultTestTimeout },
+    // ...multiply timeout by each user to be authenticated
+    { scope: 'worker', timeout: defaultTestTimeout * 2 },
   ],
   userPage: createUserPageFixture(userPrefix),
   validatedUserPage: createUserPageFixture(userValidatedPrefix),

--- a/e2e/helpers/teams.ts
+++ b/e2e/helpers/teams.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test'
 import { BackendDestinationEnum, doDelete } from './http'
 
-const teamHashBang = '#!Team'
+export const teamHashBang = '#!Team'
 
 export function getTeamIdFromPathname(pathname: string) {
   if (!pathname.includes(teamHashBang)) {

--- a/e2e/helpers/testUser.ts
+++ b/e2e/helpers/testUser.ts
@@ -67,10 +67,6 @@ export async function loginTestUser(
   testUserName: string,
   testUserPassword: string,
 ) {
-  // Perform authentication steps
-  await page.goto('/')
-  await waitForInitialPageLoad(page)
-
   // Accept cookies, so banner doesn't obscure buttons in other tests
   await acceptSiteCookies(page)
 
@@ -169,5 +165,38 @@ export const expectDiscussionPageLoaded = async (
       page.getByRole('button', { name: 'Discussion Tools' }),
     ).toBeVisible()
     await expect(page.getByPlaceholder('Search discussions')).toBeVisible()
+  })
+}
+
+export const expectDiscussionThreadLoaded = async (
+  page: Page,
+  threadId: number,
+  threadTitle: string,
+  threadBody: string,
+  projectId: string,
+) => {
+  await testAuth.step('Discussion thread has loaded', async () => {
+    await page.waitForURL(
+      `${entityUrlPathname(projectId)}/discussion/threadId=${threadId}`,
+    )
+    await expect(
+      page.getByRole('heading', { name: 'Discussion' }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', { name: /show all threads/i }),
+    ).toBeVisible({ timeout: 60_000 })
+    await expect(
+      page.getByRole('button', { name: 'Date Posted' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Most Recent' }),
+    ).toBeVisible()
+
+    const discussionThread = page.locator('.discussionThread:visible')
+    await expect(discussionThread.getByText(threadTitle)).toBeVisible()
+    await expect(discussionThread.getByText(threadBody)).toBeVisible({
+      timeout: 60_000,
+    })
   })
 }

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -80,6 +80,7 @@ test.describe('Projects', () => {
   })
 
   testAuth.afterAll(async ({ browser }) => {
+    test.slow()
     // if test failed before project was deleted, then delete project here
     if (projectId) {
       const context = await browser.newContext()

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,9 +1,11 @@
 import { Page, expect, test } from '@playwright/test'
 import { v4 as uuidv4 } from 'uuid'
 import { testAuth } from './fixtures/authenticatedUserPages'
-import { goToDashboard } from './helpers/testUser'
+import { deleteProject, getEntityIdFromPathname } from './helpers/entities'
+import { dismissAlert, getAdminPAT, goToDashboard } from './helpers/testUser'
 
 const PROJECT_NAME = 'swc-e2e-project-' + uuidv4()
+let projectId: string | undefined = undefined
 
 async function createProject(page: Page, projectName: string) {
   await page.getByLabel('Projects', { exact: true }).click()
@@ -31,6 +33,10 @@ test.describe('Projects', () => {
         await expect(
           userPage.getByRole('heading', { name: PROJECT_NAME }),
         ).toBeVisible()
+        await expect(
+          userPage.getByRole('button', { name: 'Delete Wiki Page' }),
+        ).toBeVisible()
+        projectId = getEntityIdFromPathname(userPage.url())
       },
     )
 
@@ -41,45 +47,45 @@ test.describe('Projects', () => {
         await expect(
           userPage.getByText(/an entity with the name.*already exists/i),
         ).toBeVisible()
+        await userPage.getByRole('button', { name: 'Cancel' }).click()
+        await expect(
+          userPage.getByText('Create a new Project', { exact: true }),
+        ).not.toBeVisible()
       },
     )
+
+    await testAuth.step('should delete project', async () => {
+      await userPage.getByRole('button', { name: 'Project Tools' }).click()
+      await userPage.getByRole('menuitem', { name: 'Delete Project' }).click()
+
+      await expect(
+        userPage.getByRole('heading', { name: 'Confirm Deletion' }),
+      ).toBeVisible()
+      await expect(
+        userPage.getByText(
+          `Are you sure you want to delete Project "${PROJECT_NAME}"?`,
+        ),
+      ).toBeVisible()
+
+      await userPage
+        .getByRole('button', { name: 'Delete', exact: true })
+        .click()
+    })
+
+    await testAuth.step('confirm project deleted', async () => {
+      await dismissAlert(userPage, 'The Project was successfully deleted.')
+      await expect(userPage.getByText(PROJECT_NAME)).not.toBeVisible()
+      projectId = undefined
+    })
   })
 
-  testAuth.afterAll(async ({ userPage }) => {
-    // delete project
-    await goToDashboard(userPage)
-    await expect(
-      userPage.getByRole('heading', { name: 'Your Projects' }),
-    ).toBeVisible()
-
-    await userPage.getByRole('button', { name: 'Created by me' }).click()
-    await userPage.getByRole('link', { name: PROJECT_NAME }).click()
-
-    await expect(
-      userPage.getByRole('heading', { name: PROJECT_NAME }),
-    ).toBeVisible()
-    await expect(
-      userPage.getByRole('button', { name: 'Delete Wiki Page' }),
-    ).toBeVisible()
-    await userPage.getByRole('button', { name: 'Project Tools' }).click()
-    await userPage.getByRole('menuitem', { name: 'Delete Project' }).click()
-
-    await expect(
-      userPage.getByRole('heading', { name: 'Confirm Deletion' }),
-    ).toBeVisible()
-    await expect(
-      userPage.getByText(
-        `Are you sure you want to delete Project "${PROJECT_NAME}"?`,
-      ),
-    ).toBeVisible()
-
-    await userPage.getByRole('button', { name: 'Delete', exact: true }).click()
-
-    await expect(
-      userPage.getByText('The Project was successfully deleted.'),
-    ).toBeVisible()
-
-    await userPage.getByRole('button', { name: 'Created by me' }).click()
-    await expect(userPage.getByText(PROJECT_NAME)).not.toBeVisible()
+  testAuth.afterAll(async ({ browser }) => {
+    // if test failed before project was deleted, then delete project here
+    if (projectId) {
+      const context = await browser.newContext()
+      const page = await context.newPage()
+      await deleteProject(projectId, getAdminPAT(), page)
+      await context.close()
+    }
   })
 })

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -222,6 +222,8 @@ test.describe('Teams', () => {
   )
 
   testAuth.afterAll(async ({ userPage, validatedUserPage }) => {
+    test.slow()
+
     // get credentials
     const adminPAT = getAdminPAT()
 

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -5,7 +5,11 @@ import {
   deleteTeamInvitationMessage,
   deleteTeamInviteAcceptanceMessage,
 } from './helpers/messages'
-import { deleteTeam, getTeamIdFromPathname } from './helpers/teams'
+import {
+  deleteTeam,
+  getTeamIdFromPathname,
+  teamHashBang,
+} from './helpers/teams'
 import {
   dismissAlert,
   getAccessTokenFromCookie,
@@ -78,15 +82,17 @@ test.describe('Teams', () => {
           await expect(teamNameInput).toHaveValue(TEAM_NAME)
 
           await userPage.getByRole('button', { name: 'OK' }).click()
+
+          await testAuth.step('user should get teamId', async () => {
+            await userPage.waitForURL(`/${teamHashBang}:**`)
+            teamId = getTeamIdFromPathname(userPage.url())
+          })
+
           await dismissAlert(userPage, `Team Created: ${TEAM_NAME}`)
           await expectTeamPageLoaded(userPage, TEAM_NAME)
           await expect(userPage.getByText('1 team members')).toBeVisible()
         },
       )
-
-      await testAuth.step('user should get teamId', async () => {
-        teamId = getTeamIdFromPathname(userPage.url())
-      })
 
       await testAuth.step(
         'user should invite validated user to team',
@@ -153,6 +159,7 @@ test.describe('Teams', () => {
         // ...before resolving to one team link
         await expect
           .poll(async () => {
+            await expectMyTeamsPageLoaded(validatedUserPage)
             const count = await teamLink.count()
             // if no team links appear after joining the team
             // ...try reloading the page to see if the link subsequently appears

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -57,9 +57,7 @@ test.describe.configure({ mode: 'serial' })
 test.describe('Teams', () => {
   testAuth(
     'should exercise team lifecycle',
-    async ({ userPage, validatedUserPage }, testInfo) => {
-      test.slow()
-
+    async ({ userPage, validatedUserPage }) => {
       const { userName, validatedUserName } = await testAuth.step(
         'should get user names',
         async () => {

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -108,9 +108,7 @@ test.describe('Teams', () => {
           await userPage
             .getByRole('menuitem', { name: `@${validatedUserName}` })
             .click()
-          const loadInvitedUser = userPage.getByText('Loading...')
-          await expect(loadInvitedUser).toBeVisible()
-          await expect(loadInvitedUser).not.toBeVisible()
+          await expect(userPage.getByText('Loading...')).not.toBeVisible()
 
           const inviteMessageBox = userPage.getByLabel('Invitation Message')
           await inviteMessageBox.click()

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -17,6 +17,7 @@ import {
   getAdminPAT,
   getUserIdFromLocalStorage,
   goToDashboard,
+  reloadDashboardPage,
 } from './helpers/testUser'
 import {
   userConfigs,
@@ -165,7 +166,7 @@ test.describe('Teams', () => {
             // if no team links appear after joining the team
             // ...try reloading the page to see if the link subsequently appears
             if (count === 0) {
-              await validatedUserPage.reload()
+              await reloadDashboardPage(validatedUserPage)
             }
             return count
           })
@@ -174,6 +175,7 @@ test.describe('Teams', () => {
         const responsePromise = validatedUserPage.waitForResponse(
           response =>
             response.url().includes('synapseclient') &&
+            response.status() == 200 &&
             (response.request().postData()?.includes('getTeamMemberCount') ||
               false),
           { timeout: defaultExpectTimeout * 3 }, // allow time for the response to return

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "papaparse": "^5.4.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.40.0",
     "@prettier/plugin-xml": "^3.1.0",
     "@types/node": "18.6.5",
     "dotenv": "^16.3.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,8 +14,8 @@ dotenv.config()
 // FIXME: expect timeout not available in testInfo fixture in v1.39
 // change tests to use testInfo fixture once expect settings are exposed,
 // see: https://github.com/microsoft/playwright/issues/27915
-export const defaultExpectTimeout = process.env.CI ? 2 * 60 * 1000 : 5 * 1000
-export const defaultTestTimeout = process.env.CI ? 6 * 60 * 1000 : 2 * 60 * 1000
+export const defaultExpectTimeout = process.env.CI ? 60 * 1000 : 5 * 1000
+export const defaultTestTimeout = 2 * 60 * 1000
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,15 +11,21 @@ export const baseURL = 'http://127.0.0.1:8888'
  */
 dotenv.config()
 
+// FIXME: expect timeout not available in testInfo fixture in v1.39
+// change tests to use testInfo fixture once expect settings are exposed,
+// see: https://github.com/microsoft/playwright/issues/27915
+export const defaultExpectTimeout = process.env.CI ? 2 * 60 * 1000 : 5 * 1000
+export const defaultTestTimeout = process.env.CI ? 6 * 60 * 1000 : 2 * 60 * 1000
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: './e2e',
   /* Timeout to allow portal enough time to compile when running locally */
-  timeout: 2 * 60 * 1000,
+  timeout: defaultTestTimeout,
   /* Increase expectation timeout on CI */
-  expect: { timeout: process.env.CI ? 30 * 1000 : 5 * 1000 },
+  expect: { timeout: defaultExpectTimeout },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -27,7 +33,7 @@ export default defineConfig({
   /* Limit the number of failures on CI to save resources */
   maxFailures: process.env.CI ? 10 : undefined,
   /* Retries */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,12 +561,12 @@
     react-transition-group "^4.4.5"
     rifm "^0.12.1"
 
-"@playwright/test@^1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.39.0.tgz#d10ba8e38e44104499e25001945f07faa9fa91cd"
-  integrity sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==
+"@playwright/test@^1.40.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.0.tgz#d06c506977dd7863aa16e07f2136351ecc1be6ed"
+  integrity sha512-PdW+kn4eV99iP5gxWNSDQCbhMaDVej+RXL5xr6t04nbKLCBwYtA046t7ofoczHOm8u6c+45hpDKQVZqtqwkeQg==
   dependencies:
-    playwright "1.39.0"
+    playwright "1.40.0"
 
 "@plotly/d3-sankey-circular@0.33.1":
   version "0.33.1"
@@ -3714,17 +3714,17 @@ pidtree@^0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
-playwright-core@1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.39.0.tgz#efeaea754af4fb170d11845b8da30b2323287c63"
-  integrity sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==
+playwright-core@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.0.tgz#82f61e5504cb3097803b6f8bbd98190dd34bdf14"
+  integrity sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==
 
-playwright@1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.39.0.tgz#184c81cd6478f8da28bcd9e60e94fcebf566e077"
-  integrity sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==
+playwright@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.40.0.tgz#2a1824b9fe5c4fe52ed53db9ea68003543a99df0"
+  integrity sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==
   dependencies:
-    playwright-core "1.39.0"
+    playwright-core "1.40.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
- Use a macOS runner for e2e tests to reduce network flakiness, but only run workflow on `release-**` branches in the Sage repo and only run one shard at a time
- Fix common failure points in e2e tests, e.g. adding functions for reloading page that wait for SWC to be ready for interaction and deleting project via UI if possible, otherwise deleting via API
- bump Playwright version