### PR TITLE
SWC-6633 - Fix case where quiz question help was not shown if there was no documentation link

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/QuestionContainerWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/QuestionContainerWidget.java
@@ -44,7 +44,8 @@ public class QuestionContainerWidget
     MultichoiceResponse response
   ) {
     view.configure(questionNumber, question.getPrompt());
-    final MultichoiceQuestion multichoiceQuestion = (MultichoiceQuestion) question;
+    final MultichoiceQuestion multichoiceQuestion =
+      (MultichoiceQuestion) question;
     this.questionIndex = question.getQuestionIndex();
     this.questionPrompt = question.getPrompt();
     if (question instanceof MultichoiceQuestion) {
@@ -69,7 +70,10 @@ public class QuestionContainerWidget
         }
       }
       String helpLink = question.getDocLink();
-      if (DisplayUtils.isDefined(helpLink)) {
+      String helpText = question.getHelpText();
+      if (
+        DisplayUtils.isDefined(helpLink) || DisplayUtils.isDefined(helpText)
+      ) {
         view.setMoreInfoVisible(true);
         view.configureMoreInfo(helpLink, question.getHelpText());
       } else {

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/QuestionContainerWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/QuestionContainerWidgetTest.java
@@ -99,4 +99,23 @@ public class QuestionContainerWidgetTest {
     verify(mockView).configureMoreInfo(docLink, helpText);
     verify(mockView).setMoreInfoVisible(true);
   }
+
+  @Test
+  public void testHelpShownWhenNoLink() {
+    setExclusive(false);
+    String docLink = null;
+    String helpText = "Help text";
+    when(mockMultichoiceQuestion.getDocLink()).thenReturn(docLink);
+    when(mockMultichoiceQuestion.getHelpText()).thenReturn(helpText);
+    questionContainerWidget.configure(1L, mockMultichoiceQuestion, null);
+    verify(mockView, times(2))
+      .addCheckBox(
+        eq(mockMultichoiceQuestion.getQuestionIndex()),
+        anyString(),
+        anyLong(),
+        eq(false)
+      );
+    verify(mockView).configureMoreInfo(docLink, helpText);
+    verify(mockView).setMoreInfoVisible(true);
+  }
 }


### PR DESCRIPTION
At some point, ACT may have removed the documentation links from most (all?) questions. We only checked the presence of the link to determine if we should show the help text.