### PR TITLE
SWC-6933 - Wrap all React components with context in an error boundary

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseContextJsObject.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseContextJsObject.java
@@ -15,6 +15,7 @@ public class SynapseContextJsObject {
   public boolean isInExperimentalMode;
   public boolean utcTime;
   public String appId;
+  public boolean withErrorBoundary;
 
   @JsOverlay
   public static SynapseContextJsObject create(
@@ -28,6 +29,7 @@ public class SynapseContextJsObject {
     context.utcTime = utcTime;
     context.downloadCartPageUrl = "/DownloadCart:0";
     context.appId = "synapse.org";
+    context.withErrorBoundary = true;
     return context;
   }
 }


### PR DESCRIPTION
This should limit the impact of component crashes on the app and provide more sensible UI when such errors happen.