### PR TITLE
SWC-6723: clean up end to end tests

### DIFF
--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -1,8 +1,8 @@
-import { expect, test } from '@playwright/test'
+import { expect } from '@playwright/test'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import { goToDashboard } from './helpers/testUser'
 
-test.describe('Account Settings', () => {
+testAuth.describe('Account Settings', () => {
   testAuth('should show certification status', async ({ userPage }) => {
     await goToDashboard(userPage)
 

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import { defaultExpectTimeout } from '../playwright.config'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import {
@@ -109,7 +109,7 @@ const getDiscussionReplyActionButtons = (page: Page, threadReply: string) => {
 let userProject: Project
 const fileHandleIds: string[] = []
 
-test.describe('Discussions', () => {
+testAuth.describe('Discussions', () => {
   testAuth.beforeAll(async ({ browser, storageStatePaths }) => {
     userProject = await setupProjectWithPermissions(
       browser,
@@ -120,7 +120,7 @@ test.describe('Discussions', () => {
   })
 
   testAuth.afterAll(async ({ browser }) => {
-    test.slow()
+    testAuth.slow()
     if (userProject.id) {
       await teardownProjectsAndFileHandles(
         browser,
@@ -133,7 +133,7 @@ test.describe('Discussions', () => {
   testAuth(
     'should allow discussion and reply CRUD',
     async ({ userPage, validatedUserPage }) => {
-      test.slow()
+      testAuth.slow()
 
       const threadTitle = 'The Title of the Thread'
       const threadBody = 'The body of the Thread'

--- a/e2e/favorites.spec.ts
+++ b/e2e/favorites.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import { entityUrlPathname } from './helpers/entities'
 import {
@@ -41,7 +41,7 @@ function getFavoriteStarSpiner(page: Page) {
   return page.locator('.pageHeader').locator('.spinner:visible')
 }
 
-test.describe('Favorites', () => {
+testAuth.describe('Favorites', () => {
   testAuth('should be visible', async ({ userPage }) => {
     await goToDashboard(userPage)
     await goToFavorites(userPage)

--- a/e2e/files.spec.ts
+++ b/e2e/files.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import path from 'path'
 import { defaultExpectTimeout } from '../playwright.config'
 import { testAuth } from './fixtures/authenticatedUserPages'
@@ -178,13 +178,13 @@ const getFileMD5 = async (page: Page) => {
 let userProject: Project
 const fileHandleIds: string[] = []
 
-test.describe('Files', () => {
+testAuth.describe('Files', () => {
   testAuth.beforeAll(async ({ browser, storageStatePaths }) => {
     userProject = await setupProject(browser, 'swc-e2e-user', storageStatePaths)
   })
 
   testAuth.afterAll(async ({ browser }) => {
-    test.slow()
+    testAuth.slow()
     if (userProject.id) {
       await teardownProjectsAndFileHandles(
         browser,
@@ -201,7 +201,7 @@ test.describe('Files', () => {
       // when there is a test timeout. Since test timeouts are expensive,
       // Playwright recommends skipping the test entirely with test.fixme.
       // See: https://github.com/microsoft/playwright/issues/16317
-      test.fixme(
+      testAuth.fixme(
         browserName === 'webkit' && !!process.env.CI,
         `Very slow in webkit in CI only (passes after 6min in macos-latest runner, 
           times out after 10min in Sage ubuntu-22.04-4core-16GBRAM-150GBSSD runner). 
@@ -345,7 +345,7 @@ test.describe('Files', () => {
   )
 
   testAuth('should create and delete a file', async ({ userPage }) => {
-    test.slow()
+    testAuth.slow()
 
     const fileName = 'test_file.csv'
     const filePath = `data/${fileName}`

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import { waitForInitialPageLoad } from './helpers/utils'
 
-test.describe('Homepage', () => {
+test.describe('Homepage - Unauthenticated', () => {
   test('should show Log In To Synapse button when logged out', async ({
     page,
   }) => {
@@ -16,7 +16,9 @@ test.describe('Homepage', () => {
       page.getByRole('link', { name: 'View Your Dashboard' }),
     ).toHaveCount(0)
   })
+})
 
+testAuth.describe('Homepage - Authenticated', () => {
   testAuth(
     'should show View Your Dashboard button when logged in',
     async ({ userPage }) => {

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import { v4 as uuidv4 } from 'uuid'
 import { testAuth } from './fixtures/authenticatedUserPages'
 import { deleteProject, getEntityIdFromPathname } from './helpers/entities'
@@ -21,9 +21,9 @@ async function createProject(page: Page, projectName: string) {
 // Run multiple describes in parallel, but run tests inside each describe in order
 // ...tests within describe expect afterAll to be run with the same users, i.e. on the same worker
 // https://playwright.dev/docs/api/class-test#test-describe-configure
-test.describe.configure({ mode: 'serial' })
+testAuth.describe.configure({ mode: 'serial' })
 
-test.describe('Projects', () => {
+testAuth.describe('Projects', () => {
   testAuth('should create a project', async ({ userPage }) => {
     await testAuth.step(
       'should create a project with a unique name',
@@ -80,7 +80,7 @@ test.describe('Projects', () => {
   })
 
   testAuth.afterAll(async ({ browser }) => {
-    test.slow()
+    testAuth.slow()
     // if test failed before project was deleted, then delete project here
     if (projectId) {
       const context = await browser.newContext()

--- a/e2e/teams.spec.ts
+++ b/e2e/teams.spec.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import { v4 as uuidv4 } from 'uuid'
 import { defaultExpectTimeout } from '../playwright.config'
 import { testAuth } from './fixtures/authenticatedUserPages'
@@ -52,9 +52,9 @@ let teamId: string | undefined = undefined
 // Run multiple describes in parallel, but run tests inside each describe in order
 // ...tests within describe expect afterAll to be run with the same users, i.e. on the same worker
 // https://playwright.dev/docs/api/class-test#test-describe-configure
-test.describe.configure({ mode: 'serial' })
+testAuth.describe.configure({ mode: 'serial' })
 
-test.describe('Teams', () => {
+testAuth.describe('Teams', () => {
   testAuth(
     'should exercise team lifecycle',
     async ({ userPage, validatedUserPage }) => {
@@ -123,7 +123,7 @@ test.describe('Teams', () => {
         },
       )
 
-      await test.step('user should view pending invitations', async () => {
+      await testAuth.step('user should view pending invitations', async () => {
         await expect(userPage.getByText('Pending Invitations')).toBeVisible({
           timeout: defaultExpectTimeout * 3, // add extra timeout, so backend can finish sending request
         })
@@ -132,21 +132,26 @@ test.describe('Teams', () => {
         await expect(row.getByText(INVITATION_MESSAGE)).toBeVisible()
       })
 
-      await test.step('validated user should accept team invitation', async () => {
-        await goToDashboard(validatedUserPage)
+      await testAuth.step(
+        'validated user should accept team invitation',
+        async () => {
+          await goToDashboard(validatedUserPage)
 
-        await validatedUserPage.getByLabel('Teams').click()
-        await expectMyTeamsPageLoaded(validatedUserPage)
+          await validatedUserPage.getByLabel('Teams').click()
+          await expectMyTeamsPageLoaded(validatedUserPage)
 
-        // get row for this invitation
-        // ...in case multiple tests have invited validated user at the same time
-        const row = validatedUserPage.getByRole('row', { name: TEAM_NAME })
-        await expect(row.getByText(INVITATION_MESSAGE)).toBeVisible()
-        await expect(row.getByRole('button', { name: 'Cancel' })).toBeVisible()
+          // get row for this invitation
+          // ...in case multiple tests have invited validated user at the same time
+          const row = validatedUserPage.getByRole('row', { name: TEAM_NAME })
+          await expect(row.getByText(INVITATION_MESSAGE)).toBeVisible()
+          await expect(
+            row.getByRole('button', { name: 'Cancel' }),
+          ).toBeVisible()
 
-        await row.getByRole('button', { name: 'Join' }).click()
-        await expect(row).not.toBeVisible()
-      })
+          await row.getByRole('button', { name: 'Join' }).click()
+          await expect(row).not.toBeVisible()
+        },
+      )
 
       await testAuth.step('validated user should view team page', async () => {
         const teamLink = validatedUserPage.getByRole('link', {
@@ -218,15 +223,14 @@ test.describe('Teams', () => {
   )
 
   testAuth.afterAll(async ({ userPage, validatedUserPage }) => {
-    test.slow()
+    testAuth.slow()
 
     // get credentials
     const adminPAT = getAdminPAT()
 
     const validatedUserId = await getUserIdFromLocalStorage(validatedUserPage)
-    const validatedUserAccessToken = await getAccessTokenFromCookie(
-      validatedUserPage,
-    )
+    const validatedUserAccessToken =
+      await getAccessTokenFromCookie(validatedUserPage)
 
     const userUserId = await getUserIdFromLocalStorage(userPage)
     const userAccessToken = await getAccessTokenFromCookie(userPage)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "papaparse": "^5.4.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.40.1",
+    "@playwright/test": "^1.42.1",
     "@prettier/plugin-xml": "^3.1.0",
     "@sage-bionetworks/synapse-types": "^0.0.2",
     "@types/node": "18.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,12 +507,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/test@^1.40.1":
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.42.0.tgz#f65a7dcb92f202f376a7538e71855d873d1e6aa2"
-  integrity sha512-2k1HzC28Fs+HiwbJOQDUwrWMttqSLUVdjCqitBOjdCD0svWOMQUVqrXX6iFD7POps6xXAojsX/dGBpKnjZctLA==
+"@playwright/test@^1.42.1":
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.42.1.tgz#9eff7417bcaa770e9e9a00439e078284b301f31c"
+  integrity sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==
   dependencies:
-    playwright "1.42.0"
+    playwright "1.42.1"
 
 "@plotly/d3-sankey-circular@0.33.1":
   version "0.33.1"
@@ -3933,17 +3933,17 @@ pidtree@0.6.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
-playwright-core@1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.42.0.tgz#bc6525268b13b8bed5fbead761a1a886984555c4"
-  integrity sha512-0HD9y8qEVlcbsAjdpBaFjmaTHf+1FeIddy8VJLeiqwhcNqGCBe4Wp2e8knpqiYbzxtxarxiXyNDw2cG8sCaNMQ==
+playwright-core@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.42.1.tgz#13c150b93c940a3280ab1d3fbc945bc855c9459e"
+  integrity sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==
 
-playwright@1.42.0:
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.42.0.tgz#6d4265b124d2b87432083aa7af30c46aaec5e703"
-  integrity sha512-Ko7YRUgj5xBHbntrgt4EIw/nE//XBHOKVKnBjO1KuZkmkhlbgyggTe5s9hjqQ1LpN+Xg+kHsQyt5Pa0Bw5XpvQ==
+playwright@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.42.1.tgz#79c828b51fe3830211137550542426111dc8239f"
+  integrity sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==
   dependencies:
-    playwright-core "1.42.0"
+    playwright-core "1.42.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
- SWC-6723: change `test` -> `testAuth` when running a test using the authenticated user fixtures, which resolves the error introduced in Playwright v1.42
- fix empty table expectation so that tables test passes