### PR TITLE
SWC-6901: fix button copy in projects and tables e2e tests

### DIFF
--- a/e2e/helpers/tables.ts
+++ b/e2e/helpers/tables.ts
@@ -24,7 +24,9 @@ export const expectTablesPageLoaded = async (page: Page, projectId: string) => {
     await expect(
       page.getByRole('button', { name: 'Upload a Table' }),
     ).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Add New...' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Add Table Or View' }),
+    ).toBeVisible()
   })
 }
 
@@ -34,9 +36,9 @@ export const expectTablePageLoaded = async (
   tableDescription: string,
 ) => {
   await test.step('table has loaded', async () => {
-    await expect(
-      page.getByRole('button', { name: 'Table Tools' }),
-    ).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Table Tools' })).toBeVisible(
+      { timeout: defaultExpectTimeout * 2 },
+    )
     await expect(page.locator('p').filter({ hasText: tableName })).toBeVisible()
     await expect(
       page

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -34,7 +34,7 @@ testAuth.describe('Projects', () => {
           userPage.getByRole('heading', { name: PROJECT_NAME }),
         ).toBeVisible()
         await expect(
-          userPage.getByRole('button', { name: 'Wiki Tools' }),
+          userPage.getByRole('button', { name: 'Delete Wiki Page' }),
         ).toBeVisible()
         projectId = getEntityIdFromPathname(userPage.url())
       },

--- a/e2e/tables.spec.ts
+++ b/e2e/tables.spec.ts
@@ -147,9 +147,8 @@ testAuth.describe('Tables', () => {
 
     await testAuth.step('User creates a table', async () => {
       await testAuth.step('open table creation modal', async () => {
-        await userPage.getByRole('button', { name: 'Add  New...' }).click()
         await userPage
-          .getByRole('menuitem', { name: 'Add Table or View' })
+          .getByRole('button', { name: 'Add Table or View' })
           .click()
 
         const dialog = userPage.getByRole('dialog')
@@ -297,12 +296,13 @@ testAuth.describe('Tables', () => {
         await expect(tableSchemaEditorHeader).not.toBeVisible(
           { timeout: defaultExpectTimeout * 3 }, // allow time for the response to return
         )
-        await expectTablePageLoaded(userPage, tableName, tableDescription)
 
         await dismissAlert(
           userPage,
           'You made changes to the columns in this Table',
         )
+
+        await expectTablePageLoaded(userPage, tableName, tableDescription)
       })
 
       await expectTableSchemaCorrect(userPage, updatedColumnsSchemaConfig)


### PR DESCRIPTION
Projects tests passed consistently in [my fork](https://github.com/hallieswan/SynapseWebClient/actions/runs/9616777938) after the copy update. Tables tests are now finding the button using the updated copy, but are still flaky (tracked in SWC-6812).