### PR TITLE
SWC-6895 - Bump synapse-react-client to v3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-transition-group": "2.6.0",
     "sass": "^1.63.6",
     "spark-md5": "^3.0.2",
-    "synapse-react-client": "3.3.2",
+    "synapse-react-client": "3.3.3",
     "universal-cookie": "^4.0.4",
     "xss": "^1.0.15"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,6 +4929,11 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1, react-transition-g
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-type-animation@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-type-animation/-/react-type-animation-3.2.0.tgz#6863d5d60e3beb237f2bd690cceb585402c47e6a"
+  integrity sha512-WXTe0i3rRNKjmggPvT5ntye1QBt0ATGbijeW6V3cQe2W0jaMABXXlPPEdtofnS9tM7wSRHchEvI9SUw+0kUohw==
+
 react-virtualized-auto-sizer@^1.0.20, react-virtualized-auto-sizer@^1.0.24:
   version "1.0.24"
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz#3ebdc92f4b05ad65693b3cc8e7d8dd54924c0227"
@@ -5680,10 +5685,10 @@ svg-path-sdf@^1.1.3:
     parse-svg-path "^0.1.2"
     svg-path-bounds "^1.0.1"
 
-synapse-react-client@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.3.2.tgz#e5575a658845549063fb46f7b30cc84b85e02722"
-  integrity sha512-d28RFaYYwBw5tXXuP4jOUD0xvt+s8DQy1/NweCSQNem7WnaW9k7H2Kj17yB8Ow5rxN0UKF4IEr/PIBP3N7J1NA==
+synapse-react-client@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-3.3.3.tgz#01688f8ff5d78d9f1a5f7f7e5bd6b7d9a1421bb7"
+  integrity sha512-u2rSzCJu+etfnD/G8XhbfRo7fNDKPFCbeCP8k+MGgcSFqu4nyWxjSxHTwXx9Byid6vevWxWUBEy1/+y78pTFGw==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.1.2"
     "@brainhubeu/react-carousel" "1.19.26"
@@ -5760,6 +5765,7 @@ synapse-react-client@3.3.2:
     react-sizeme "^3.0.2"
     react-switch "^7.0.0"
     react-transition-group "^4.4.5"
+    react-type-animation "^3.2.0"
     react-virtualized-auto-sizer "^1.0.24"
     react-vtree "3.0.0-beta.3"
     react-window "^1.8.10"


### PR DESCRIPTION
Fixes SWC-6895. Note that this will also include SWC-6929