### PR TITLE
SWC-6638: show both certification and validation badges on profile pages

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/AccountLevelBadgesProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/AccountLevelBadgesProps.java
@@ -5,13 +5,13 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class AccountLevelBadgeProps extends ReactComponentProps {
+public class AccountLevelBadgesProps extends ReactComponentProps {
 
   String userId;
 
   @JsOverlay
-  public static AccountLevelBadgeProps create(String userId) {
-    AccountLevelBadgeProps props = new AccountLevelBadgeProps();
+  public static AccountLevelBadgesProps create(String userId) {
+    AccountLevelBadgesProps props = new AccountLevelBadgesProps();
     props.userId = userId;
     return props;
   }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -46,7 +46,7 @@ public class SRC {
     public static ReactComponentType<LoginPageProps> LoginPage;
     public static ReactComponentType<HasAccessProps> HasAccess;
     public static ReactComponentType<UserCardProps> UserCard;
-    public static ReactComponentType<AccountLevelBadgeProps> AccountLevelBadge;
+    public static ReactComponentType<AccountLevelBadgesProps> AccountLevelBadges;
     public static ReactComponentType<PageProgressProps> PageProgress;
     public static ReactComponentType<TermsAndConditionsProps> TermsAndConditions;
     public static ReactComponentType<IDUReportProps> IDUReport;

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.java
@@ -431,6 +431,7 @@ public class UserProfileEditorWidgetViewImpl
           accountTypeContainer.setVisible(showAccountType);
         }
 
+        // error will be handled/shown by React component
         @Override
         public void onFailure(Throwable caught) {}
       }

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.java
@@ -1,8 +1,12 @@
 package org.sagebionetworks.web.client.widget.profile;
 
+import static org.sagebionetworks.web.client.presenter.ProfilePresenter.IS_CERTIFIED;
+import static org.sagebionetworks.web.client.presenter.ProfilePresenter.IS_VERIFIED;
+
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.SuggestBox;
@@ -20,12 +24,14 @@ import org.gwtbootstrap3.client.ui.base.TextBoxBase;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
+import org.sagebionetworks.repo.model.UserBundle;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
+import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
-import org.sagebionetworks.web.client.jsinterop.AccountLevelBadgeProps;
+import org.sagebionetworks.web.client.jsinterop.AccountLevelBadgesProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactNode;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -120,7 +126,10 @@ public class UserProfileEditorWidgetViewImpl
   Anchor orcIdLink;
 
   @UiField
-  ReactComponentDiv accountLevelBadgeContainer;
+  Column accountTypeContainer;
+
+  @UiField
+  ReactComponentDiv accountLevelBadgesContainer;
 
   @UiField
   Div userProfileLinksUI;
@@ -145,6 +154,7 @@ public class UserProfileEditorWidgetViewImpl
   Presenter presenter;
   String originalButtonText;
   CookieProvider cookies;
+  SynapseJavascriptClient jsClient;
 
   @Inject
   public UserProfileEditorWidgetViewImpl(
@@ -154,12 +164,14 @@ public class UserProfileEditorWidgetViewImpl
     AuthenticationController authController,
     SynapseJSNIUtils jsniUtils,
     SynapseReactClientFullContextPropsProvider propsProvider,
-    CookieProvider cookies
+    CookieProvider cookies,
+    SynapseJavascriptClient jsClient
   ) {
     widget = binder.createAndBindUi(this);
     this.jsniUtils = jsniUtils;
     this.propsProvider = propsProvider;
     this.cookies = cookies;
+    this.jsClient = jsClient;
     locationSuggestBox = new SuggestBox(locationOracle);
     locationSuggestBox.setWidth("100%");
     locationTextBox = locationSuggestBox.getTextBox();
@@ -388,13 +400,14 @@ public class UserProfileEditorWidgetViewImpl
 
   @Override
   public void setOwnerId(String userId) {
-    ReactNode accountLevelBadgeComponent =
+    ReactNode accountLevelBadgesComponent =
       React.createElementWithSynapseContext(
-        SRC.SynapseComponents.AccountLevelBadge,
-        AccountLevelBadgeProps.create(userId),
+        SRC.SynapseComponents.AccountLevelBadges,
+        AccountLevelBadgesProps.create(userId),
         propsProvider.getJsInteropContextProps()
       );
-    accountLevelBadgeContainer.render(accountLevelBadgeComponent);
+    accountLevelBadgesContainer.render(accountLevelBadgesComponent);
+    setAccountTypeVisibility(Long.parseLong(userId));
 
     UserProfileLinksProps props = UserProfileLinksProps.create(userId);
     ReactNode profileLinksComponent = React.createElementWithSynapseContext(
@@ -403,6 +416,25 @@ public class UserProfileEditorWidgetViewImpl
       propsProvider.getJsInteropContextProps()
     );
     userProfileLinksReactComponentContainer.render(profileLinksComponent);
+  }
+
+  public void setAccountTypeVisibility(Long userId) {
+    int mask = IS_CERTIFIED | IS_VERIFIED;
+    jsClient.getUserBundle(
+      userId,
+      mask,
+      new AsyncCallback<UserBundle>() {
+        @Override
+        public void onSuccess(UserBundle bundle) {
+          boolean showAccountType =
+            bundle.getIsCertified() | bundle.getIsVerified();
+          accountTypeContainer.setVisible(showAccountType);
+        }
+
+        @Override
+        public void onFailure(Throwable caught) {}
+      }
+    );
   }
 
   @Override

--- a/src/main/resources/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/profile/UserProfileEditorWidgetViewImpl.ui.xml
@@ -156,15 +156,15 @@
               </bh:Div>
             </b:FormGroup>
           </b:Column>
-          <b:Column size="MD_12,LG_6">
+        </b:Row>
+        <b:Row>
+          <b:Column size="XS_12" ui:field="accountTypeContainer">
             <b:FormGroup>
               <b:FormLabel for="accountType">Account Type</b:FormLabel>
-              <bh:Div>
-                <w:ReactComponentDiv
-                  ui:field="accountLevelBadgeContainer"
-                  addStyleNames="accountLevelBadgeContainer"
-                />
-              </bh:Div>
+              <w:ReactComponentDiv
+                ui:field="accountLevelBadgesContainer"
+                addStyleNames="accountLevelBadgesContainer margin-top-5"
+              />
             </b:FormGroup>
           </b:Column>
         </b:Row>


### PR DESCRIPTION
- depends on https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/649
- requires SRC bump

type | profile
:---:|:---:
registered | <img width="1633" alt="SWC_registered" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/593f9618-6b32-4440-bbfb-e8cb23dc74b3">
certified | <img width="1644" alt="SWC_certified" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/f223c1eb-108d-41a6-9bb7-5d9d9508aab0">
certified and validated | <img width="1641" alt="SWC_certified_validated" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/6f1732c3-44f2-4728-aacb-9f0abc3d5a36"> <img width="1637" alt="SWC_tooltip" src="https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/9545bad6-5e77-4d99-83a2-6413392d43bb">
