### PR TITLE
SWC-6790: Fix outdated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,23 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <!-- Clean dir where we copy JS/CSS from node_modules -->
+              <directory>src/main/webapp/generated</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>3.3.2</version>

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
@@ -124,7 +124,7 @@ public class PlotlyWidgetViewImpl implements PlotlyWidgetView {
   ) /*-{
 
 		try {
-			var plot = $wnd.createPlotlyComponent($wnd.Plotly);
+			var plot = $wnd.createPlotlyComponent['default']($wnd.Plotly);
 
 			// SWC-3668: We must manually construct an Object from the parent window Object prototype.  This is a general GWT js integration issue.
 			// If we define the layout in the standard way, like "xaxis: {title:"mytitle"}", then  Object.getPrototypeOf(obj) === Object.prototype is false.


### PR DESCRIPTION
Attempt to fix SWC-6790

Note: pointing to 497 (currently staging). This PR is based off of 496, so we could alternatively patch that branch with this PR.

If the issue is that old resources are used in the build job, this should fix it by cleaning the re-used files before copying the latest versions