### PR TITLE
SWC-6730: use SRC create/update AR modal in experimental mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-transition-group": "2.6.0",
     "sass": "^1.63.6",
     "spark-md5": "^3.0.2",
-    "synapse-react-client": "3.2.10",
+    "synapse-react-client": "3.2.11",
     "universal-cookie": "^4.0.4",
     "xss": "^1.0.15"
   },

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -67,6 +67,7 @@ import org.sagebionetworks.web.client.widget.accessrequirements.TeamSubjectWidge
 import org.sagebionetworks.web.client.widget.accessrequirements.TermsOfUseAccessRequirementWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.approval.AccessorGroupWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateAccessRequirementWizard;
+import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateOrUpdateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.accessrequirements.submission.ACTDataAccessSubmissionWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.submission.OpenSubmissionWidget;
 import org.sagebionetworks.web.client.widget.asynch.AsynchronousProgressWidget;
@@ -735,6 +736,8 @@ public interface PortalGinInjector extends Ginjector {
   FileHandleWidget getFileHandleWidget();
 
   CreateAccessRequirementWizard getCreateAccessRequirementWizard();
+
+  CreateOrUpdateAccessRequirementWizard getCreateOrUpdateAccessRequirementWizard();
 
   ProfileCertifiedValidatedWidget getProfileCertifiedValidatedWidget();
 

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -66,8 +66,8 @@ import org.sagebionetworks.web.client.widget.accessrequirements.SelfSignAccessRe
 import org.sagebionetworks.web.client.widget.accessrequirements.TeamSubjectWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.TermsOfUseAccessRequirementWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.approval.AccessorGroupWidget;
-import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateOrUpdateAccessRequirementWizard;
+import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.LegacyCreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.accessrequirements.submission.ACTDataAccessSubmissionWidget;
 import org.sagebionetworks.web.client.widget.accessrequirements.submission.OpenSubmissionWidget;
 import org.sagebionetworks.web.client.widget.asynch.AsynchronousProgressWidget;
@@ -735,7 +735,7 @@ public interface PortalGinInjector extends Ginjector {
 
   FileHandleWidget getFileHandleWidget();
 
-  CreateAccessRequirementWizard getCreateAccessRequirementWizard();
+  LegacyCreateAccessRequirementWizard getLegacyCreateAccessRequirementWizard();
 
   CreateOrUpdateAccessRequirementWizard getCreateOrUpdateAccessRequirementWizard();
 

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/CreateOrUpdateAccessRequirementWizardProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/CreateOrUpdateAccessRequirementWizardProps.java
@@ -1,0 +1,59 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class CreateOrUpdateAccessRequirementWizardProps
+  extends ReactComponentProps {
+
+  @FunctionalInterface
+  @JsFunction
+  public interface OnComplete {
+    void onComplete();
+  }
+
+  @FunctionalInterface
+  @JsFunction
+  public interface OnCancel {
+    void onCancel();
+  }
+
+  boolean open;
+
+  @JsNullable
+  RestrictableObjectDescriptorJsObject subject;
+
+  @JsNullable
+  String accessRequirementId;
+
+  @JsNullable
+  OnComplete onComplete;
+
+  @JsNullable
+  OnCancel onCancel;
+
+  @JsOverlay
+  public static CreateOrUpdateAccessRequirementWizardProps create(
+    boolean open,
+    RestrictableObjectDescriptor subject,
+    String accessRequirementId,
+    OnComplete onComplete,
+    OnCancel onCancel
+  ) {
+    CreateOrUpdateAccessRequirementWizardProps props =
+      new CreateOrUpdateAccessRequirementWizardProps();
+    props.open = open;
+    if (subject != null) {
+      props.subject = RestrictableObjectDescriptorJsObject.create(subject);
+    }
+    props.accessRequirementId = accessRequirementId;
+    props.onComplete = onComplete;
+    props.onCancel = onCancel;
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/RestrictableObjectDescriptorJsObject.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/RestrictableObjectDescriptorJsObject.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class RestrictableObjectDescriptorJsObject extends ReactComponentProps {
+
+  String id;
+  String type;
+
+  @JsOverlay
+  public static RestrictableObjectDescriptorJsObject create(
+    RestrictableObjectDescriptor rod
+  ) {
+    RestrictableObjectDescriptorJsObject props =
+      new RestrictableObjectDescriptorJsObject();
+    props.id = rod.getId();
+    props.type = rod.getType().toString();
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -118,6 +118,9 @@ public class SRC {
     public static ReactComponentType<
       AccessRequirementAclEditorProps
     > AccessRequirementAclEditor;
+    public static ReactComponentType<
+      CreateOrUpdateAccessRequirementWizardProps
+    > CreateOrUpdateAccessRequirementWizard;
 
     /**
      * Pushes a global toast message. In SWC, you should use {@link DisplayUtils#notify}, rather than calling this method directly.

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/CreateAccessRequirementButton.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/CreateAccessRequirementButton.java
@@ -14,8 +14,8 @@ import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.CallbackP;
-import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateOrUpdateAccessRequirementWizard;
+import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.LegacyCreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.asynch.IsACTMemberAsyncHandler;
 import org.sagebionetworks.web.client.widget.entity.renderer.SingleButtonView;
 import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidget.WizardCallback;
@@ -98,8 +98,8 @@ public class CreateAccessRequirementButton
   }
 
   private void useSwcWizard() {
-    CreateAccessRequirementWizard wizard =
-      ginInjector.getCreateAccessRequirementWizard();
+    LegacyCreateAccessRequirementWizard wizard =
+      ginInjector.getLegacyCreateAccessRequirementWizard();
     if (subject != null) {
       wizard.configure(subject);
     } else if (ar != null) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
@@ -17,6 +17,8 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
   private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   private final ReactComponentDiv reactComponentDiv;
+
+  private boolean open;
   private RestrictableObjectDescriptor subject;
   private String accessRequirementId;
   private CreateOrUpdateAccessRequirementWizardProps.OnComplete onComplete;
@@ -31,9 +33,16 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
     reactComponentDiv = new ReactComponentDiv();
   }
 
-  private void renderComponent(
-    CreateOrUpdateAccessRequirementWizardProps props
-  ) {
+  private void renderComponent() {
+    CreateOrUpdateAccessRequirementWizardProps props =
+      CreateOrUpdateAccessRequirementWizardProps.create(
+        this.open,
+        this.subject,
+        this.accessRequirementId,
+        this.onComplete,
+        this.onCancel
+      );
+
     ReactNode reactNode = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateOrUpdateAccessRequirementWizard,
       props,
@@ -48,19 +57,15 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
     CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel
   ) {
     reactComponentDiv.clear();
+
     this.subject = subject;
     this.onComplete = onComplete;
     this.onCancel = onCancel;
-    CreateOrUpdateAccessRequirementWizardProps props =
-      CreateOrUpdateAccessRequirementWizardProps.create(
-        false,
-        subject,
-        null,
-        onComplete,
-        onCancel
-      );
 
-    renderComponent(props);
+    this.open = false;
+    this.accessRequirementId = null;
+
+    renderComponent();
   }
 
   public void configure(
@@ -69,31 +74,20 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
     CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel
   ) {
     reactComponentDiv.clear();
+
     this.accessRequirementId = accessRequirement.getId().toString();
     this.onComplete = onComplete;
     this.onCancel = onCancel;
-    CreateOrUpdateAccessRequirementWizardProps props =
-      CreateOrUpdateAccessRequirementWizardProps.create(
-        false,
-        null,
-        accessRequirementId,
-        onComplete,
-        onCancel
-      );
 
-    renderComponent(props);
+    this.open = false;
+    this.subject = null;
+
+    renderComponent();
   }
 
   public void setOpen(boolean open) {
-    CreateOrUpdateAccessRequirementWizardProps props =
-      CreateOrUpdateAccessRequirementWizardProps.create(
-        open,
-        subject,
-        accessRequirementId,
-        onComplete,
-        onCancel
-      );
-    renderComponent(props);
+    this.open = open;
+    renderComponent();
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
@@ -1,0 +1,103 @@
+package org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import org.sagebionetworks.repo.model.AccessRequirement;
+import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
+import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
+import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.widget.ReactComponentDiv;
+
+public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
+
+  private final SynapseReactClientFullContextPropsProvider propsProvider;
+
+  private final ReactComponentDiv reactComponentDiv;
+  private RestrictableObjectDescriptor subject;
+  private String accessRequirementId;
+  private CreateOrUpdateAccessRequirementWizardProps.OnComplete onComplete;
+  private CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel;
+
+  @Inject
+  public CreateOrUpdateAccessRequirementWizard(
+    SynapseReactClientFullContextPropsProvider propsProvider
+  ) {
+    super();
+    this.propsProvider = propsProvider;
+    reactComponentDiv = new ReactComponentDiv();
+  }
+
+  private void renderComponent(
+    CreateOrUpdateAccessRequirementWizardProps props
+  ) {
+    ReactNode reactNode = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.CreateOrUpdateAccessRequirementWizard,
+      props,
+      propsProvider.getJsInteropContextProps()
+    );
+    reactComponentDiv.render(reactNode);
+  }
+
+  public void configure(
+    RestrictableObjectDescriptor subject,
+    CreateOrUpdateAccessRequirementWizardProps.OnComplete onComplete,
+    CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel
+  ) {
+    reactComponentDiv.clear();
+    this.subject = subject;
+    this.onComplete = onComplete;
+    this.onCancel = onCancel;
+    CreateOrUpdateAccessRequirementWizardProps props =
+      CreateOrUpdateAccessRequirementWizardProps.create(
+        false,
+        subject,
+        null,
+        onComplete,
+        onCancel
+      );
+
+    renderComponent(props);
+  }
+
+  public void configure(
+    AccessRequirement accessRequirement,
+    CreateOrUpdateAccessRequirementWizardProps.OnComplete onComplete,
+    CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel
+  ) {
+    reactComponentDiv.clear();
+    this.accessRequirementId = accessRequirement.getId().toString();
+    this.onComplete = onComplete;
+    this.onCancel = onCancel;
+    CreateOrUpdateAccessRequirementWizardProps props =
+      CreateOrUpdateAccessRequirementWizardProps.create(
+        false,
+        null,
+        accessRequirementId,
+        onComplete,
+        onCancel
+      );
+
+    renderComponent(props);
+  }
+
+  public void setOpen(boolean open) {
+    CreateOrUpdateAccessRequirementWizardProps props =
+      CreateOrUpdateAccessRequirementWizardProps.create(
+        open,
+        subject,
+        accessRequirementId,
+        onComplete,
+        onCancel
+      );
+    renderComponent(props);
+  }
+
+  @Override
+  public Widget asWidget() {
+    return reactComponentDiv.asWidget();
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/LegacyCreateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/LegacyCreateAccessRequirementWizard.java
@@ -15,7 +15,7 @@ import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidge
  * @author Jay
  *
  */
-public class CreateAccessRequirementWizard implements IsWidget {
+public class LegacyCreateAccessRequirementWizard implements IsWidget {
 
   public static final String CREATE_ACCESS_REQUIREMENT_TITLE =
     "Create Access Requirement";
@@ -26,7 +26,7 @@ public class CreateAccessRequirementWizard implements IsWidget {
   CreateAccessRequirementStep1 step1;
 
   @Inject
-  public CreateAccessRequirementWizard(
+  public LegacyCreateAccessRequirementWizard(
     ModalWizardWidget modalWizardWidget,
     CreateAccessRequirementStep1 step1
   ) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/CreateAccessRequirementButtonTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/CreateAccessRequirementButtonTest.java
@@ -22,8 +22,8 @@ import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementW
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.accessrequirements.CreateAccessRequirementButton;
-import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateOrUpdateAccessRequirementWizard;
+import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.LegacyCreateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.asynch.IsACTMemberAsyncHandler;
 import org.sagebionetworks.web.client.widget.entity.renderer.SingleButtonView;
 import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidget;
@@ -45,7 +45,7 @@ public class CreateAccessRequirementButtonTest {
   PortalGinInjector mockGinInjector;
 
   @Mock
-  CreateAccessRequirementWizard mockCreateAccessRequirementWizard;
+  LegacyCreateAccessRequirementWizard mockLegacyCreateAccessRequirementWizard;
 
   @Mock
   CreateOrUpdateAccessRequirementWizard mockCreateOrUpdateAccessRequirementWizard;
@@ -85,8 +85,8 @@ public class CreateAccessRequirementButtonTest {
         mockCookies,
         mockGinInjector
       );
-    when(mockGinInjector.getCreateAccessRequirementWizard())
-      .thenReturn(mockCreateAccessRequirementWizard);
+    when(mockGinInjector.getLegacyCreateAccessRequirementWizard())
+      .thenReturn(mockLegacyCreateAccessRequirementWizard);
     when(mockGinInjector.getCreateOrUpdateAccessRequirementWizard())
       .thenReturn(mockCreateOrUpdateAccessRequirementWizard);
   }
@@ -118,8 +118,9 @@ public class CreateAccessRequirementButtonTest {
     when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
       .thenReturn(null);
     widget.onClick();
-    verify(mockCreateAccessRequirementWizard).configure(mockAccessRequirement);
-    verify(mockCreateAccessRequirementWizard)
+    verify(mockLegacyCreateAccessRequirementWizard)
+      .configure(mockAccessRequirement);
+    verify(mockLegacyCreateAccessRequirementWizard)
       .showModal(wizardCallbackCallback.capture());
     wizardCallbackCallback.getValue().onFinished();
     verify(mockRefreshCallback).invoke();
@@ -140,8 +141,8 @@ public class CreateAccessRequirementButtonTest {
     when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
       .thenReturn(null);
     widget.onClick();
-    verify(mockCreateAccessRequirementWizard).configure(mockSubject);
-    verify(mockCreateAccessRequirementWizard)
+    verify(mockLegacyCreateAccessRequirementWizard).configure(mockSubject);
+    verify(mockLegacyCreateAccessRequirementWizard)
       .showModal(any(ModalWizardWidget.WizardCallback.class));
     verify(mockCreateOrUpdateAccessRequirementWizard, never()).setOpen(true);
   }
@@ -152,8 +153,9 @@ public class CreateAccessRequirementButtonTest {
     when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
       .thenReturn(null);
     widget.onClick();
-    verify(mockCreateAccessRequirementWizard).configure(mockAccessRequirement);
-    verify(mockCreateAccessRequirementWizard)
+    verify(mockLegacyCreateAccessRequirementWizard)
+      .configure(mockAccessRequirement);
+    verify(mockLegacyCreateAccessRequirementWizard)
       .showModal(wizardCallbackCallback.capture());
     wizardCallbackCallback.getValue().onCanceled();
     verify(mockRefreshCallback).invoke();
@@ -187,9 +189,9 @@ public class CreateAccessRequirementButtonTest {
       );
     verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(true);
 
-    verify(mockCreateAccessRequirementWizard, never())
+    verify(mockLegacyCreateAccessRequirementWizard, never())
       .configure(mockAccessRequirement);
-    verify(mockCreateAccessRequirementWizard, never())
+    verify(mockLegacyCreateAccessRequirementWizard, never())
       .showModal(wizardCallbackCallback.capture());
 
     createOrUpdateArOnCompleteCaptor.getValue().onComplete();
@@ -220,8 +222,9 @@ public class CreateAccessRequirementButtonTest {
       );
     verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(true);
 
-    verify(mockCreateAccessRequirementWizard, never()).configure(mockSubject);
-    verify(mockCreateAccessRequirementWizard, never())
+    verify(mockLegacyCreateAccessRequirementWizard, never())
+      .configure(mockSubject);
+    verify(mockLegacyCreateAccessRequirementWizard, never())
       .showModal(wizardCallbackCallback.capture());
 
     createOrUpdateArOnCompleteCaptor.getValue().onComplete();
@@ -248,7 +251,7 @@ public class CreateAccessRequirementButtonTest {
     createOrUpdateArOnCancelCaptor.getValue().onCancel();
     verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(false);
     verify(mockRefreshCallback).invoke();
-    verify(mockCreateAccessRequirementWizard, never())
+    verify(mockLegacyCreateAccessRequirementWizard, never())
       .configure(mockAccessRequirement);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/CreateAccessRequirementButtonTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/CreateAccessRequirementButtonTest.java
@@ -1,11 +1,12 @@
 package org.sagebionetworks.web.unitclient.widget.accessrequirements;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.gwt.event.dom.client.ClickHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -14,13 +15,17 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
+import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.PortalGinInjector;
+import org.sagebionetworks.web.client.cookie.CookieProvider;
+import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.CallbackP;
-import org.sagebionetworks.web.client.widget.Button;
 import org.sagebionetworks.web.client.widget.accessrequirements.CreateAccessRequirementButton;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateAccessRequirementWizard;
+import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateOrUpdateAccessRequirementWizard;
 import org.sagebionetworks.web.client.widget.asynch.IsACTMemberAsyncHandler;
+import org.sagebionetworks.web.client.widget.entity.renderer.SingleButtonView;
 import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidget;
 
 public class CreateAccessRequirementButtonTest {
@@ -28,10 +33,13 @@ public class CreateAccessRequirementButtonTest {
   CreateAccessRequirementButton widget;
 
   @Mock
-  Button mockButton;
+  SingleButtonView mockView;
 
   @Mock
   IsACTMemberAsyncHandler mockIsACTMemberAsyncHandler;
+
+  @Mock
+  CookieProvider mockCookies;
 
   @Mock
   PortalGinInjector mockGinInjector;
@@ -39,11 +47,21 @@ public class CreateAccessRequirementButtonTest {
   @Mock
   CreateAccessRequirementWizard mockCreateAccessRequirementWizard;
 
-  @Captor
-  ArgumentCaptor<ClickHandler> clickHandlerCaptor;
+  @Mock
+  CreateOrUpdateAccessRequirementWizard mockCreateOrUpdateAccessRequirementWizard;
 
   @Captor
-  ArgumentCaptor<CallbackP> callbackPCaptor;
+  ArgumentCaptor<
+    CreateOrUpdateAccessRequirementWizardProps.OnComplete
+  > createOrUpdateArOnCompleteCaptor;
+
+  @Captor
+  ArgumentCaptor<
+    CreateOrUpdateAccessRequirementWizardProps.OnCancel
+  > createOrUpdateArOnCancelCaptor;
+
+  @Captor
+  ArgumentCaptor<CallbackP<Boolean>> callbackPCaptor;
 
   @Mock
   AccessRequirement mockAccessRequirement;
@@ -57,33 +75,32 @@ public class CreateAccessRequirementButtonTest {
   @Mock
   Callback mockRefreshCallback;
 
-  ClickHandler onButtonClickHandler;
-
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     widget =
       new CreateAccessRequirementButton(
-        mockButton,
+        mockView,
         mockIsACTMemberAsyncHandler,
+        mockCookies,
         mockGinInjector
       );
     when(mockGinInjector.getCreateAccessRequirementWizard())
       .thenReturn(mockCreateAccessRequirementWizard);
-    verify(mockButton).addClickHandler(clickHandlerCaptor.capture());
-    onButtonClickHandler = clickHandlerCaptor.getValue();
+    when(mockGinInjector.getCreateOrUpdateAccessRequirementWizard())
+      .thenReturn(mockCreateOrUpdateAccessRequirementWizard);
   }
 
   @Test
   public void testConstruction() {
-    verify(mockButton).setVisible(false);
+    verify(mockView).setButtonVisible(false);
   }
 
   @Test
   public void testConfigureWithAR() {
     widget.configure(mockAccessRequirement, mockRefreshCallback);
-    verify(mockButton)
-      .setText(
+    verify(mockView)
+      .setButtonText(
         CreateAccessRequirementButton.EDIT_ACCESS_REQUIREMENT_BUTTON_TEXT
       );
     verify(mockIsACTMemberAsyncHandler)
@@ -92,45 +109,146 @@ public class CreateAccessRequirementButtonTest {
     CallbackP<Boolean> isACTMemberCallback = callbackPCaptor.getValue();
     // invoking with false should hide the button again
     isACTMemberCallback.invoke(false);
-    verify(mockButton, times(2)).setVisible(false);
+    verify(mockView, times(2)).setButtonVisible(false);
 
     isACTMemberCallback.invoke(true);
-    verify(mockButton).setVisible(true);
+    verify(mockView).setButtonVisible(true);
 
     // configured with an AR, when clicked it should pop up the wizard with the existing AR
-    onButtonClickHandler.onClick(null);
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn(null);
+    widget.onClick();
     verify(mockCreateAccessRequirementWizard).configure(mockAccessRequirement);
     verify(mockCreateAccessRequirementWizard)
       .showModal(wizardCallbackCallback.capture());
     wizardCallbackCallback.getValue().onFinished();
     verify(mockRefreshCallback).invoke();
+    verify(mockCreateOrUpdateAccessRequirementWizard, never()).setOpen(true);
   }
 
   @Test
   public void testConfigureWithSubject() {
     widget.configure(mockSubject, mockRefreshCallback);
-    verify(mockButton)
-      .setText(
+    verify(mockView)
+      .setButtonText(
         CreateAccessRequirementButton.CREATE_NEW_ACCESS_REQUIREMENT_BUTTON_TEXT
       );
     verify(mockIsACTMemberAsyncHandler)
       .isACTActionAvailable(callbackPCaptor.capture());
 
     // configured with a subject, when clicked it should pop up the wizard pointing to the new subject
-    onButtonClickHandler.onClick(null);
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn(null);
+    widget.onClick();
     verify(mockCreateAccessRequirementWizard).configure(mockSubject);
     verify(mockCreateAccessRequirementWizard)
       .showModal(any(ModalWizardWidget.WizardCallback.class));
+    verify(mockCreateOrUpdateAccessRequirementWizard, never()).setOpen(true);
   }
 
   @Test
   public void testOnCancelRefreshPage() {
     widget.configure(mockAccessRequirement, mockRefreshCallback);
-    onButtonClickHandler.onClick(null);
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn(null);
+    widget.onClick();
     verify(mockCreateAccessRequirementWizard).configure(mockAccessRequirement);
     verify(mockCreateAccessRequirementWizard)
       .showModal(wizardCallbackCallback.capture());
     wizardCallbackCallback.getValue().onCanceled();
     verify(mockRefreshCallback).invoke();
+    verify(mockCreateOrUpdateAccessRequirementWizard, never()).setOpen(true);
+  }
+
+  @Test
+  public void testConfigureWithARInExperimentalMode() {
+    widget.configure(mockAccessRequirement, mockRefreshCallback);
+    verify(mockView)
+      .setButtonText(
+        CreateAccessRequirementButton.EDIT_ACCESS_REQUIREMENT_BUTTON_TEXT
+      );
+    verify(mockIsACTMemberAsyncHandler)
+      .isACTActionAvailable(callbackPCaptor.capture());
+
+    CallbackP<Boolean> isACTMemberCallback = callbackPCaptor.getValue();
+    isACTMemberCallback.invoke(true);
+    verify(mockView).setButtonVisible(true);
+
+    // experimental mode -- use SRC wizard
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn("true");
+    widget.onClick();
+
+    verify(mockCreateOrUpdateAccessRequirementWizard)
+      .configure(
+        eq(mockAccessRequirement),
+        createOrUpdateArOnCompleteCaptor.capture(),
+        createOrUpdateArOnCancelCaptor.capture()
+      );
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(true);
+
+    verify(mockCreateAccessRequirementWizard, never())
+      .configure(mockAccessRequirement);
+    verify(mockCreateAccessRequirementWizard, never())
+      .showModal(wizardCallbackCallback.capture());
+
+    createOrUpdateArOnCompleteCaptor.getValue().onComplete();
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(false);
+    verify(mockRefreshCallback).invoke();
+  }
+
+  @Test
+  public void testConfigureWithSubjectInExperimentalMode() {
+    widget.configure(mockSubject, mockRefreshCallback);
+    verify(mockView)
+      .setButtonText(
+        CreateAccessRequirementButton.CREATE_NEW_ACCESS_REQUIREMENT_BUTTON_TEXT
+      );
+    verify(mockIsACTMemberAsyncHandler)
+      .isACTActionAvailable(callbackPCaptor.capture());
+
+    // experimental mode -- use SRC wizard
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn("true");
+    widget.onClick();
+
+    verify(mockCreateOrUpdateAccessRequirementWizard)
+      .configure(
+        eq(mockSubject),
+        createOrUpdateArOnCompleteCaptor.capture(),
+        createOrUpdateArOnCancelCaptor.capture()
+      );
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(true);
+
+    verify(mockCreateAccessRequirementWizard, never()).configure(mockSubject);
+    verify(mockCreateAccessRequirementWizard, never())
+      .showModal(wizardCallbackCallback.capture());
+
+    createOrUpdateArOnCompleteCaptor.getValue().onComplete();
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(false);
+    verify(mockRefreshCallback).invoke();
+  }
+
+  @Test
+  public void testOnCancelRefreshPageInExperimentalMode() {
+    widget.configure(mockAccessRequirement, mockRefreshCallback);
+    when(mockCookies.getCookie(DisplayUtils.SYNAPSE_TEST_WEBSITE_COOKIE_KEY))
+      .thenReturn("true");
+    widget.onClick();
+
+    // experimental mode -- use SRC wizard
+    verify(mockCreateOrUpdateAccessRequirementWizard)
+      .configure(
+        eq(mockAccessRequirement),
+        createOrUpdateArOnCompleteCaptor.capture(),
+        createOrUpdateArOnCancelCaptor.capture()
+      );
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(true);
+
+    createOrUpdateArOnCancelCaptor.getValue().onCancel();
+    verify(mockCreateOrUpdateAccessRequirementWizard).setOpen(false);
+    verify(mockRefreshCallback).invoke();
+    verify(mockCreateAccessRequirementWizard, never())
+      .configure(mockAccessRequirement);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,10 +5066,10 @@ svg-path-sdf@^1.1.3:
     parse-svg-path "^0.1.2"
     svg-path-bounds "^1.0.1"
 
-synapse-react-client@3.2.10:
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.2.10.tgz#34bebef47d89cb4d51ca40d2bba3f3a9e74fa857"
-  integrity sha512-77IUM+Z8v5UEA0zZ8nEkpOgczmiudXV69QybNH+qTaCrvPGJAKcElwWeflXiNBVSAi/0zdH/vP7BqRXgUu19zw==
+synapse-react-client@3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.2.11.tgz#fa1956f95dd4a01182339dbda16df59e7060151b"
+  integrity sha512-/QkYlcSxS3SC5Lq+hcLWv96VnG7VJfPK/wiLQF/OTFslR4RY4eMg140zeuv5qHNKgoBhmDB+jRZM8I6Ncwx5qw==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.1.2"
     "@brainhubeu/react-carousel" "1.19.26"


### PR DESCRIPTION
## Updates

- Uses new SRC create/update AR modal in Experimental mode. Will require SRC version bump.
- Maintains original SWC AR modal in non-Experimental mode
- SRC wizard allows user to enter search term in EntityFinder in the edit AR modal (original bug reported in SWC-6730)

https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/03928120-85ce-4b96-a650-ed75cf6fd29e

## Create AR

Original SWC wizard:

https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/bdd2c79c-8530-4ca3-922e-e648caedce66

New SRC wizard: 

https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/3c1086f0-ba8c-4039-8bdb-e689f3849ba8

## Edit AR

Original SWC wizard: 

https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/43d390c3-57ce-4938-935f-ffe40898656e

New SRC wizard:

https://github.com/Sage-Bionetworks/SynapseWebClient/assets/26949006/eaa4f034-d232-45b3-bc5c-51ed1809ecf7




