### PR TITLE
SWC-6656 - Only record trace on first retry, which should speed up webkit runs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     // Until reports are saved in a secure location, do not collect traces on CI, since login network requests include user credentials
-    trace: process.env.CI ? 'off' : 'retain-on-failure',
+    // Collect the trace only on the first retry to speed up slow webkit runs. See https://github.com/microsoft/playwright/issues/18119#issuecomment-1370734489
+    trace: process.env.CI ? 'off' : 'on-first-retry',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
SWC-6656

Trace recording may be one reason why we're seeing slow runs in webkit that eventually time out and cause failures. This change will cause Playwright to only record traces on the first retry after failure, instead of recording for all tests.

That this change may speed up webkit is discussed here: https://github.com/microsoft/playwright/issues/18119