### PR TITLE
SWC-6882 - Fixes for ReactComponent component tree management, MUI Grid re-introduction

### DIFF
--- a/devdocs/ReactIntegration.md
+++ b/devdocs/ReactIntegration.md
@@ -57,12 +57,12 @@ class MyView {
 
   void renderComponent() {
     MyProps props = props.create(/**/);
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.MyComponent,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 }
 

--- a/e2e/discussions.spec.ts
+++ b/e2e/discussions.spec.ts
@@ -82,7 +82,7 @@ const expectThreadReplyVisible = async (
 const getDiscussionParentActionButtons = (page: Page, threadTitle: string) => {
   const parentPost = page
     .locator(discussionThreadSelector)
-    .locator('.row')
+    .getByRole('article')
     .filter({ hasText: threadTitle })
   return {
     PIN: parentPost.locator(discussionActionIconClasses.PIN),
@@ -96,8 +96,7 @@ const getDiscussionParentActionButtons = (page: Page, threadTitle: string) => {
 
 const getDiscussionReplyActionButtons = (page: Page, threadReply: string) => {
   const replyPost = page
-    .locator(discussionThreadSelector)
-    .locator('.row')
+    .locator(discussionReplySelector)
     .filter({ hasText: threadReply })
   return {
     EDIT: replyPost.locator(discussionActionIconClasses.EDIT),

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,10 @@
                   file="${project.basedir}/node_modules/moment/min/moment.min.js"
                   tofile="src/main/webapp/generated/moment.min.js"
                 />
+                <copy
+                  file="${project.basedir}/node_modules/@mui/material/umd/material-ui.production.min.js"
+                  tofile="src/main/webapp/generated/material-ui.production.min.js"
+                />
                 <copy todir="src/main/webapp/generated">
                   <fileset
                     dir="${project.basedir}/node_modules/synapse-react-client/dist/umd"

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
@@ -27,7 +27,7 @@ import org.sagebionetworks.web.client.cache.SessionStorage;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.mvp.AppActivityMapper;
 import org.sagebionetworks.web.client.mvp.AppPlaceHistoryMapper;
@@ -467,7 +467,7 @@ public class GlobalApplicationStateImpl implements GlobalApplicationState {
       isToastContainerInitialized = true;
 
       Element toastContainer = RootPanel.get("toastContainer").getElement();
-      ReactNode component = React.createElementWithThemeContext(
+      ReactElement component = React.createElementWithThemeContext(
         SRC.SynapseComponents.SynapseToastContainer,
         null
       );

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
@@ -8,15 +8,19 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class React {
 
-  public static native <P extends ReactComponentProps> ReactNode createElement(
-    ReactComponentType<P> component,
+  public static native <
+    T extends ReactComponentType<P>, P extends ReactComponentProps
+  > ReactElement<T, P> createElement(
+    ReactComponentType<P> componentType,
     P props
   );
 
-  public static native <P extends ReactComponentProps> ReactNode createElement(
-    ReactComponentType<P> component,
+  public static native <
+    T extends ReactComponentType<P>, P extends ReactComponentProps
+  > ReactElement<T, P> createElement(
+    ReactComponentType<P> componentType,
     P props,
-    ReactNode... children
+    ReactElement<?, ?>... children
   );
 
   public static native <T> T createRef();
@@ -27,9 +31,9 @@ public class React {
    */
   @JsOverlay
   public static <
-    P extends ReactComponentProps
-  > ReactNode createElementWithThemeContext(
-    ReactComponentType<P> component,
+    T extends ReactComponentType<P>, P extends ReactComponentProps
+  > ReactElement<?, ?> createElementWithThemeContext(
+    ReactComponentType<P> componentType,
     P props
   ) {
     SynapseReactClientFullContextProviderProps emptyContext =
@@ -37,7 +41,7 @@ public class React {
         SynapseContextJsObject.create(null, false, false),
         null
       );
-    return createElementWithSynapseContext(component, props, emptyContext);
+    return createElementWithSynapseContext(componentType, props, emptyContext);
   }
 
   /**
@@ -45,7 +49,7 @@ public class React {
    * simplifies creating the wrapper.
    *
    * For setting props, use {@link SynapseReactClientFullContextPropsProvider}
-   * @param component
+   * @param componentType
    * @param props
    * @param wrapperProps
    * @param <P>
@@ -53,13 +57,13 @@ public class React {
    */
   @JsOverlay
   public static <
-    P extends ReactComponentProps
-  > ReactNode createElementWithSynapseContext(
-    ReactComponentType<P> component,
+    T extends ReactComponentType<P>, P extends ReactComponentProps
+  > ReactElement<?, ?> createElementWithSynapseContext(
+    T componentType,
     P props,
     SynapseReactClientFullContextProviderProps wrapperProps
   ) {
-    ReactNode componentElement = createElement(component, props);
+    ReactElement componentElement = createElement(componentType, props);
     return createElement(
       SRC.SynapseContext.FullContextProvider,
       wrapperProps,
@@ -67,16 +71,16 @@ public class React {
     );
   }
 
-  public static native ReactNode cloneElement(ReactNode element);
+  public static native ReactElement cloneElement(ReactElement element);
 
-  public static native ReactNode cloneElement(
-    ReactNode element,
+  public static native ReactElement cloneElement(
+    ReactElement element,
     ReactComponentProps props
   );
 
-  public static native ReactNode cloneElement(
-    ReactNode element,
+  public static native ReactElement cloneElement(
+    ReactElement element,
     ReactComponentProps props,
-    ReactNode... children
+    ReactElement... children
   );
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactComponentProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactComponentProps.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.jsinterop;
 import com.google.gwt.dom.client.Element;
 import jsinterop.annotations.JsConstructor;
 import jsinterop.annotations.JsFunction;
-import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
@@ -18,29 +17,6 @@ public class ReactComponentProps {
     void run(Element element);
   }
 
-  public JsArray<ReactNode<?>> children;
-
   // Either a ComponentRef or CallbackRef may be passed. A CallbackRef will be invoked when the ref is set.
   public Object ref;
-
-  @JsOverlay
-  public final void addChild(ReactNode<?> child) {
-    if (children == null) {
-      children = new JsArray<>();
-    }
-    children.push(child);
-  }
-
-  @JsOverlay
-  public final void clearChildren() {
-    children = new JsArray<>();
-  }
-
-  @JsOverlay
-  public final JsArray<ReactNode<?>> getChildren() {
-    if (children == null) {
-      children = new JsArray<>();
-    }
-    return children;
-  }
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOMRoot.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOMRoot.java
@@ -6,7 +6,7 @@ import jsinterop.annotations.JsType;
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class ReactDOMRoot {
 
-  public native void render(ReactNode element);
+  public native void render(ReactElement element);
 
   public native void unmount();
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactElement.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactElement.java
@@ -5,11 +5,15 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class ReactNode<T extends ReactComponentProps> {
+public class ReactElement<
+  T extends ReactComponentType<P>, P extends ReactComponentProps
+> {
+
+  public T type;
 
   @JsNullable
-  public T props;
+  public P props;
 
   @JsNullable
-  public ComponentRef ref;
+  public String key;
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/Grid.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/Grid.java
@@ -1,0 +1,103 @@
+package org.sagebionetworks.web.client.jsinterop.mui;
+
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.react.HasStyle;
+
+public class Grid extends HasStyle<GridProps> {
+
+  public Grid() {
+    super();
+    this.props = GridProps.create(false);
+  }
+
+  @Override
+  protected void onLoad() {
+    renderComponent();
+  }
+
+  private void renderComponent() {
+    ReactNode component = React.createElement(MaterialUI.Unstable_Grid2, props);
+    this.render(component);
+  }
+
+  public void setId(String id) {
+    props.id = id;
+    renderComponent();
+  }
+
+  public void setContainer(boolean container) {
+    props.container = container;
+    renderComponent();
+  }
+
+  public void setXs(int xs) {
+    props.xs = xs;
+    renderComponent();
+  }
+
+  public void setSm(int sm) {
+    props.sm = sm;
+    renderComponent();
+  }
+
+  public void setMd(int md) {
+    props.md = md;
+    renderComponent();
+  }
+
+  public void setLg(int lg) {
+    props.lg = lg;
+    renderComponent();
+  }
+
+  public void setXl(int xl) {
+    props.xl = xl;
+    renderComponent();
+  }
+
+  public void setXsOffset(int xsOffset) {
+    props.xsOffset = xsOffset;
+    renderComponent();
+  }
+
+  public void setSmOffset(int smOffset) {
+    props.smOffset = smOffset;
+    renderComponent();
+  }
+
+  public void setMdOffset(int mdOffset) {
+    props.mdOffset = mdOffset;
+    renderComponent();
+  }
+
+  public void setLgOffset(int lgOffset) {
+    props.lgOffset = lgOffset;
+    renderComponent();
+  }
+
+  public void setXlOffset(int xlOffset) {
+    props.xlOffset = xlOffset;
+    renderComponent();
+  }
+
+  public void setMt(String mt) {
+    props.mt = mt;
+    renderComponent();
+  }
+
+  public void setPl(String pl) {
+    props.pl = pl;
+    renderComponent();
+  }
+
+  public void setRowSpacing(String rowSpacing) {
+    props.rowSpacing = rowSpacing;
+    renderComponent();
+  }
+
+  public void setColumnSpacing(String columnSpacing) {
+    props.columnSpacing = columnSpacing;
+    renderComponent();
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/Grid.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/Grid.java
@@ -1,103 +1,91 @@
 package org.sagebionetworks.web.client.jsinterop.mui;
 
-import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
 import org.sagebionetworks.web.client.jsinterop.react.HasStyle;
 
-public class Grid extends HasStyle<GridProps> {
+public class Grid extends HasStyle<ReactComponentType<GridProps>, GridProps> {
 
   public Grid() {
-    super();
-    this.props = GridProps.create(false);
-  }
-
-  @Override
-  protected void onLoad() {
-    renderComponent();
-  }
-
-  private void renderComponent() {
-    ReactNode component = React.createElement(MaterialUI.Unstable_Grid2, props);
-    this.render(component);
+    super(MaterialUI.Unstable_Grid2, GridProps.create(false));
   }
 
   public void setId(String id) {
     props.id = id;
-    renderComponent();
+    this.render();
   }
 
   public void setContainer(boolean container) {
     props.container = container;
-    renderComponent();
+    this.render();
   }
 
   public void setXs(int xs) {
     props.xs = xs;
-    renderComponent();
+    this.render();
   }
 
   public void setSm(int sm) {
     props.sm = sm;
-    renderComponent();
+    this.render();
   }
 
   public void setMd(int md) {
     props.md = md;
-    renderComponent();
+    this.render();
   }
 
   public void setLg(int lg) {
     props.lg = lg;
-    renderComponent();
+    this.render();
   }
 
   public void setXl(int xl) {
     props.xl = xl;
-    renderComponent();
+    this.render();
   }
 
   public void setXsOffset(int xsOffset) {
     props.xsOffset = xsOffset;
-    renderComponent();
+    this.render();
   }
 
   public void setSmOffset(int smOffset) {
     props.smOffset = smOffset;
-    renderComponent();
+    this.render();
   }
 
   public void setMdOffset(int mdOffset) {
     props.mdOffset = mdOffset;
-    renderComponent();
+    this.render();
   }
 
   public void setLgOffset(int lgOffset) {
     props.lgOffset = lgOffset;
-    renderComponent();
+    this.render();
   }
 
   public void setXlOffset(int xlOffset) {
     props.xlOffset = xlOffset;
-    renderComponent();
+    this.render();
   }
 
   public void setMt(String mt) {
     props.mt = mt;
-    renderComponent();
+    this.render();
   }
 
   public void setPl(String pl) {
     props.pl = pl;
-    renderComponent();
+    this.render();
   }
 
   public void setRowSpacing(String rowSpacing) {
     props.rowSpacing = rowSpacing;
-    renderComponent();
+    this.render();
   }
 
   public void setColumnSpacing(String columnSpacing) {
     props.columnSpacing = columnSpacing;
-    renderComponent();
+    this.render();
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/GridProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/GridProps.java
@@ -1,0 +1,69 @@
+package org.sagebionetworks.web.client.jsinterop.mui;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+import org.sagebionetworks.web.client.jsinterop.PropsWithStyle;
+import org.sagebionetworks.web.client.jsinterop.React;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class GridProps extends PropsWithStyle {
+
+  @JsNullable
+  String id;
+
+  boolean container;
+
+  @JsNullable
+  int xs;
+
+  @JsNullable
+  int sm;
+
+  @JsNullable
+  int md;
+
+  @JsNullable
+  int lg;
+
+  @JsNullable
+  int xl;
+
+  @JsNullable
+  int xsOffset;
+
+  @JsNullable
+  int smOffset;
+
+  @JsNullable
+  int mdOffset;
+
+  @JsNullable
+  int lgOffset;
+
+  @JsNullable
+  int xlOffset;
+
+  @JsNullable
+  String mt;
+
+  @JsNullable
+  String pl;
+
+  @JsNullable
+  String rowSpacing;
+
+  @JsNullable
+  String columnSpacing;
+
+  @JsOverlay
+  public static GridProps create(boolean container) {
+    GridProps props = new GridProps();
+    props.ref = React.createRef();
+    if (container) {
+      props.container = true;
+    }
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/GridProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/GridProps.java
@@ -60,7 +60,7 @@ public class GridProps extends PropsWithStyle {
   @JsOverlay
   public static GridProps create(boolean container) {
     GridProps props = new GridProps();
-    props.ref = React.createRef();
+
     if (container) {
       props.container = true;
     }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/MaterialUI.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/mui/MaterialUI.java
@@ -1,0 +1,11 @@
+package org.sagebionetworks.web.client.jsinterop.mui;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+public class MaterialUI {
+
+  public static ReactComponentType<GridProps> Unstable_Grid2;
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/react/HasStyle.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/react/HasStyle.java
@@ -3,18 +3,21 @@ package org.sagebionetworks.web.client.jsinterop.react;
 import jsinterop.base.JsPropertyMap;
 import org.sagebionetworks.web.client.jsinterop.JsObject;
 import org.sagebionetworks.web.client.jsinterop.PropsWithStyle;
-import org.sagebionetworks.web.client.widget.ReactComponent;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
+import org.sagebionetworks.web.client.widget.ReactComponentV2;
 
 /**
  * Abstract class for React component widgets that have a style prop. The style prop for the component may be manipulated
  * to show/hide the component based on the current state of the widget.
  * @param <T> the prop type.
  */
-public abstract class HasStyle<T extends PropsWithStyle>
-  extends ReactComponent<T> {
+public abstract class HasStyle<
+  T extends ReactComponentType<P>, P extends PropsWithStyle
+>
+  extends ReactComponentV2<T, P> {
 
-  public HasStyle() {
-    super();
+  public HasStyle(T reactComponentType, P props) {
+    super(reactComponentType, props);
   }
 
   public void setStyle(JsPropertyMap<String> style) {
@@ -33,7 +36,7 @@ public abstract class HasStyle<T extends PropsWithStyle>
     } else {
       // Update the style prop to `display: none`.
       if (this.props == null) {
-        this.props = (T) JsPropertyMap.of();
+        this.props = (P) JsPropertyMap.of();
       }
 
       if (this.props.style == null) {

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/react/HasStyle.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/react/HasStyle.java
@@ -36,6 +36,10 @@ public abstract class HasStyle<T extends PropsWithStyle>
         this.props = (T) JsPropertyMap.of();
       }
 
+      if (this.props.style == null) {
+        this.props.style = (JsPropertyMap<String>) new JsObject();
+      }
+
       this.props.style.set("display", "none");
       setStyle(this.props.style);
     }

--- a/src/main/java/org/sagebionetworks/web/client/view/ACTAccessApprovalsViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ACTAccessApprovalsViewImpl.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.DateTimePicker;
@@ -26,6 +25,7 @@ import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseJSNIUtilsImpl;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.header.Header;
 
 public class ACTAccessApprovalsViewImpl implements ACTAccessApprovalsView {
@@ -82,7 +82,7 @@ public class ACTAccessApprovalsViewImpl implements ACTAccessApprovalsView {
   Anchor downloadLink;
 
   @UiField
-  Column accessorUI;
+  Grid accessorUI;
 
   private Presenter presenter;
   private Header headerWidget;

--- a/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -43,7 +43,7 @@ public class DataAccessManagementViewImpl implements DataAccessManagementView {
     headerWidget.refresh();
     Window.scrollTo(0, 0);
 
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ReviewerDashboard,
       null,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -90,7 +90,7 @@ public class DownViewImpl implements DownView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadCartPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -43,7 +43,7 @@ public class DownloadCartPageViewImpl implements DownloadCartPageView {
     DownloadCartPageProps props = DownloadCartPageProps.create(entityId -> {
       presenter.onViewSharingSettingsClicked(entityId);
     });
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadCartPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -61,7 +61,7 @@ public class FollowingPageViewImpl
 
   private void configure() {
     headerWidget.configure();
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubscriptionPage,
       EmptyProps.create(),
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
@@ -6,14 +6,12 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.FeatureFlagConfig;
 import org.sagebionetworks.web.client.FeatureFlagKey;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
-import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseHomepageProps;
 import org.sagebionetworks.web.client.jsinterop.SynapseHomepageV2Props;
@@ -54,7 +52,7 @@ public class HomeViewImpl extends Composite implements HomeView {
   @Override
   public void render() {
     scrollToTop();
-    ReactNode component;
+    ReactElement component;
 
     if (featureFlagConfig.isFeatureEnabled(FeatureFlagKey.HOMEPAGE_V2)) {
       SynapseHomepageV2Props props = SynapseHomepageV2Props.create(href -> {

--- a/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
@@ -14,7 +14,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.TermsAndConditionsProps;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -168,7 +168,7 @@ public class LoginViewImpl extends Composite implements LoginView {
       TermsAndConditionsProps props = TermsAndConditionsProps.create(
         this::onFormChange
       );
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.TermsAndConditions,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
@@ -34,7 +34,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Search;
 import org.sagebionetworks.web.client.place.Synapse;
@@ -603,7 +603,7 @@ public class ProfileViewImpl extends Composite implements ProfileView {
         "https://help.synapse.org/docs/Navigating-Synapse.2048557182.html#NavigatingSynapse-Favorites"
       );
       EmptyProps props = EmptyProps.create();
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.FavoritesPage,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/SignedTokenViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/SignedTokenViewImpl.java
@@ -12,9 +12,9 @@ import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.Modal;
-import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.repo.model.SignedTokenInterface;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.LoadingSpinner;
 import org.sagebionetworks.web.client.widget.header.Header;
 
@@ -36,7 +36,7 @@ public class SignedTokenViewImpl implements SignedTokenView {
   Button cancelUnsubscribe;
 
   @UiField
-  Row successUI;
+  Grid successUI;
 
   @UiField
   Heading successMessage;

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.dom.client.SpanElement;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.web.client.jsinterop.EntityTypeIconProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class EntityTypeIconImpl
@@ -23,7 +23,7 @@ public class EntityTypeIconImpl
   @Override
   public void configure(EntityType type) {
     EntityTypeIconProps props = EntityTypeIconProps.create(type);
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.EntityTypeIcon,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
@@ -8,7 +8,7 @@ import org.gwtbootstrap3.client.ui.constants.AlertType;
 import org.sagebionetworks.web.client.jsinterop.AlertButtonConfig;
 import org.sagebionetworks.web.client.jsinterop.FullWidthAlertProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class FullWidthAlert implements IsWidget {
@@ -60,7 +60,7 @@ public class FullWidthAlert implements IsWidget {
       isGlobal,
       alertType
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.FullWidthAlert,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
@@ -7,7 +7,7 @@ import org.gwtbootstrap3.client.ui.constants.Pull;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.jsinterop.HelpPopoverProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 /**
@@ -54,7 +54,7 @@ public class HelpWidget implements IsWidget {
       showCloseButton,
       className
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.HelpPopover,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.web.client.widget;
 import com.google.gwt.dom.client.SpanElement;
 import org.sagebionetworks.web.client.jsinterop.IconSvgProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class IconSvg extends ReactComponent {
@@ -24,7 +24,7 @@ public class IconSvg extends ReactComponent {
 
   private void renderComponent() {
     IconSvgProps props = IconSvgProps.create(icon, label);
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.IconSvg,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.sagebionetworks.web.client.jsinterop.AlertButtonConfig;
 import org.sagebionetworks.web.client.jsinterop.OrientationBannerProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class OrientationBanner implements IsWidget {
@@ -43,7 +43,7 @@ public class OrientationBanner implements IsWidget {
       primaryButtonConfig,
       secondaryButtonConfig
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.OrientationBanner,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponent.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponent.java
@@ -1,180 +1,55 @@
 package org.sagebionetworks.web.client.widget;
 
 import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.ComplexPanel;
-import com.google.gwt.user.client.ui.Widget;
-import java.util.ArrayList;
-import java.util.List;
-import jsinterop.base.JsPropertyMap;
-import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactComponentProps;
-import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
+import com.google.gwt.user.client.ui.FlowPanel;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
 import org.sagebionetworks.web.client.jsinterop.ReactDOMRoot;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 
 /**
- * Widget that manages the lifecycle of a React component. To use this widget, create a {@link ReactNode} using the
- * {@link React} API and call {@link #render(ReactNode)} to render the React component.
- * <p>
- * This widget also manages appending child elements if the associated React component can contain children. If all
- * child widgets use this class, then the child {@link ReactNode}s will be cloned and passed as children to the React
- * component. If any child of this component is a non-ReactComponent widget, then the child widgets will be injected
- * into the node found using the component's `ref`.
- * <p>
- * The root element defaults to a `div`, but can be changed (e.g. to a `span`) using the {@link #ReactComponent(String)} constructor.
- * <p>
- * This widget automatically unmounts the ReactComponent (if any) when this container is detached/unloaded.
+ * Automatically unmounts the ReactComponent (if any) inside this div when this container is detached/unloaded.
  */
-public class ReactComponent<T extends ReactComponentProps>
-  extends ComplexPanel
-  implements HasClickHandlers {
+public class ReactComponent extends FlowPanel implements HasClickHandlers {
 
   private ReactDOMRoot root;
-  private ReactComponentType<T> reactComponentType;
-  public T props;
-
-  private ReactNode<?> reactElement;
+  private ReactElement<?, ?> reactElement;
 
   public ReactComponent() {
-    this(DivElement.TAG);
+    super(DivElement.TAG);
   }
 
   public ReactComponent(String tag) {
-    setElement(Document.get().createElement(tag));
+    super(tag);
   }
 
-  private boolean allChildrenAreReactComponents() {
-    boolean allChildrenAreReactComponents = getChildren().size() > 0;
-    for (Widget w : getChildren()) {
-      if (!(w instanceof ReactComponent)) {
-        allChildrenAreReactComponents = false;
-        break;
-      }
-    }
-    return allChildrenAreReactComponents;
-  }
-
-  private boolean isRenderedAsReactComponentChild() {
-    return (
-      getParent() instanceof ReactComponent &&
-      ((ReactComponent<?>) getParent()).allChildrenAreReactComponents()
-    );
-  }
-
-  /**
-   * This method returns the root ReactComponent widget, which is the only place where this React tree is attached to the DOM.
-   */
-  private ReactComponent<?> getRootReactComponentWidget() {
-    if (isRenderedAsReactComponentChild()) {
-      return ((ReactComponent<?>) getParent()).getRootReactComponentWidget();
-    } else {
-      return this;
-    }
-  }
-
-  @Override
-  public HandlerRegistration addClickHandler(ClickHandler handler) {
-    return addDomHandler(handler, ClickEvent.getType());
-  }
-
-  private void maybeCreateRoot() {
-    if (root == null && !isRenderedAsReactComponentChild()) {
+  private void createRoot() {
+    if (root == null) {
       root = ReactDOM.createRoot(this.getElement());
     }
   }
 
-  /**
-   * Override the current props of the React component.
-   * Because re-rendering the component will use `React.cloneElement`, old props must be explicitly set to `undefined`
-   * to remove them.
-   */
-  public void overrideProps(T props) {
-    this.props = props;
-    this.rerender();
-  }
-
-  /**
-   * Injects the GWT children into the React component. If all children are ReactComponents,
-   * they will be cloned and added as React children.
-   */
-  private void injectChildWidgetsIntoComponent() {
-    if (this.allChildrenAreReactComponents()) {
-      // If all widget children are ReactNodes, clone the React component and add them as children
-      List<ReactComponent<?>> childWidgets = new ArrayList<>();
-      getChildren().forEach(w -> childWidgets.add(((ReactComponent<?>) w)));
-
-      ReactNode<?>[] childReactElements = childWidgets
-        .stream()
-        .map(ReactComponent::getReactElement)
-        .toArray(ReactNode<?>[]::new);
-
-      this.reactElement =
-        React.cloneElement(reactElement, this.props, childReactElements);
-    } else if (getChildren().size() > 0) {
-      // Create a callback ref that will allow us to inject the GWT children into the DOM
-      ReactComponentProps.CallbackRef refCallback = (Element node) -> {
-        if (node != null) {
-          // Once the DOM node is defined, inject each child
-          getChildren().forEach(w -> node.appendChild(w.getElement()));
-        }
-      };
-
-      if (this.props == null) {
-        this.props = (T) JsPropertyMap.of();
-      }
-      this.props.ref = refCallback;
-
-      this.reactElement =
-        React.cloneElement(
-          reactElement,
-          // Override the ref
-          this.props
-        );
-    }
-  }
-
-  public void render(ReactNode<?> reactNode) {
-    this.reactElement = reactNode;
-    maybeCreateRoot();
-    injectChildWidgetsIntoComponent();
-
-    // This component may be a React child of another component. If so, we must rerender the ancestor component(s) so
-    // that they use the new ReactElement created in this render step.
-    ReactComponent<?> componentToRender = getRootReactComponentWidget();
-    if (componentToRender == this) {
-      // Resynchronize with the DOM
-      root.render(this.reactElement);
-    } else {
-      // Walk up the tree to the parent and repeat rerendering
-      componentToRender.rerender();
-    }
-  }
-
-  @Override
-  public void setVisible(boolean visible) {
-    super.setVisible(visible);
-    // Re-render the element
-    this.rerender();
+  public void render(ReactElement<?, ?> reactElement) {
+    this.reactElement = reactElement;
+    createRoot();
+    root.render(reactElement);
   }
 
   @Override
   protected void onLoad() {
     super.onLoad();
-    maybeCreateRoot();
-    this.rerender();
+    createRoot();
+    if (reactElement != null) {
+      this.render(reactElement);
+    }
   }
 
   @Override
   protected void onUnload() {
-    super.onUnload();
     if (root != null) {
       // Asynchronously schedule unmounting the root to allow React to finish the current render cycle.
       // https://github.com/facebook/react/issues/25675
@@ -187,66 +62,18 @@ public class ReactComponent<T extends ReactComponentProps>
       };
       t.schedule(0);
     }
-  }
-
-  /**
-   * Adds a child widget.
-   *
-   * @param child the widget to be added
-   * @throws UnsupportedOperationException if this method is not supported (most
-   *           often this means that a specific overload must be called)
-   */
-  @Override
-  public void add(Widget child) {
-    // See implementation in com.google.gwt.user.client.ui.ComplexPanel
-
-    // Detach new child
-    child.removeFromParent();
-
-    // Logical attach
-    getChildren().add(child);
-
-    // Physical attach (via React API!)
-    if (reactElement != null) {
-      // Rerender if possible
-      this.render(reactElement);
-    }
-
-    // Adopt.
-    adopt(child);
+    super.onUnload();
   }
 
   @Override
-  public boolean remove(Widget w) {
-    // See implementation in ComplexPanel
-
-    // Validate.
-    if (w.getParent() != this) {
-      return false;
-    }
-    // Orphan.
-    try {
-      orphan(w);
-    } finally {
-      // Note - compared to ComplexPanel, we flipped logical and physical detach
-      // This is because our render implementation depends on logical attachment
-
-      // Logical detach.
-      getChildren().remove(w);
-
-      // Physical detach (via React API!)
-      this.rerender();
-    }
-    return true;
+  public void clear() {
+    // clear doesn't typically call onUnload, but we want to for this element.
+    this.onUnload();
+    super.clear();
   }
 
-  public ReactNode<?> getReactElement() {
-    return reactElement;
-  }
-
-  public void rerender() {
-    if (reactElement != null) {
-      this.render(reactElement);
-    }
+  @Override
+  public HandlerRegistration addClickHandler(ClickHandler handler) {
+    return addDomHandler(handler, ClickEvent.getType());
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.widget;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -8,6 +7,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.Widget;
 import java.util.ArrayList;
@@ -94,8 +94,16 @@ public abstract class ReactComponentV2<
 
   private void destroyRoot() {
     if (root != null) {
-      root.unmount();
-      root = null;
+      // Asynchronously schedule unmounting the root to allow React to finish the current render cycle.
+      // https://github.com/facebook/react/issues/25675
+      Timer t = new Timer() {
+        @Override
+        public void run() {
+          root.unmount();
+          root = null;
+        }
+      };
+      t.schedule(0);
     }
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
@@ -1,0 +1,259 @@
+package org.sagebionetworks.web.client.widget;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.HasClickHandlers;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.ComplexPanel;
+import com.google.gwt.user.client.ui.Widget;
+import java.util.ArrayList;
+import java.util.List;
+import jsinterop.base.JsPropertyMap;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentProps;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
+import org.sagebionetworks.web.client.jsinterop.ReactDOM;
+import org.sagebionetworks.web.client.jsinterop.ReactDOMRoot;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+
+/**
+ * Abstract widget that manages the lifecycle of a {@link React} component tree mounted with {@link ReactDOM}.
+ * <p>
+ * To use it, extend the class, supply a {@link ReactComponentType} and {@link ReactComponentProps} to the constructor,
+ * and call {@link #render()} to render the React component.
+ * <p>
+ * This widget also manages appending child elements if the associated React component can contain children. If all
+ * child widgets implement this class, then the child {@link ReactElement}s will be passed as children to the React
+ * component. If any child of this component is a non-ReactComponent widget, then all child widgets (including
+ * implementations of {@link ReactComponentV2}) will be injected into the node found using the component's `ref`.
+ * <p>
+ * The root element defaults to a `div`, but can be changed (e.g. to a `span`) using the
+ * {@link #ReactComponentV2(T, P, String)} constructor.
+ * <p>
+ * This widget automatically unmounts the ReactComponent (if any) when this container is detached/unloaded.
+ */
+public abstract class ReactComponentV2<
+  T extends ReactComponentType<P>, P extends ReactComponentProps
+>
+  extends ComplexPanel
+  implements HasClickHandlers {
+
+  private ReactDOMRoot root;
+  private final ReactComponentType<P> reactComponentType;
+  public P props;
+
+  private final ArrayList<Element> nonReactChildElements = new ArrayList<>();
+
+  public ReactComponentV2(T reactComponentType, P props) {
+    this(reactComponentType, props, DivElement.TAG);
+  }
+
+  public ReactComponentV2(T reactComponentType, P props, String tag) {
+    this.reactComponentType = reactComponentType;
+    this.props = props;
+    setElement(Document.get().createElement(tag));
+  }
+
+  /**
+   * If any children of this widget do not implement this class, then we will inject them into the DOM using the React
+   * component's `ref` prop. This method will update the props with a callback ref that handles appending the children
+   * to the DOM node on which the ref is forwarded.
+   */
+  private void maybeUpdatePropsWithCallbackRef() {
+    if (!this.allChildrenAreReactComponents() && getChildren().size() > 0) {
+      // Create a callback ref that will allow us to inject the GWT children into the DOM
+      ReactComponentProps.CallbackRef callbackRef = (Element node) -> {
+        if (node != null) {
+          // Once the DOM node is defined, inject each child
+          getChildren()
+            .forEach(w -> {
+              node.appendChild(w.getElement());
+              // Keep track of child elements to ensure they are removed before the next time this component renders
+              nonReactChildElements.add(w.getElement());
+            });
+        }
+      };
+
+      if (this.props == null) {
+        this.props = (P) JsPropertyMap.of();
+      }
+      // Override the ref
+      this.props.ref = callbackRef;
+    }
+  }
+
+  public ReactElement<T, P> createReactElement() {
+    if (!nonReactChildElements.isEmpty()) {
+      // Remove any non-React children that were previously injected
+      nonReactChildElements.forEach(Element::removeFromParent);
+      nonReactChildElements.clear();
+    }
+
+    maybeUpdatePropsWithCallbackRef();
+    return React.createElement(
+      reactComponentType,
+      props,
+      getChildReactElements()
+    );
+  }
+
+  /**
+   * @return true iff there are children, and all children are React components
+   */
+  private boolean allChildrenAreReactComponents() {
+    boolean allChildrenAreReactComponents = getChildren().size() > 0;
+    for (Widget w : getChildren()) {
+      if (!(w instanceof ReactComponentV2)) {
+        allChildrenAreReactComponents = false;
+        break;
+      }
+    }
+    return allChildrenAreReactComponents;
+  }
+
+  private boolean isRenderedAsReactComponentChild() {
+    return (
+      getParent() instanceof ReactComponentV2 &&
+      ((ReactComponentV2<?, ?>) getParent()).allChildrenAreReactComponents()
+    );
+  }
+
+  /**
+   * This method returns the root ReactComponent widget, which is the only place where this React tree is attached to the DOM.
+   */
+  private ReactComponentV2<?, ?> getRootReactComponentWidget() {
+    if (isRenderedAsReactComponentChild()) {
+      return (
+        (ReactComponentV2<?, ?>) getParent()
+      ).getRootReactComponentWidget();
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public HandlerRegistration addClickHandler(ClickHandler handler) {
+    return addDomHandler(handler, ClickEvent.getType());
+  }
+
+  private void synchronizeReactDomRoot() {
+    if (isRenderedAsReactComponentChild()) {
+      // This component is rendered as a child of another React component, so destroy the root if one exists
+      if (root != null) {
+        root.unmount();
+        root = null;
+      }
+    } else {
+      if (root == null) {
+        root = ReactDOM.createRoot(this.getElement());
+      }
+    }
+  }
+
+  private ReactElement<?, ?>[] getChildReactElements() {
+    if (this.allChildrenAreReactComponents()) {
+      // If all widget children are ReactNodes, get their ReactElements and add them as React children
+      List<ReactComponentV2<?, ?>> childWidgets = new ArrayList<>();
+      getChildren()
+        .forEach(w -> childWidgets.add(((ReactComponentV2<?, ?>) w)));
+
+      return childWidgets
+        .stream()
+        .map(ReactComponentV2::createReactElement)
+        .toArray(ReactElement<?, ?>[]::new);
+    } else {
+      return new ReactElement[0];
+    }
+  }
+
+  public void render() {
+    GWT.debugger();
+    synchronizeReactDomRoot();
+
+    // This component may be a React child of another component. If so, we must rerender the ancestor component(s) so
+    // that they use the new ReactElement created in this render step.
+    ReactComponentV2<?, ?> componentToRender = getRootReactComponentWidget();
+    componentToRender.synchronizeReactDomRoot();
+    componentToRender.root.render(componentToRender.createReactElement());
+  }
+
+  @Override
+  public void setVisible(boolean visible) {
+    super.setVisible(visible);
+    // Re-render the element
+    this.render();
+  }
+
+  @Override
+  protected void onLoad() {
+    super.onLoad();
+    this.render();
+  }
+
+  @Override
+  protected void onUnload() {
+    super.onUnload();
+    if (root != null) {
+      root.unmount();
+    }
+    root = null;
+  }
+
+  /**
+   * Adds a child widget.
+   *
+   * @param child the widget to be added
+   * @throws UnsupportedOperationException if this method is not supported (most
+   *           often this means that a specific overload must be called)
+   */
+  @Override
+  public void add(Widget child) {
+    // See implementation in com.google.gwt.user.client.ui.ComplexPanel
+
+    // Detach new child
+    child.removeFromParent();
+
+    // Logical attach
+    getChildren().add(child);
+
+    // Physical attach (via React API!)
+    this.render();
+
+    // Adopt.
+    adopt(child);
+  }
+
+  @Override
+  public boolean remove(Widget w) {
+    // See implementation in ComplexPanel
+
+    // Validate.
+    if (w.getParent() != this) {
+      return false;
+    }
+    // Orphan.
+    try {
+      orphan(w);
+    } finally {
+      // Note - compared to ComplexPanel, we flipped logical and physical detach
+      // This is because our render implementation depends on logical attachment
+
+      // Logical detach.
+      getChildren().remove(w);
+
+      // Re-render any ReactComponent children to physically detach them
+      if (w instanceof ReactComponentV2) {
+        GWT.debugger();
+        ((ReactComponentV2<?, ?>) w).render();
+      }
+
+      // Physical detach (via React API!)
+      this.render();
+    }
+    return true;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
@@ -187,13 +187,12 @@ public abstract class ReactComponentV2<
   }
 
   public void render() {
-    GWT.debugger();
     synchronizeReactDomRoot();
 
-    // This component may be a React child of another component. If so, we must rerender the ancestor component(s) so
-    // that they use the new ReactElement created in this render step.
+    // This component may be a React child of another component, so retrieve the root widget that renders this component tree.
     ReactComponentV2<?, ?> componentToRender = getRootReactComponentWidget();
     componentToRender.synchronizeReactDomRoot();
+    // Create a fresh ReactElement tree and render it
     componentToRender.root.render(componentToRender.createReactElement());
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementRelatedProjectsListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -32,7 +32,7 @@ public class AccessRequirementRelatedProjectsList implements IsWidget {
   public void configure(String accessRequirementId) {
     AccessRequirementRelatedProjectsListProps props =
       AccessRequirementRelatedProjectsListProps.create(accessRequirementId);
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AccessRequirementRelatedProjectsList,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
@@ -6,7 +6,7 @@ import org.sagebionetworks.repo.model.request.ReferenceList;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityHeaderTableProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -44,7 +44,7 @@ public class EntitySubjectsWidgetViewImpl implements EntitySubjectsWidgetView {
     ReferenceList entityReferences,
     boolean isEditable
   ) {
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityHeaderTable,
       EntityHeaderTableProps.create(
         entityReferences.getReferences(),

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorHandler;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.ReactRef;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -42,7 +42,7 @@ public class CreateManagedACTAccessRequirementStep3ViewImpl
   public void configure(String accessRequirementId) {
     componentRef = React.createRef();
     reactContainer.clear();
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AccessRequirementAclEditor,
       AccessRequirementAclEditorProps.create(
         accessRequirementId,

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -43,12 +43,12 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
         this.onCancel
       );
 
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateOrUpdateAccessRequirementWizard,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   public void configure(

--- a/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.BreadcrumbItem;
 import org.sagebionetworks.web.client.jsinterop.EntityPageBreadcrumbsProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -81,7 +81,7 @@ public class BreadcrumbViewImpl implements BreadcrumbView {
       items.toArray(new BreadcrumbItem[0])
     );
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageBreadcrumbs,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.java
@@ -6,11 +6,11 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.repo.model.discussion.DiscussionThreadOrder;
 import org.sagebionetworks.repo.model.table.SortDirection;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.table.v2.results.SortableTableHeaderImpl;
 import org.sagebionetworks.web.client.widget.table.v2.results.SortingListener;
 
@@ -21,7 +21,7 @@ public class DiscussionThreadListWidgetViewImpl
     extends UiBinder<Widget, DiscussionThreadListWidgetViewImpl> {}
 
   @UiField
-  Column threadListContainer;
+  Grid threadListContainer;
 
   @UiField
   Div synAlertContainer;

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
@@ -4,7 +4,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps;
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps.OnSearchResultsVisibleHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -21,7 +21,7 @@ public class ForumSearchWrapper extends ReactComponent {
       projectId,
       onSearchResultsVisible
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ForumSearch,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/SingleDiscussionThreadWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/SingleDiscussionThreadWidgetViewImpl.java
@@ -43,6 +43,9 @@ public class SingleDiscussionThreadWidgetViewImpl
   Div synAlertContainer;
 
   @UiField
+  Div discussionThreadMessageContainer;
+
+  @UiField
   Div refreshAlertContainer;
 
   @UiField
@@ -102,6 +105,9 @@ public class SingleDiscussionThreadWidgetViewImpl
   @Inject
   public SingleDiscussionThreadWidgetViewImpl(Binder binder) {
     widget = binder.createAndBindUi(this);
+    discussionThreadMessageContainer
+      .getElement()
+      .setAttribute("role", "article");
     deleteIcon.addClickHandler(
       new ClickHandler() {
         @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
@@ -33,7 +33,7 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.jsinterop.EntityBadgeIconsProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseReactClientFullContextProviderProps;
 import org.sagebionetworks.web.client.place.Synapse;
@@ -285,13 +285,13 @@ public class EntityBadgeViewImpl extends Composite implements EntityBadgeView {
     EntityBadgeIconsProps props,
     SynapseReactClientFullContextProviderProps providerProps
   ) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityBadgeIcons,
       props,
       providerProps
     );
 
-    iconsContainer.render(reactNode);
+    iconsContainer.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
@@ -22,12 +22,12 @@ public class EntityModalWidgetViewImpl implements EntityModalWidgetView {
 
   @Override
   public void renderComponent(EntityModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -26,12 +26,12 @@ public class EntityViewScopeEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(EntityViewScopeEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityViewScopeEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -40,7 +40,7 @@ public class ModifiedCreatedByWidgetViewImpl
 
   @Override
   public void setProps(CreatedByModifiedByProps props) {
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreatedByModifiedBy,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SqlDefinedTableEditorModalProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -26,12 +26,12 @@ public class SqlDefinedEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(SqlDefinedTableEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SqlDefinedTableEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
@@ -21,7 +21,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.EntityFinderProps;
 import org.sagebionetworks.web.client.jsinterop.EntityFinderScope;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsni.ReferenceJSNIObject;
 import org.sagebionetworks.web.client.widget.HelpWidget;
@@ -158,7 +158,7 @@ public class EntityFinderWidgetViewImpl implements EntityFinderWidgetView {
       treeOnly
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityFinder,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.view.DownViewImpl.ErrorPageType;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -92,7 +92,7 @@ public class StuAlertViewImpl implements StuAlertView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploaderViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploaderViewImpl.java
@@ -23,7 +23,6 @@ import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.DropDownMenu;
 import org.gwtbootstrap3.client.ui.FieldSet;
 import org.gwtbootstrap3.client.ui.Form;
@@ -35,14 +34,12 @@ import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.NavTabs;
 import org.gwtbootstrap3.client.ui.Progress;
 import org.gwtbootstrap3.client.ui.ProgressBar;
-import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.TabContent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TabPane;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.constants.ButtonSize;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
-import org.gwtbootstrap3.client.ui.constants.ColumnSize;
 import org.gwtbootstrap3.client.ui.constants.HeadingSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.InputType;
@@ -53,7 +50,6 @@ import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Italic;
 import org.gwtbootstrap3.client.ui.html.Span;
-import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.EventHandlerUtils;
@@ -61,11 +57,11 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SageImageBundle;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.jsinterop.ToastMessageOptions;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.JavaScriptCallback;
 import org.sagebionetworks.web.client.widget.entity.SharingAndDataUseConditionWidget;
-import org.sagebionetworks.web.client.widget.entity.menu.v3.Action;
 
 /**
  * Note on the form submission. This supports two form submission use cases. 1. Submit to Portal
@@ -531,8 +527,10 @@ public class UploaderViewImpl extends FlowPanel implements UploaderView {
       container.add(sharingDataUseWidget.asWidget());
     }
 
-    Row row = new Row();
-    Column col = new Column(ColumnSize.XS_12);
+    Grid row = new Grid();
+    row.setContainer(true);
+    Grid col = new Grid();
+    col.setXs(12);
     col.add(uploadBtn);
     if (showCancelButton) {
       col.add(cancelBtn);
@@ -665,8 +663,10 @@ public class UploaderViewImpl extends FlowPanel implements UploaderView {
     uploadPanel.add(uploadDestinationContainer);
     uploadPanel.add(formPanel);
 
-    Row row = new Row();
-    Column col = new Column(ColumnSize.XS_12);
+    Grid row = new Grid();
+    row.setContainer(true);
+    Grid col = new Grid();
+    col.setXs(12);
     col.add(spinningProgressContainer);
     col.add(progressContainer);
     row.add(col);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadConfirmationProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -72,7 +72,7 @@ public class AddToDownloadListV2Impl implements AddToDownloadListV2 {
       folderId,
       onClose
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadConfirmation,
       editorProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityPageTitleBarProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -22,12 +22,12 @@ public class BasicTitleBarViewImpl implements BasicTitleBarView {
 
   @Override
   public void setProps(EntityPageTitleBarProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageTitleBar,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponentContainer.render(reactNode);
+    reactComponentContainer.render(reactElement);
   }
 
   interface BasicTitleBarViewImplUiBinder

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SkeletonButtonProps;
 import org.sagebionetworks.web.client.jsinterop.entity.actionmenu.EntityActionMenuPropsJsInterop;
@@ -52,7 +52,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   }
 
   private void renderMenuComponent(EntityActionMenuPropsJsInterop props) {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityActionMenu,
       props,
       propsProvider.getJsInteropContextProps()
@@ -61,7 +61,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   }
 
   private void renderLoaderComponent() {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SkeletonButton,
       SkeletonButtonProps.create("Tools Menu Placeholder"),
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
@@ -9,7 +9,7 @@ import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HtmlPreviewProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -47,7 +47,7 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   public void configure(String createdBy, String rawHtml) {
     HtmlPreviewProps props = HtmlPreviewProps.create(createdBy, rawHtml);
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HtmlPreview,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.IDUReportProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -28,7 +28,7 @@ public class IntendedDataUseReportWidgetViewImpl
   public void render(String accessRequirementId) {
     IDUReportProps props = IDUReportProps.create(accessRequirementId);
 
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.IDUReport,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
@@ -165,7 +165,7 @@ public class PlotlyWidgetViewImpl implements PlotlyWidgetView {
 			};
 
 			var component = $wnd.React.createElement(plot, props)
-			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(component);
+			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(component);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
@@ -13,7 +13,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HasAccessProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -194,7 +194,7 @@ public class RestrictionWidgetViewImpl implements RestrictionWidgetView {
       null,
       null
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HasAccess,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.java
@@ -5,6 +5,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.SimplePanel;
@@ -12,13 +13,13 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.ModalBody;
 import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.sagebionetworks.web.client.DisplayConstants;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.LoadingSpinner;
 import org.sagebionetworks.web.client.widget.user.UserBadge;
 
@@ -39,13 +40,13 @@ public class FilesTabViewImpl implements FilesTabView {
   SimplePanel addToDownloadListWidgetContainer;
 
   @UiField
-  Column filePreviewContainer;
+  Grid filePreviewContainer;
 
   @UiField
   Div filePreviewWidgetContainer;
 
   @UiField
-  Column fileProvenanceContainer;
+  FlowPanel fileProvenanceContainer;
 
   @UiField
   Div fileProvenanceGraphContainer;
@@ -75,7 +76,7 @@ public class FilesTabViewImpl implements FilesTabView {
   Div discussionThreadsContainer;
 
   @UiField
-  Column discussionContainer;
+  FlowPanel discussionContainer;
 
   @UiField
   Text discussionText;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.java
@@ -8,10 +8,10 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.Anchor;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Span;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.FullWidthAlert;
 
 public class TablesTabViewImpl implements TablesTabView {
@@ -39,7 +39,7 @@ public class TablesTabViewImpl implements TablesTabView {
   SimplePanel synapseAlertContainer;
 
   @UiField
-  Column provenanceContainer;
+  Grid provenanceContainer;
 
   @UiField
   Div provenanceContainerHighlightBox;

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EvaluationCardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.evaluation.EvaluationRowWidget.EvaluationActionHandler;
@@ -81,7 +81,7 @@ public class AdministerEvaluationsListViewImpl
     container.addStyleName("margin-top-50");
     rows.add(container);
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationCard,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.EvaluationEditorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -66,7 +66,7 @@ public class EvaluationEditorReactComponentPage extends Composite {
       entityId,
       this.onPageBack
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationEditorPage,
       editorProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AvailableEvaluationQueueListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -28,7 +28,7 @@ public class EvaluationListViewImpl implements EvaluationListView {
 
   @Override
   public void configure(List<Evaluation> list, boolean isSelectable) {
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AvailableEvaluationQueueList,
       AvailableEvaluationQueueListProps.create(
         list,

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationSubmitterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationSubmitterViewImpl.java
@@ -452,7 +452,7 @@ public class EvaluationSubmitterViewImpl implements EvaluationSubmitterView {
 
 			var component = $wnd.React.createElement($wnd.SRC.SynapseComponents.EntityForm, props, null);
 			var wrapper = $wnd.React.createElement($wnd.SRC.SynapseContext.FullContextProvider, wrapperProps, component);
-            reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(wrapper);
+            reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(wrapper);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SubmissionViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -26,12 +26,12 @@ public class SubmissionViewScopeEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(SubmissionViewScopeEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubmissionViewScopeEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
@@ -10,7 +10,7 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseFooterProps;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -91,7 +91,7 @@ public class FooterViewImpl implements FooterView, IsWidget {
           globalAppState.refreshPage();
         }
       );
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.SynapseFooter,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.CookieNotificationProps;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseNavDrawerProps;
 import org.sagebionetworks.web.client.place.Home;
@@ -110,7 +110,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
     CookieNotificationProps props = CookieNotificationProps.create(prefs -> {
       rerenderGoogleAnalytics();
     });
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CookiesNotification,
       props,
       propsProvider.getJsInteropContextProps()
@@ -125,7 +125,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
 
   private void rerenderGoogleAnalytics() {
     EmptyProps props = EmptyProps.create();
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.GoogleAnalytics,
       props,
       propsProvider.getJsInteropContextProps()
@@ -144,7 +144,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapseNavDrawer,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.LoginPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Profile;
 import org.sagebionetworks.web.client.place.Synapse.ProfileArea;
@@ -58,7 +58,7 @@ public class LoginWidgetViewImpl implements LoginWidgetView, IsWidget {
           null,
           () -> this.postLogin()
         );
-        ReactNode component = React.createElementWithSynapseContext(
+        ReactElement component = React.createElementWithSynapseContext(
           SRC.SynapseComponents.LoginPage,
           props,
           propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
@@ -10,7 +10,7 @@ import org.sagebionetworks.web.client.SynapseProperties;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.PageProgressProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -60,7 +60,7 @@ public class PageProgressWidgetViewImpl
       () -> forwardBtnCallback.invoke(),
       isForwardActive
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.PageProgress,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
@@ -14,7 +14,6 @@ import com.google.inject.Inject;
 import java.util.List;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.Tooltip;
@@ -31,6 +30,7 @@ import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactNode;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.UserProfileLinksProps;
+import org.sagebionetworks.web.client.jsinterop.mui.Grid;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.shared.WebConstants;
 
@@ -96,13 +96,13 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
   Anchor changePasswordLink;
 
   @UiField
-  Column orcIDContainer;
+  Grid orcIDContainer;
 
   @UiField
   Anchor orcIdLink;
 
   @UiField
-  Column accountTypeContainer;
+  Grid accountTypeContainer;
 
   @UiField
   ReactComponent accountLevelBadgesContainer;
@@ -114,7 +114,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
   ReactComponent userProfileLinksReactComponentContainer;
 
   @UiField
-  Column emailAddressContainer;
+  Grid emailAddressContainer;
 
   @UiField
   Div commandsContainer;
@@ -134,11 +134,11 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
     CookieProvider cookies,
     SynapseJavascriptClient jsClient
   ) {
-    widget = binder.createAndBindUi(this);
     this.jsniUtils = jsniUtils;
     this.propsProvider = propsProvider;
     this.cookies = cookies;
     this.jsClient = jsClient;
+    widget = binder.createAndBindUi(this);
     editProfileButton.addClickHandler(event -> {
       Window.open(WebConstants.ONESAGE_ACCOUNT_SETTINGS_URL, "_blank", "");
     });

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
@@ -27,7 +27,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.AccountLevelBadgesProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.UserProfileLinksProps;
 import org.sagebionetworks.web.client.jsinterop.mui.Grid;
@@ -249,7 +249,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
 
   @Override
   public void setOwnerId(String userId) {
-    ReactNode accountLevelBadgesComponent =
+    ReactElement accountLevelBadgesComponent =
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.AccountLevelBadges,
         AccountLevelBadgesProps.create(userId),
@@ -259,7 +259,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
     setAccountTypeVisibility(Long.parseLong(userId));
 
     UserProfileLinksProps props = UserProfileLinksProps.create(userId);
-    ReactNode profileLinksComponent = React.createElementWithSynapseContext(
+    ReactElement profileLinksComponent = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserProfileLinks,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps;
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps.OnUpdateJavaScriptObject;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -57,7 +57,7 @@ public class ProvenanceWidgetViewImpl
       nodesListener,
       edgesListener
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ProvenanceGraph,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
@@ -7,20 +7,20 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityAclEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class EntityAccessControlListModalWidgetImpl
   implements EntityAccessControlListModalWidget {
 
-  private final ReactComponent<EntityAclEditorModalProps> reactComponent;
+  private final ReactComponent reactComponent;
   private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   private EntityAclEditorModalProps componentProps;
 
   @Inject
   EntityAccessControlListModalWidgetImpl(
-    ReactComponent<EntityAclEditorModalProps> reactComponent,
+    ReactComponent reactComponent,
     SynapseReactClientFullContextPropsProvider propsProvider
   ) {
     this.reactComponent = reactComponent;
@@ -54,7 +54,7 @@ public class EntityAccessControlListModalWidgetImpl
   }
 
   private void renderComponent() {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       EntityAclEditorModal,
       componentProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/statistics/StatisticsPlotWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/statistics/StatisticsPlotWidgetViewImpl.java
@@ -96,7 +96,7 @@ public class StatisticsPlotWidgetViewImpl
 
 			var component = $wnd.React.createElement($wnd.SRC.SynapseComponents.StatisticsPlot, props, null)
 			var wrapper = $wnd.React.createElement($wnd.SRC.SynapseContext.FullContextProvider, wrapperProps, component)
-			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(wrapper);
+			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(wrapper);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
@@ -6,7 +6,7 @@ import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQuery
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryResultBundleCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnViewSharingSettingsHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -30,7 +30,7 @@ public class QueryWrapperPlotNav extends ReactComponent {
       hideSqlEditorControl
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.QueryWrapperPlotNav,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.web.client.widget.table.explore;
 
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.StandaloneQueryWrapperProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -14,7 +14,7 @@ public class StandaloneQueryWrapper extends ReactComponent {
     String sql
   ) {
     StandaloneQueryWrapperProps props = StandaloneQueryWrapperProps.create(sql);
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.StandaloneQueryWrapper,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateTableViewWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -29,12 +29,12 @@ public class CreateTableViewWizard implements IsWidget {
   }
 
   private void renderComponent(CreateTableViewWizardProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateTableViewWizard,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   public void configure(

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
@@ -19,7 +19,7 @@ import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQuery
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryResultBundleCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnViewSharingSettingsHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.FullWidthAlert;
@@ -188,7 +188,7 @@ public class TableEntityWidgetViewImpl
   public void setItemsEditorVisible(boolean visible) {
     itemsEditorContainer.setVisible(visible);
     if (visible) {
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.DatasetItemsEditor,
         this.presenter.getItemsEditorProps(),
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.TableColumnSchemaEditorProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -27,12 +27,12 @@ public class ColumnModelsEditorWidgetViewImpl
 
   @Override
   public void renderComponent(TableColumnSchemaEditorProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TableColumnSchemaEditor,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.web.client.widget.trash;
 
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -11,7 +11,7 @@ public class TrashCanList extends ReactComponent {
   public TrashCanList(
     SynapseReactClientFullContextPropsProvider contextPropsProvider
   ) {
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TrashCanList,
       null,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.JSON;
 import org.sagebionetworks.web.client.jsinterop.MenuAction;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.UserCardProps;
 import org.sagebionetworks.web.client.place.Profile;
@@ -118,7 +118,7 @@ public class UserBadgeViewImpl extends Div implements UserBadgeView {
       extraCssClassStrings
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserCard,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/resources/org/sagebionetworks/web/client/view/ACTAccessApprovalsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ACTAccessApprovalsViewImpl.ui.xml
@@ -1,8 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bd="urn:import:org.gwtbootstrap3.extras.datetimepicker.client.ui"
@@ -45,8 +45,8 @@
     <bh:Div
       addStyleNames="margin-top-30 margin-left-35 min-height-400 margin-right-10"
     >
-      <b:Row>
-        <b:Column size="SM_4">
+      <MUI:Grid container="true">
+        <MUI:Grid sm="4">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -65,8 +65,8 @@
               <bh:Div ui:field="submitterSelectContainer" />
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-        <b:Column size="SM_4" ui:field="accessorUI">
+        </MUI:Grid>
+        <MUI:Grid sm="4" ui:field="accessorUI">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -85,8 +85,8 @@
               <bh:Div ui:field="accessorSelectContainer" />
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-        <b:Column size="SM_4">
+        </MUI:Grid>
+        <MUI:Grid sm="4">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -114,8 +114,8 @@
               />
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-      </b:Row>
+        </MUI:Grid>
+      </MUI:Grid>
       <b:Button
         ui:field="exportButton"
         text="Export CSV"

--- a/src/main/resources/org/sagebionetworks/web/client/view/ACTDataAccessSubmissionsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ACTDataAccessSubmissionsViewImpl.ui.xml
@@ -1,11 +1,10 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bd="urn:import:org.gwtbootstrap3.extras.datetimepicker.client.ui"
 >
   <bh:Div>
     <bh:Div addStyleNames="pageHeader">
@@ -98,8 +97,8 @@
     <bh:Div
       addStyleNames="margin-top-30 margin-left-35 min-height-400 margin-right-10"
     >
-      <b:Row>
-        <b:Column size="SM_4">
+      <MUI:Grid container="true">
+        <MUI:Grid sm="4">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -124,8 +123,8 @@
               </b:ButtonGroup>
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-        <b:Column size="SM_4">
+        </MUI:Grid>
+        <MUI:Grid sm="4">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -144,9 +143,9 @@
               <bh:Div ui:field="accessorSelectContainer" />
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-        <b:Column size="SM_4" />
-      </b:Row>
+        </MUI:Grid>
+        <MUI:Grid sm="4" />
+      </MUI:Grid>
       <bh:Hr />
       <!-- table header -->
       <t:Table

--- a/src/main/resources/org/sagebionetworks/web/client/view/ACTViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ACTViewImpl.ui.xml
@@ -1,8 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
@@ -18,8 +18,8 @@
     <bh:Div
       addStyleNames="margin-top-30 margin-left-35 min-height-400 margin-right-10"
     >
-      <b:Row>
-        <b:Column size="SM_6">
+      <MUI:Grid container="true">
+        <MUI:Grid sm="6">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -44,8 +44,8 @@
               </b:ButtonGroup>
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-        <b:Column size="SM_6">
+        </MUI:Grid>
+        <MUI:Grid sm="6">
           <b:Panel
             addStyleNames="margin-left-10 margin-right-10 margin-bottom-20"
           >
@@ -64,8 +64,8 @@
               <bh:Div ui:field="userSelectContainer" />
             </b:PanelBody>
           </b:Panel>
-        </b:Column>
-      </b:Row>
+        </MUI:Grid>
+      </MUI:Grid>
       <bh:Hr />
       <!-- table header -->
       <t:Table

--- a/src/main/resources/org/sagebionetworks/web/client/view/AccountViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/AccountViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/ChallengeOverviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ChallengeOverviewViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/ChangeUsernameViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ChangeUsernameViewImpl.ui.xml
@@ -2,9 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 >
   <g:HTMLPanel>
     <div class="row margin-top-left-10 margin-right-15 margin-bottom-20">
@@ -17,20 +14,16 @@
 							carefully choose yours.
             </h4>
             <g:TextBox ui:field="username" addStyleNames="form-control" />
-            <b:Row>
-              <b:Column size="XS_9">
-                <g:SimplePanel
-                  ui:field="errorContainer"
-                  addStyleNames="left margin-top-10"
-                />
-              </b:Column>
-              <b:Column size="XS_3">
-                <g:Button
-                  ui:field="changeUsernameButton"
-                  styleName="right btn btn-primary btn-lg margin-top-10"
-                />
-              </b:Column>
-            </b:Row>
+            <g:Button
+              ui:field="changeUsernameButton"
+              styleName="right btn btn-primary btn-lg margin-top-10"
+            />
+
+            <g:SimplePanel
+              ui:field="errorContainer"
+              addStyleNames="left margin-top-10"
+              width="100%"
+            />
           </div>
         </div>
       </div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/ComingSoonViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ComingSoonViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"

--- a/src/main/resources/org/sagebionetworks/web/client/view/DataAccessApprovalTokenViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/DataAccessApprovalTokenViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/DownViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/DownViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <w:ReactComponent ui:field="srcDownContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/view/EmailInvitationViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/EmailInvitationViewImpl.ui.xml
@@ -3,6 +3,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -12,36 +13,38 @@
       size="31px"
       addStyleNames="center-block margin-top-100"
     />
-    <b:Column size="XS_12, MD_6" offset="MD_3">
-      <g:SimplePanel ui:field="synapseAlertContainer" />
-      <bh:Div ui:field="notLoggedInContainer" visible="false">
-        <b:Heading
-          ui:field="invitationTitle"
-          size="H4"
-          addStyleNames="margin-top-20"
-        />
-        <b:BlockQuote ui:field="invitationMessageWrapper" visible="false">
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12" md="6" mdOffset="3">
+        <g:SimplePanel ui:field="synapseAlertContainer" />
+        <bh:Div ui:field="notLoggedInContainer" visible="false">
           <b:Heading
-            ui:field="invitationMessage"
-            size="H5"
+            ui:field="invitationTitle"
+            size="H4"
+            addStyleNames="margin-top-20"
+          />
+          <b:BlockQuote ui:field="invitationMessageWrapper" visible="false">
+            <b:Heading
+              ui:field="invitationMessage"
+              size="H5"
+              addStyleNames="margin-top-10"
+            />
+          </b:BlockQuote>
+          <b:Button
+            ui:field="registerButton"
+            text="Register for an account"
+            size="LARGE"
+            width="100%"
+            type="SUCCESS"
             addStyleNames="margin-top-10"
           />
-        </b:BlockQuote>
-        <b:Button
-          ui:field="registerButton"
-          text="Register for an account"
-          size="LARGE"
-          width="100%"
-          type="SUCCESS"
-          addStyleNames="margin-top-10"
-        />
-        <bh:Div
-          addStyleNames="lightGreyBackground padding-15 center font-size-16"
-        >
-          <bh:Span text="Already have an account?" marginRight="10" />
-          <b:Anchor text="Sign in" ui:field="loginLink" />
+          <bh:Div
+            addStyleNames="lightGreyBackground padding-15 center font-size-16"
+          >
+            <bh:Span text="Already have an account?" marginRight="10" />
+            <b:Anchor text="Sign in" ui:field="loginLink" />
+          </bh:Div>
         </bh:Div>
-      </bh:Div>
-    </b:Column>
+      </MUI:Grid>
+    </MUI:Grid>
   </b:Container>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/view/EntityViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/EntityViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/ErrorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ErrorViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/EvaluationViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/EvaluationViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/HelpViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/HelpViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/MapViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/MapViewImpl.ui.xml
@@ -2,12 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:HTMLPanel>
     <div class="color-line" />

--- a/src/main/resources/org/sagebionetworks/web/client/view/NewAccountViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/NewAccountViewImpl.ui.xml
@@ -1,28 +1,26 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div addStyleNames="container" marginTop="30">
     <b:Heading size="H3" text="Register with Synapse" />
-    <b:Row>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>First Name</b:FormLabel>
           <b:TextBox ui:field="firstNameField" />
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+      </MUI:Grid>
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>Last Name</b:FormLabel>
           <b:TextBox ui:field="lastNameField" />
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+      </MUI:Grid>
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>Email Address</b:FormLabel>
           <b:Icon
@@ -31,8 +29,8 @@
           />
           <b:TextBox ui:field="emailField" readOnly="true" />
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+      </MUI:Grid>
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>Username</b:FormLabel>
           <b:Icon
@@ -46,8 +44,8 @@
             must also be at least 3 characters long.
           </bh:Paragraph>
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+      </MUI:Grid>
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>Password</b:FormLabel>
           <b:Icon
@@ -59,8 +57,8 @@
             Passwords must be at least 8 characters.
           </bh:Paragraph>
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="MD_4 SM_6 XS_12" marginTop="30">
+      </MUI:Grid>
+      <MUI:Grid xs="12" sm="6" md="4" mt="30px">
         <b:FormGroup>
           <b:FormLabel>Confirm Password</b:FormLabel>
           <b:Icon
@@ -69,8 +67,8 @@
           />
           <b:Input type="PASSWORD" ui:field="password2Field" />
         </b:FormGroup>
-      </b:Column>
-    </b:Row>
+      </MUI:Grid>
+    </MUI:Grid>
     <bh:Div ui:field="synAlertContainer" />
     <bh:Div ui:field="pageProgressContainer" />
   </bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/OAuthClientEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/OAuthClientEditorViewImpl.ui.xml
@@ -2,10 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bb="urn:import:org.gwtbootstrap3.client.ui"
 >
   <g:HTMLPanel>
     <div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/PasswordResetSignedTokenViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/PasswordResetSignedTokenViewImpl.ui.xml
@@ -2,11 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="max-width-350 center-in-div form-horizontal">
     <b:Heading

--- a/src/main/resources/org/sagebionetworks/web/client/view/PeopleSearchViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/PeopleSearchViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/PlaceViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/PlaceViewImpl.ui.xml
@@ -1,10 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <bh:Div addStyleNames="pageHeader" marginBottom="10">

--- a/src/main/resources/org/sagebionetworks/web/client/view/ProfileViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/ProfileViewImpl.ui.xml
@@ -4,6 +4,7 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:tr="urn:import:org.sagebionetworks.web.client.widget.table.v2.results"
@@ -80,9 +81,9 @@
                         text="Create a New Project"
                       />
                     </div>
-                    <b:Column size="XS_12">
+                    <MUI:Grid xs="12">
                       <g:FlowPanel ui:field="projectSynAlertPanel" />
-                    </b:Column>
+                    </MUI:Grid>
                   </div>
                   <div
                     class="panel panel-default padding-5 min-height-200"
@@ -226,9 +227,9 @@
                         text="Create a New Team"
                       />
                     </div>
-                    <b:Column size="XS_12">
+                    <MUI:Grid xs="12">
                       <g:SimplePanel ui:field="teamSynAlertPanel" />
-                    </b:Column>
+                    </MUI:Grid>
                   </div>
                   <g:FlowPanel ui:field="openInvitesContainer" />
                   <div

--- a/src/main/resources/org/sagebionetworks/web/client/view/PublicProfileViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/PublicProfileViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/SearchViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SearchViewImpl.ui.xml
@@ -2,8 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:HTMLPanel>
@@ -15,16 +15,16 @@
         <div class="col-md-9 col-md-push-3">
           <div class="row">
             <div class="col-md-12">
-              <b:Row>
-                <b:Column size="MD_9">
+              <MUI:Grid container="true">
+                <MUI:Grid md="9">
                   <b:InputGroup width="100%">
                     <b:TextBox
                       ui:field="searchField"
                       addStyleNames="form-control input-lg search-textbox"
                     />
                   </b:InputGroup>
-                </b:Column>
-                <b:Column size="MD_3">
+                </MUI:Grid>
+                <MUI:Grid md="3">
                   <b:Button
                     ui:field="searchButton"
                     block="true"
@@ -32,8 +32,8 @@
                     text="Search"
                     icon="SEARCH"
                   />
-                </b:Column>
-              </b:Row>
+                </MUI:Grid>
+              </MUI:Grid>
             </div>
           </div>
           <div class="row">

--- a/src/main/resources/org/sagebionetworks/web/client/view/SignedTokenViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SignedTokenViewImpl.ui.xml
@@ -3,6 +3,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -58,24 +59,24 @@
       </b:Modal>
       <bh:Div ui:field="otherUI">
         <!-- Success UI -->
-        <b:Row ui:field="successUI">
-          <b:Column size="XS_12, MD_6" offset="MD_3">
+        <MUI:Grid container="true" ui:field="successUI">
+          <MUI:Grid xs="12" md="6" mdOffset="3">
             <bh:Div>
               <b:Alert type="SUCCESS">
                 <b:Heading size="H3" ui:field="successMessage" />
               </b:Alert>
             </bh:Div>
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
 
         <!-- Error UI and standard ok button -->
-        <b:Row>
-          <b:Column size="XS_12, MD_6" offset="MD_3">
+        <MUI:Grid container="true">
+          <MUI:Grid xs="12" md="6" mdOffset="3">
             <g:SimplePanel ui:field="synapseAlertContainer" />
-          </b:Column>
-        </b:Row>
-        <b:Row addStyleNames="margin-top-60">
-          <b:Column size="XS_12, MD_6" offset="MD_3">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true" addStyleNames="margin-top-60">
+          <MUI:Grid xs="12" md="6" mdOffset="3">
             <b:Button
               ui:field="okButton"
               type="PRIMARY"
@@ -83,8 +84,8 @@
               size="LARGE"
               pull="RIGHT"
             />
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
       </bh:Div>
     </b:Container>
   </bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/SubscriptionViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SubscriptionViewImpl.ui.xml
@@ -1,53 +1,47 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <bh:Div
       addStyleNames="margin-top-30 margin-left-35 min-height-400 margin-right-10"
     >
-      <b:Row>
-        <b:Column size="XS_12">
-          <bh:Div ui:field="synAlertContainer" />
-          <b:Heading
-            size="H2"
-            text="Notification Settings"
-            addStyleNames="margin-top-30"
-          />
-          <bh:Div addStyleNames="margin-left-15 margin-top-20">
-            <bh:Div ui:field="topicWidgetContainer" />
+      <bh:Div ui:field="synAlertContainer" />
+      <b:Heading
+        size="H2"
+        text="Notification Settings"
+        addStyleNames="margin-top-30"
+      />
 
-            <b:Radio
-              ui:field="followButton"
-              text="Following"
-              name="subscriptionState"
-              addStyleNames="font-size-24"
-            />
-            <b:Heading
-              size="H5"
-              text="You will receive notifications on this topic"
-              addStyleNames="margin-left-20 margin-right-10 margin-bottom-20"
-            />
-            <b:Radio
-              ui:field="unfollowButton"
-              text="Not following"
-              name="subscriptionState"
-              addStyleNames="font-size-24"
-            />
-            <b:Heading
-              size="H5"
-              text="You will not receive notifications on this topic"
-              addStyleNames="margin-left-20 margin-right-10 margin-bottom-20"
-            />
-            <!-- <b:Anchor ui:field="notificationCenterLink" text="Manage all notifications" 
+      <bh:Div addStyleNames="margin-left-15 margin-top-20">
+        <bh:Div ui:field="topicWidgetContainer" />
+        <b:Radio
+          ui:field="followButton"
+          text="Following"
+          name="subscriptionState"
+          addStyleNames="font-size-24"
+        />
+        <b:Heading
+          size="H5"
+          text="You will receive notifications on this topic"
+          addStyleNames="margin-left-20 margin-right-10 margin-bottom-20"
+        />
+        <b:Radio
+          ui:field="unfollowButton"
+          text="Not following"
+          name="subscriptionState"
+          addStyleNames="font-size-24"
+        />
+        <b:Heading
+          size="H5"
+          text="You will not receive notifications on this topic"
+          addStyleNames="margin-left-20 margin-right-10 margin-bottom-20"
+        />
+        <!-- <b:Anchor ui:field="notificationCenterLink" text="Manage all notifications"
 							addStyleNames="margin-top-10 font-size-24"/> -->
-          </bh:Div>
-        </b:Column>
-      </b:Row>
+      </bh:Div>
     </bh:Div>
   </bh:Div>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/view/SynapseForumViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SynapseForumViewImpl.ui.xml
@@ -1,9 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b3="urn:import:org.gwtbootstrap3.extras.toggleswitch.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/SynapseStandaloneWikiViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SynapseStandaloneWikiViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
@@ -13,15 +12,8 @@
   <bh:Div>
     <b:Container>
       <b:Container fluid="true">
-        <b:Row>
-          <b:Column size="XS_12">
-            <bh:Div
-              ui:field="markdownContainer"
-              addStyleNames="min-height-400"
-            />
-            <bh:Div ui:field="synAlertContainer" />
-          </b:Column>
-        </b:Row>
+        <bh:Div ui:field="markdownContainer" addStyleNames="min-height-400" />
+        <bh:Div ui:field="synAlertContainer" />
       </b:Container>
     </b:Container>
   </bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/SynapseWikiViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/SynapseWikiViewImpl.ui.xml
@@ -2,15 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
-  <bh:Div>
-    <b:Row>
-      <b:Column size="XS_12">
-        <g:FlowPanel ui:field="mainContainer" addStyleNames="margin-10" />
-      </b:Column>
-    </b:Row>
-  </bh:Div>
+  <g:FlowPanel ui:field="mainContainer" addStyleNames="margin-10" />
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/view/TeamViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/TeamViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/TrashViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/TrashViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:bb="urn:import:org.gwtbootstrap3.client.ui"
 >
   <g:HTMLPanel>
     <div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/WikiDiffViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/WikiDiffViewImpl.ui.xml
@@ -1,47 +1,41 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <bh:Div
       addStyleNames="margin-top-30 margin-left-35 min-height-400 margin-right-10"
     >
       <bh:Div ui:field="synAlertContainer" />
-      <b:Row>
-        <b:Column size="SM_12">
-          <b:Panel>
-            <b:PanelHeader>
-              <b:Heading size="H3" text="Compare Wiki Versions" />
-            </b:PanelHeader>
-            <b:PanelBody>
-              <b:ButtonGroup>
-                <b:Button
-                  ui:field="version1DropdownButton"
-                  dataToggle="DROPDOWN"
-                  text="Select a base version..."
-                />
-                <b:DropDownMenu ui:field="version1Dropdown" />
-              </b:ButtonGroup>
-              <b:Icon
-                type="EXCHANGE"
-                addStyleNames="margin-left-15 margin-right-15"
-              />
-              <b:ButtonGroup>
-                <b:Button
-                  ui:field="version2DropdownButton"
-                  dataToggle="DROPDOWN"
-                  text="Select another version..."
-                />
-                <b:DropDownMenu ui:field="version2Dropdown" />
-              </b:ButtonGroup>
-            </b:PanelBody>
-          </b:Panel>
-        </b:Column>
-      </b:Row>
+      <b:Panel>
+        <b:PanelHeader>
+          <b:Heading size="H3" text="Compare Wiki Versions" />
+        </b:PanelHeader>
+        <b:PanelBody>
+          <b:ButtonGroup>
+            <b:Button
+              ui:field="version1DropdownButton"
+              dataToggle="DROPDOWN"
+              text="Select a base version..."
+            />
+            <b:DropDownMenu ui:field="version1Dropdown" />
+          </b:ButtonGroup>
+          <b:Icon
+            type="EXCHANGE"
+            addStyleNames="margin-left-15 margin-right-15"
+          />
+          <b:ButtonGroup>
+            <b:Button
+              ui:field="version2DropdownButton"
+              dataToggle="DROPDOWN"
+              text="Select another version..."
+            />
+            <b:DropDownMenu ui:field="version2Dropdown" />
+          </b:ButtonGroup>
+        </b:PanelBody>
+      </b:Panel>
       <b:Panel ui:field="diffContainer" width="100%" />
     </bh:Div>
   </bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/view/WikiViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/WikiViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
 >
   <ui:style>
     .important {

--- a/src/main/resources/org/sagebionetworks/web/client/view/users/PasswordResetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/users/PasswordResetViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/view/users/RegisterAccountViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/users/RegisterAccountViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/view/users/RegisterWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/view/users/RegisterWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParserViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParserViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/CopyTextModalImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/CopyTextModalImpl.ui.xml
@@ -2,12 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <b:Modal
     ui:field="modal"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainerViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainerViewImpl.ui.xml
@@ -1,12 +1,11 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
-  <bh:Div marginBottom="5">
+  <bh:Div marginBottom="5" width="100%">
     <bh:Div ui:field="container" />
     <bh:ClearFix />
     <b:Button ui:field="loadMoreButton" text="Show more results" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/LoadingSpinner.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/LoadingSpinner.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div

--- a/src/main/resources/org/sagebionetworks/web/client/widget/QuarantinedEmailModal.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/QuarantinedEmailModal.ui.xml
@@ -1,10 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <b:Modal
     title="Update Your Synapse Email Address"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/RadioWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/RadioWidgetViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/SelectionOptions.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/SelectionOptions.ui.xml
@@ -1,9 +1,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="border-top-1" marginTop="20" paddingTop="10">
     <b:Anchor ui:field="selectAll" text="Select All" marginRight="20" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/SelectionToolbar.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/SelectionToolbar.ui.xml
@@ -1,9 +1,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <b:ButtonToolBar ui:field="buttonToolbar" visible="false">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/TextBoxWithCopyToClipboardWidget.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/TextBoxWithCopyToClipboardWidget.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/TeamSubjectWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/TeamSubjectWidgetViewImpl.ui.xml
@@ -1,6 +1,5 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/approval/AccessorGroupViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/approval/AccessorGroupViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateAccessRequirementStep1ViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateAccessRequirementStep1ViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateBasicAccessRequirementStep2ViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateBasicAccessRequirementStep2ViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep2ViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep2ViewImpl.ui.xml
@@ -1,14 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div>
     <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/submission/ACTDataAccessSubmissionWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/accessrequirements/submission/ACTDataAccessSubmissionWidgetViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/asynch/AsynchronousProgressViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/asynch/AsynchronousProgressViewImpl.ui.xml
@@ -1,11 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/asynch/InlineAsynchronousProgressViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/asynch/InlineAsynchronousProgressViewImpl.ui.xml
@@ -1,11 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/BiodallianceWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/BiodallianceWidgetViewImpl.ui.xml
@@ -2,9 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/editor/BiodallianceEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/editor/BiodallianceEditorViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/editor/BiodallianceSourceEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/biodalliance13/editor/BiodallianceSourceEditorViewImpl.ui.xml
@@ -1,11 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:Table width="100%" height="30px">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/ContainerClientsHelpImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/ContainerClientsHelpImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/FileClientsHelpViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/FileClientsHelpViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Span>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/FileViewClientsHelpImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/clienthelp/FileViewClientsHelpImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListItemWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListItemWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.ui.xml
@@ -1,16 +1,15 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:tr="urn:import:org.sagebionetworks.web.client.widget.table.v2.results"
 >
   <bh:Div>
     <bh:Div ui:field="threadCountAlertContainer" />
-    <b:Row>
-      <b:Column size="XS_12">
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12">
         <!-- Thread header -->
         <bh:Div
           ui:field="threadHeader"
@@ -46,16 +45,16 @@
             </t:TableRow>
           </t:Table>
         </bh:Div>
-      </b:Column>
-      <b:Column size="XS_12" ui:field="threadListContainer" paddingLeft="22" />
-    </b:Row>
-    <b:Row>
-      <b:Column size="XS_12">
+      </MUI:Grid>
+      <MUI:Grid xs="12" ui:field="threadListContainer" />
+    </MUI:Grid>
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12">
         <bh:Span ui:field="noThreadsFound" visible="false" paddingLeft="10">
           No threads found.
         </bh:Span>
-      </b:Column>
-    </b:Row>
+      </MUI:Grid>
+    </MUI:Grid>
     <bh:Div ui:field="synAlertContainer" />
   </bh:Div>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/ForumWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/ForumWidgetViewImpl.ui.xml
@@ -69,66 +69,57 @@
       <bh:Div addStyleNames="highlight-title">
         <bh:Text>Deleted Threads</bh:Text>
       </bh:Div>
-      <b:Row>
-        <b:Column size="XS_12">
-          <g:SimplePanel
-            addStyleNames="margin-15"
-            ui:field="deletedThreadListContainer"
-            visible="false"
-          />
-        </b:Column>
-      </b:Row>
+      <g:SimplePanel
+        addStyleNames="margin-15"
+        ui:field="deletedThreadListContainer"
+        visible="false"
+      />
     </bh:Div>
     <bh:Div
       ui:field="mainContainer"
       addStyleNames="padding-top-0-imp margin-bottom-20 "
     >
-      <b:Row>
-        <b:Column size="XS_12">
-          <g:SimplePanel
-            addStyleNames="margin-top-10 light-border"
-            ui:field="threadListContainer"
+      <g:SimplePanel
+        addStyleNames="margin-top-10 light-border"
+        width="100%"
+        ui:field="threadListContainer"
+      />
+      <bh:Div
+        ui:field="singleThreadAndSortContainer"
+        addStyleNames="light-border"
+        width="100%"
+        paddingTop="15"
+        paddingRight="30"
+        paddingBottom="15"
+        paddingLeft="30"
+      >
+        <b:ButtonGroup
+          ui:field="repliesSortButtonGroup"
+          addStyleNames="flexcontainer-row flexcontainer-justify-center"
+          visible="false"
+        >
+          <b:Button
+            ui:field="sortRepliesAscendingButton"
+            text="Date Posted"
+            addStyleNames="margin-top-10"
           />
-        </b:Column>
-        <b:Column size="XS_12">
-          <bh:Div
-            ui:field="singleThreadAndSortContainer"
-            addStyleNames="light-border"
-            paddingTop="15"
-            paddingRight="30"
-            paddingBottom="15"
-            paddingLeft="30"
-          >
-            <b:ButtonGroup
-              ui:field="repliesSortButtonGroup"
-              addStyleNames="flexcontainer-row flexcontainer-justify-center"
-              visible="false"
-            >
-              <b:Button
-                ui:field="sortRepliesAscendingButton"
-                text="Date Posted"
-                addStyleNames="margin-top-10"
-              />
-              <b:Button
-                ui:field="sortRepliesDescendingButton"
-                text="Most Recent"
-                addStyleNames="margin-top-10"
-              />
-            </b:ButtonGroup>
-            <g:SimplePanel
-              addStyleNames="margin-top-10"
-              ui:field="singleThreadContainer"
-            />
-          </bh:Div>
-        </b:Column>
-        <b:Column size="XS_12">
-          <g:SimplePanel
-            addStyleNames="margin-top-10 light-border"
-            ui:field="defaultThreadContainer"
-            visible="false"
+          <b:Button
+            ui:field="sortRepliesDescendingButton"
+            text="Most Recent"
+            addStyleNames="margin-top-10"
           />
-        </b:Column>
-      </b:Row>
+        </b:ButtonGroup>
+        <g:SimplePanel
+          addStyleNames="margin-top-10"
+          ui:field="singleThreadContainer"
+        />
+      </bh:Div>
+      <g:SimplePanel
+        width="100%"
+        addStyleNames="margin-top-10 light-border"
+        ui:field="defaultThreadContainer"
+        visible="false"
+      />
     </bh:Div>
     <g:SimplePanel ui:field="newThreadModalContainer" />
     <bh:Div ui:field="synAlertContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/NewReplyWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/NewReplyWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/ReplyWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/ReplyWidgetViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div
@@ -28,53 +27,47 @@
         size="16px"
       />
       <b:Container fluid="true">
-        <b:Row>
-          <b:Column size="XS_12">
-            <bh:Div ui:field="replyMessage" />
-          </b:Column>
-          <b:Column size="XS_12">
-            <bh:Div addStyleNames="margin-left-10 small left">
-              <bh:Span ui:field="createdOn" />
-              <b:Label
-                text="Edited"
-                ui:field="edited"
-                visible="false"
-                addStyleNames="margin-left-10 moveup-1"
-              />
-            </bh:Div>
-            <bh:Div ui:field="commandsContainer">
-              <b:Tooltip title="Delete reply" placement="LEFT">
-                <b:Icon
-                  ui:field="deleteIcon"
-                  type="TRASH_O"
-                  size="LARGE"
-                  pull="RIGHT"
-                  addStyleNames="imageButton line-height-1em"
-                  visible="false"
-                />
-              </b:Tooltip>
-              <b:Tooltip title="Edit reply" placement="LEFT">
-                <b:Icon
-                  ui:field="editIcon"
-                  type="PENCIL"
-                  size="LARGE"
-                  pull="RIGHT"
-                  addStyleNames="imageButton margin-right-5 line-height-1em"
-                  visible="false"
-                />
-              </b:Tooltip>
-              <b:Tooltip title="Link directly to this reply" placement="LEFT">
-                <b:Icon
-                  ui:field="linkIcon"
-                  type="LINK"
-                  size="LARGE"
-                  pull="RIGHT"
-                  addStyleNames="imageButton margin-right-5 line-height-1em "
-                />
-              </b:Tooltip>
-            </bh:Div>
-          </b:Column>
-        </b:Row>
+        <bh:Div ui:field="replyMessage" />
+        <bh:Div addStyleNames="margin-left-10 small left">
+          <bh:Span ui:field="createdOn" />
+          <b:Label
+            text="Edited"
+            ui:field="edited"
+            visible="false"
+            addStyleNames="margin-left-10 moveup-1"
+          />
+        </bh:Div>
+        <bh:Div ui:field="commandsContainer">
+          <b:Tooltip title="Delete reply" placement="LEFT">
+            <b:Icon
+              ui:field="deleteIcon"
+              type="TRASH_O"
+              size="LARGE"
+              pull="RIGHT"
+              addStyleNames="imageButton line-height-1em"
+              visible="false"
+            />
+          </b:Tooltip>
+          <b:Tooltip title="Edit reply" placement="LEFT">
+            <b:Icon
+              ui:field="editIcon"
+              type="PENCIL"
+              size="LARGE"
+              pull="RIGHT"
+              addStyleNames="imageButton margin-right-5 line-height-1em"
+              visible="false"
+            />
+          </b:Tooltip>
+          <b:Tooltip title="Link directly to this reply" placement="LEFT">
+            <b:Icon
+              ui:field="linkIcon"
+              type="LINK"
+              size="LARGE"
+              pull="RIGHT"
+              addStyleNames="imageButton margin-right-5 line-height-1em "
+            />
+          </b:Tooltip>
+        </bh:Div>
       </b:Container>
     </bh:Div>
     <g:SimplePanel ui:field="editReplyModalContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/SingleDiscussionThreadWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/SingleDiscussionThreadWidgetViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <ui:with
@@ -34,101 +33,99 @@
             addStyleNames="synapse-accent-primary-bg margin-left-5"
           />
         </bh:Div>
-        <bh:Div width="100%">
+        <bh:Div width="100%" ui:field="discussionThreadMessageContainer">
           <b:Container fluid="true">
-            <b:Row>
-              <b:Column size="XS_12">
-                <bh:Span
-                  ui:field="threadTitle"
-                  addStyleNames="lead margin-right-10 margin-left-10"
-                />
-                <bh:Span
-                  ui:field="subscribersContainer"
-                  addStyleNames="right margin-left-10 margin-right-10"
-                />
-              </b:Column>
-              <b:Column size="XS_12">
-                <w:LoadingSpinner
-                  ui:field="loadingMessage"
+            <g:FlowPanel>
+              <bh:Span
+                ui:field="threadTitle"
+                addStyleNames="lead margin-right-10 margin-left-10"
+              />
+              <bh:Span
+                ui:field="subscribersContainer"
+                addStyleNames="right margin-left-10 margin-right-10"
+              />
+            </g:FlowPanel>
+            <g:FlowPanel>
+              <w:LoadingSpinner
+                ui:field="loadingMessage"
+                visible="false"
+                size="31px"
+              />
+              <bh:Div ui:field="threadMessage" />
+            </g:FlowPanel>
+            <g:FlowPanel addStyleNames="margin-top-3">
+              <bh:Div addStyleNames="margin-left-10 small left">
+                <bh:Span ui:field="createdOn" />
+                <b:Label
+                  text="Edited"
+                  ui:field="edited"
                   visible="false"
-                  size="31px"
+                  addStyleNames="margin-left-10 moveup-1"
                 />
-                <bh:Div ui:field="threadMessage" />
-              </b:Column>
-              <b:Column size="XS_12" addStyleNames="margin-top-3">
-                <bh:Div addStyleNames="margin-left-10 small left">
-                  <bh:Span ui:field="createdOn" />
-                  <b:Label
-                    text="Edited"
-                    ui:field="edited"
-                    visible="false"
-                    addStyleNames="margin-left-10 moveup-1"
-                  />
-                </bh:Div>
-                <bh:Div ui:field="commandsContainer">
-                  <bh:Span
-                    ui:field="subscribeButtonContainer"
-                    addStyleNames="right"
-                  />
-                  <b:Tooltip title="Delete thread" placement="LEFT">
-                    <b:Icon
-                      ui:field="deleteIcon"
-                      type="TRASH_O"
-                      size="LARGE"
-                      pull="RIGHT"
-                      addStyleNames="imageButton margin-right-10 line-height-1em"
-                      visible="false"
-                    />
-                  </b:Tooltip>
-                  <b:Tooltip title="Edit thread" placement="LEFT">
-                    <b:Icon
-                      ui:field="editIcon"
-                      type="PENCIL"
-                      size="LARGE"
-                      pull="RIGHT"
-                      addStyleNames="imageButton margin-right-5 line-height-1em"
-                      visible="false"
-                    />
-                  </b:Tooltip>
-                  <b:Tooltip title="Pin thread" placement="LEFT">
-                    <b:Icon
-                      ui:field="pinIcon"
-                      type="THUMB_TACK"
-                      size="LARGE"
-                      pull="RIGHT"
-                      addStyleNames="imageButton margin-right-5 line-height-1em"
-                      visible="false"
-                    />
-                  </b:Tooltip>
-                  <b:Tooltip title="Unpin thread" placement="LEFT">
-                    <b:IconStack
-                      ui:field="unpinIconStack"
-                      addStyleNames="imageButton line-height-1em right moveup-5"
-                      visible="false"
-                    >
-                      <b:Icon
-                        type="BAN"
-                        stackBase="true"
-                        addStyleNames="halfOpacity"
-                      />
-                      <b:Icon
-                        type="THUMB_TACK"
-                        stackTop="true"
-                        ui:field="unpinIcon"
-                      />
-                    </b:IconStack>
-                  </b:Tooltip>
-                </bh:Div>
-                <b:Tooltip title="Restore deleted thread" placement="LEFT">
-                  <g:Image
-                    resource='{icons.restore24}'
-                    ui:field="restoreIcon"
-                    addStyleNames="imageButton line-height-1em right moveup-5"
+              </bh:Div>
+              <bh:Div ui:field="commandsContainer">
+                <bh:Span
+                  ui:field="subscribeButtonContainer"
+                  addStyleNames="right"
+                />
+                <b:Tooltip title="Delete thread" placement="LEFT">
+                  <b:Icon
+                    ui:field="deleteIcon"
+                    type="TRASH_O"
+                    size="LARGE"
+                    pull="RIGHT"
+                    addStyleNames="imageButton margin-right-10 line-height-1em"
                     visible="false"
                   />
                 </b:Tooltip>
-              </b:Column>
-            </b:Row>
+                <b:Tooltip title="Edit thread" placement="LEFT">
+                  <b:Icon
+                    ui:field="editIcon"
+                    type="PENCIL"
+                    size="LARGE"
+                    pull="RIGHT"
+                    addStyleNames="imageButton margin-right-5 line-height-1em"
+                    visible="false"
+                  />
+                </b:Tooltip>
+                <b:Tooltip title="Pin thread" placement="LEFT">
+                  <b:Icon
+                    ui:field="pinIcon"
+                    type="THUMB_TACK"
+                    size="LARGE"
+                    pull="RIGHT"
+                    addStyleNames="imageButton margin-right-5 line-height-1em"
+                    visible="false"
+                  />
+                </b:Tooltip>
+                <b:Tooltip title="Unpin thread" placement="LEFT">
+                  <b:IconStack
+                    ui:field="unpinIconStack"
+                    addStyleNames="imageButton line-height-1em right moveup-5"
+                    visible="false"
+                  >
+                    <b:Icon
+                      type="BAN"
+                      stackBase="true"
+                      addStyleNames="halfOpacity"
+                    />
+                    <b:Icon
+                      type="THUMB_TACK"
+                      stackTop="true"
+                      ui:field="unpinIcon"
+                    />
+                  </b:IconStack>
+                </b:Tooltip>
+              </bh:Div>
+              <b:Tooltip title="Restore deleted thread" placement="LEFT">
+                <g:Image
+                  resource='{icons.restore24}'
+                  ui:field="restoreIcon"
+                  addStyleNames="imageButton line-height-1em right moveup-5"
+                  visible="false"
+                />
+              </b:Tooltip>
+            </g:FlowPanel>
           </b:Container>
         </bh:Div>
       </bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/modal/DiscussionThreadModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/modal/DiscussionThreadModalViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/modal/ReplyModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/modal/ReplyModalViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerCommitListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerCommitListWidgetViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoListWidgetViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
@@ -4,73 +4,72 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
-  <b:Row>
-    <b:Column size="XS_12">
-      <b:Row>
-        <bh:Div addStyleNames="margin-left-15 margin-right-15">
-          <g:SimplePanel ui:field="dockerTitlebarContainer" />
-          <g:SimplePanel ui:field="dockerMetadataContainer" />
-        </bh:Div>
-      </b:Row>
-      <g:FlowPanel addStyleNames="entity-page-side-margins">
-        <b:Row>
-          <b:Column size="XS_12, MD_6">
-            <b:Panel>
-              <bh:Div addStyleNames="highlight-title">
-                <bh:Text text="Docker Pull Command" />
-              </bh:Div>
-              <b:PanelBody addStyleNames="margin-15">
-                <g:TextBox
-                  ui:field="dockerPullCommand"
-                  addStyleNames="border-none noBackground"
-                  readOnly="true"
-                  width="100%"
-                />
-              </b:PanelBody>
-            </b:Panel>
-            <b:Panel addStyleNames="margin-top-15">
-              <b:PanelBody ui:field="dockerRepoWikiPageContainer" />
-            </b:Panel>
-          </b:Column>
-          <b:Column size="XS_12, MD_6">
-            <g:FlowPanel addStyleNames="margin-bottom-15">
-              <bh:Div addStyleNames="highlight-title">
-                <bh:Text>Tags</bh:Text>
-                <w:HelpWidget
-                  helpMarkdown="An image name is made up of slash-separated name components, optionally prefixed by a registry hostname."
-                  href="https://docs.docker.com/engine/reference/commandline/tag/"
-                  addStyleNames="margin-left-5"
-                  placement="BOTTOM"
-                />
-              </bh:Div>
-              <bh:Div
-                addStyleNames="padding-15"
-                ui:field="dockerCommitListContainer"
+  <g:FlowPanel>
+    <g:SimplePanel ui:field="dockerTitlebarContainer" />
+    <g:SimplePanel ui:field="dockerMetadataContainer" />
+    <g:FlowPanel addStyleNames="entity-page-side-margins">
+      <MUI:Grid container="true" columnSpacing="15px">
+        <MUI:Grid xs="12" md="6">
+          <b:Panel addStyleNames="margin-bottom-15">
+            <bh:Div addStyleNames="highlight-title">
+              <bh:Text text="Docker Pull Command" />
+            </bh:Div>
+            <b:PanelBody addStyleNames="margin-15">
+              <g:TextBox
+                ui:field="dockerPullCommand"
+                addStyleNames="border-none noBackground"
+                readOnly="true"
+                width="100%"
               />
-            </g:FlowPanel>
-            <g:FlowPanel
-              ui:field="provenancePanel"
-              addStyleNames="light-border padding-10 margin-bottom-15"
-            >
-              <bh:Div addStyleNames="highlight-title">
-                <bh:Text>Provenance</bh:Text>
-                <w:HelpWidget
-                  helpMarkdown="Provenance tracks the relationship between data, code and analytical results"
-                  href="https://help.synapse.org/docs/Provenance.1972470373.html"
-                  addStyleNames="margin-left-5"
-                  placement="BOTTOM"
-                />
-              </bh:Div>
-              <bh:Div ui:field="dockerRepoProvenanceContainer" />
-            </g:FlowPanel>
-          </b:Column>
-        </b:Row>
-      </g:FlowPanel>
-      <g:SimplePanel ui:field="dockerModifiedAndCreatedContainer" />
-    </b:Column>
+            </b:PanelBody>
+          </b:Panel>
+        </MUI:Grid>
+        <MUI:Grid xs="12" md="6">
+          <g:FlowPanel addStyleNames="margin-bottom-15">
+            <bh:Div addStyleNames="highlight-title">
+              <bh:Text>Tags</bh:Text>
+              <w:HelpWidget
+                helpMarkdown="An image name is made up of slash-separated name components, optionally prefixed by a registry hostname."
+                href="https://docs.docker.com/engine/reference/commandline/tag/"
+                addStyleNames="margin-left-5"
+                placement="BOTTOM"
+              />
+            </bh:Div>
+            <bh:Div
+              addStyleNames="padding-15"
+              ui:field="dockerCommitListContainer"
+            />
+          </g:FlowPanel>
+        </MUI:Grid>
+        <MUI:Grid xs="12" md="6">
+          <b:Panel>
+            <b:PanelBody ui:field="dockerRepoWikiPageContainer" />
+          </b:Panel>
+        </MUI:Grid>
+        <MUI:Grid xs="12" md="6">
+          <g:FlowPanel
+            ui:field="provenancePanel"
+            addStyleNames="margin-bottom-15"
+          >
+            <bh:Div addStyleNames="highlight-title">
+              <bh:Text>Provenance</bh:Text>
+              <w:HelpWidget
+                helpMarkdown="Provenance tracks the relationship between data, code and analytical results"
+                href="https://help.synapse.org/docs/Provenance.1972470373.html"
+                addStyleNames="margin-left-5"
+                placement="BOTTOM"
+              />
+            </bh:Div>
+            <bh:Div ui:field="dockerRepoProvenanceContainer" />
+          </g:FlowPanel>
+        </MUI:Grid>
+      </MUI:Grid>
+    </g:FlowPanel>
+    <g:SimplePanel ui:field="dockerModifiedAndCreatedContainer" />
     <g:SimplePanel ui:field="synapseAlertContainer" />
-  </b:Row>
+  </g:FlowPanel>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/modal/AddExternalRepoModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/modal/AddExternalRepoModalViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
@@ -13,16 +12,12 @@
     addStyleNames="modal"
   >
     <b:ModalBody>
-      <b:Row>
-        <b:Column size="XS_12">
-          <bh:Span addStyleNames="font-size-18">Repository Name</bh:Span>
-          <b:TextBox
-            ui:field="repoName"
-            placeholder="index.docker.io:5000/library/ubuntu"
-            addStyleNames="font-size-24 margin-bottom-10"
-          />
-        </b:Column>
-      </b:Row>
+      <bh:Span addStyleNames="font-size-18">Repository Name</bh:Span>
+      <b:TextBox
+        ui:field="repoName"
+        placeholder="index.docker.io:5000/library/ubuntu"
+        addStyleNames="font-size-24 margin-bottom-10"
+      />
       <bh:Div ui:field="synAlertContainer" />
     </b:ModalBody>
     <b:ModalFooter>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModalViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/doi/DoiWidgetV2ViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/doi/DoiWidgetV2ViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/BigPromptModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/BigPromptModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/ChallengeBadgeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/ChallengeBadgeViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditFileMetadataModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditFileMetadataModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <!-- Dialog for creating a new table -->

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditProjectMetadataModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditProjectMetadataModalViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <!-- Dialog for creating a new table -->

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditRegisteredTeamDialogViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EditRegisteredTeamDialogViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal
     title="Edit Team Registration"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityListRowBadgeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityListRowBadgeViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityMetadataViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/EntityPageTopViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/FavoriteWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/FavoriteWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/MarkdownEditorWidgetViewImpl.ui.xml
@@ -2,12 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div addStyleNames="markdownEditor">
     <bh:Div ui:field="writingUI">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/MarkdownWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/MarkdownWidgetViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:FlowPanel addStyleNames="markdownWidget min-height-48">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.ui.xml
@@ -1,11 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <w:ReactComponent ui:field="container" visible="false" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/PromptModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/PromptModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <!-- Dialog for creating a new table -->

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/VersionHistoryWidgetViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:d="urn:import:com.google.gwt.dom.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiAttachmentsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiAttachmentsViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:d="urn:import:com.google.gwt.dom.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <g:FlowPanel>
     <g:FlowPanel ui:field="attachmentsPanel" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiMarkdownEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiMarkdownEditorViewImpl.ui.xml
@@ -1,13 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiPageDeleteConfirmationDialogViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiPageDeleteConfirmationDialogViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/WikiPageWidgetViewImpl.ui.xml
@@ -2,12 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:FlowPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/ApproveUserAccessModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/ApproveUserAccessModalViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RejectDataAccessRequestModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RejectDataAccessRequestModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RejectReasonViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RejectReasonViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RevokeUserAccessModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/RevokeUserAccessModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/UserBadgeItem.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/UserBadgeItem.ui.xml
@@ -1,12 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <ui:with
     field='icons'

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/UserBadgeListViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/act/UserBadgeListViewImpl.ui.xml
@@ -1,9 +1,5 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/annotation/EditAnnotationsDialogViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/annotation/EditAnnotationsDialogViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget.entity.controller"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/EntityTreeBrowserViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/EntityTreeBrowserViewImpl.ui.xml
@@ -2,13 +2,10 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:tr="urn:import:org.sagebionetworks.web.client.widget.table.v2.results"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div marginTop="12" marginBottom="12">
     <bh:Div ui:field="synAlertContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/FilesBrowserViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/FilesBrowserViewImpl.ui.xml
@@ -2,12 +2,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div addStyleNames="filesBrowser margin-top-15">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/MyEntitiesBrowserViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/MyEntitiesBrowserViewImpl.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerViewImpl.ui.xml
@@ -1,10 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Span>
     <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityRefProvEntryViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/EntityRefProvEntryViewImpl.ui.xml
@@ -1,12 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.entity.menu.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceEditorWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceEditorWidgetViewImpl.ui.xml
@@ -2,12 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.entity.menu.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceURLDialogWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/ProvenanceURLDialogWidgetViewImpl.ui.xml
@@ -2,12 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.entity.menu.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal
     ui:field="modal"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/StorageLocationWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/StorageLocationWidgetViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/SynapseAlertViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/URLProvEntryViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/controller/URLProvEntryViewImpl.ui.xml
@@ -1,12 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.entity.menu.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/dialog/BaseEditWidgetDescriptorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/dialog/BaseEditWidgetDescriptorViewImpl.ui.xml
@@ -3,9 +3,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <ui:with
     field='icons'

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/AddFolderDialogWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/AddFolderDialogWidgetViewImpl.ui.xml
@@ -1,11 +1,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <!-- dataKeyboard must be false in this case since clicking ESC will not call the Close handler (need to cleanup Folder that was created up front) -->

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/AwsLoginViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/AwsLoginViewImpl.ui.xml
@@ -1,11 +1,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Panel addStyleNames="awsLogin">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/QuizInfoViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/QuizInfoViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:HTMLPanel>
     <div class="margin-10">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
 >
   <g:FlowPanel>
     <g:SimplePanel ui:field="dialogContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/APITableColumnConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/APITableColumnConfigViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/APITableColumnManagerViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/APITableColumnManagerViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/AttachmentConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/AttachmentConfigViewImpl.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/BookmarkConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/CytoscapeConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/CytoscapeConfigViewImpl.ui.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>
-    <b:Row addStyleNames="margin-10">
-      <b:Column size="XS_6">
+    <MUI:Grid container="true" addStyleNames="margin-10">
+      <MUI:Grid xs="6">
         <b:FormGroup>
           <b:FormLabel>Cytoscape JS network file</b:FormLabel>
           <b:InputGroup>
@@ -27,11 +27,11 @@
             </b:InputGroupButton>
           </b:InputGroup>
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="XS_6" />
-    </b:Row>
-    <b:Row addStyleNames="margin-10">
-      <b:Column size="XS_6">
+      </MUI:Grid>
+      <MUI:Grid xs="6" />
+    </MUI:Grid>
+    <MUI:Grid container="true" addStyleNames="margin-10">
+      <MUI:Grid xs="6">
         <b:FormGroup>
           <b:FormLabel>Cytoscape JS style file</b:FormLabel>
           <b:InputGroup>
@@ -50,11 +50,11 @@
             </b:InputGroupButton>
           </b:InputGroup>
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="XS_6" />
-    </b:Row>
-    <b:Row addStyleNames="margin-10">
-      <b:Column size="XS_6">
+      </MUI:Grid>
+      <MUI:Grid xs="6" />
+    </MUI:Grid>
+    <MUI:Grid container="true" addStyleNames="margin-10">
+      <MUI:Grid xs="6">
         <b:FormGroup>
           <b:FormLabel>Display height (px)</b:FormLabel>
           <b:TextBox
@@ -62,8 +62,8 @@
             ui:field="displayHeightField"
           />
         </b:FormGroup>
-      </b:Column>
-      <b:Column size="XS_6" />
-    </b:Row>
+      </MUI:Grid>
+      <MUI:Grid xs="6" />
+    </MUI:Grid>
   </bh:Div>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/EntityListConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/EntityListConfigViewImpl.ui.xml
@@ -1,12 +1,9 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/EvaluationSubmissionConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/EvaluationSubmissionConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/ImageParamsPanelViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/ImageParamsPanelViewImpl.ui.xml
@@ -5,7 +5,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:b3="urn:import:org.gwtbootstrap3.extras.slider.client.ui"
 >
   <b:Panel addStyleNames="margin-top-10 margin-bottom-10">
     <b:PanelBody>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/PlotlyConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/PlotlyConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/PreviewConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/PreviewConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/ShinySiteConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/ShinySiteConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/SynapseFormConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/SynapseFormConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/TabbedTableConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/TabbedTableConfigViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/UserSelectorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/UserSelectorViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/editor/VideoConfigViewImpl.ui.xml
@@ -27,34 +27,32 @@
     </b:NavTabs>
     <b:TabContent>
       <b:TabPane b:id="tab1" addStyleNames="margin-top-15" ui:field="tab1">
-        <b:Row addStyleNames="margin-10">
-          <b:Column size="XS_12">
-            <b:FormLabel>Video File</b:FormLabel>
-            <b:InputGroup>
-              <b:TextBox
-                ui:field="entity"
-                autoComplete="false"
-                enabled="false"
-                height="34px"
-              />
-              <b:InputGroupButton>
-                <b:Button ui:field="button" icon="SEARCH" height="34px" />
-              </b:InputGroupButton>
-            </b:InputGroup>
-          </b:Column>
-          <b:Column size="XS_12">
-            <b:Heading size="H5" ui:field="videoFormatWarning" visible="false">
-              <bh:Text>We recommend using the mp4 video format for</bh:Text>
-              <b:Anchor
-                ui:field="moreInfoLink"
-                target="_blank"
-                addStyleNames="margin-left-5"
-                text="cross-browser compatability"
-                href="http://en.wikipedia.org/wiki/HTML5_video#Browser_support"
-              />
-            </b:Heading>
-          </b:Column>
-        </b:Row>
+        <g:FlowPanel>
+          <b:FormLabel>Video File</b:FormLabel>
+          <b:InputGroup>
+            <b:TextBox
+              ui:field="entity"
+              autoComplete="false"
+              enabled="false"
+              height="34px"
+            />
+            <b:InputGroupButton>
+              <b:Button ui:field="button" icon="SEARCH" height="34px" />
+            </b:InputGroupButton>
+          </b:InputGroup>
+        </g:FlowPanel>
+        <g:FlowPanel>
+          <b:Heading size="H5" ui:field="videoFormatWarning" visible="false">
+            <bh:Text>We recommend using the mp4 video format for</bh:Text>
+            <b:Anchor
+              ui:field="moreInfoLink"
+              target="_blank"
+              addStyleNames="margin-left-5"
+              text="cross-browser compatability"
+              href="http://en.wikipedia.org/wiki/HTML5_video#Browser_support"
+            />
+          </b:Heading>
+        </g:FlowPanel>
       </b:TabPane>
       <b:TabPane b:id="tab2" addStyleNames="margin-top-15" ui:field="tab2">
         <b:FieldSet>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <s:ReactComponent ui:field="reactComponentContainer" />
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/ProjectTitleBarViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/ProjectTitleBarViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/S3DirectLoginDialogImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/S3DirectLoginDialogImpl.ui.xml
@@ -1,12 +1,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Span>
     <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/downloadlist/FileHandleAssociationRowViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/downloadlist/FileHandleAssociationRowViewImpl.ui.xml
@@ -1,12 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow addStyleNames="border-bottom-1">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/downloadlist/PackageSizeSummaryViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/file/downloadlist/PackageSizeSummaryViewImpl.ui.xml
@@ -1,13 +1,9 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Span>
     <b:Icon

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/ChallengeTeamsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/ChallengeTeamsViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/CytoscapeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/CytoscapeViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/EntityListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/EntityListWidgetViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.ui.xml
@@ -1,9 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="margin-5">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/NbConvertPreviewViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="margin-5">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.ui.xml
@@ -2,9 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="margin-5">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/SRCDemoWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/SRCDemoWidgetViewImpl.ui.xml
@@ -1,9 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div addStyleNames="margin-5">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/TeamMemberCountViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/TeamMemberCountViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Span>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/UserListRowWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/UserListRowWidgetViewImpl.ui.xml
@@ -1,9 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/UserListViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/renderer/UserListViewImpl.ui.xml
@@ -1,9 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetModalsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetModalsViewImpl.ui.xml
@@ -2,13 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Span>
     <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.ui.xml
@@ -1,13 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/ChallengeTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/ChallengeTabViewImpl.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:FlowPanel addStyleNames="margin-top-15 entity-page-side-margins">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/DiscussionTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/DiscussionTabViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/DockerTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/DockerTabViewImpl.ui.xml
@@ -5,7 +5,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <g:FlowPanel addStyleNames="margin-bottom-15">
     <g:SimplePanel ui:field="synapseAlertContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
@@ -4,6 +4,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -31,8 +32,13 @@
         visible="false"
       />
       <g:SimplePanel ui:field="fileBrowserContainer" />
-      <b:Row addStyleNames="margin-top-10">
-        <b:Column size="MD_6" ui:field="filePreviewContainer">
+      <MUI:Grid
+        container="true"
+        columnSpacing="15px"
+        rowSpacing="15px"
+        addStyleNames="margin-top-10"
+      >
+        <MUI:Grid xs="12" md="6" ui:field="filePreviewContainer">
           <g:FlowPanel>
             <bh:Div addStyleNames="highlight-title">
               <bh:Text>Preview</bh:Text>
@@ -56,9 +62,9 @@
               <bh:Div ui:field="filePreviewWidgetContainer" />
             </g:ScrollPanel>
           </g:FlowPanel>
-        </b:Column>
-        <b:Column size="MD_6" ui:field="fileProvenanceContainer">
-          <g:FlowPanel>
+        </MUI:Grid>
+        <MUI:Grid xs="12" md="6">
+          <g:FlowPanel ui:field="fileProvenanceContainer">
             <bh:Div addStyleNames="highlight-title">
               <bh:Text>Provenance</bh:Text>
               <w:HelpWidget
@@ -79,18 +85,14 @@
               addStyleNames="padding-15 whiteBackground"
             />
           </g:FlowPanel>
-        </b:Column>
-      </b:Row>
-      <b:Row addStyleNames="margin-top-10">
-        <b:Column size="MD_12" ui:field="discussionContainer">
-          <g:FlowPanel>
-            <bh:Div addStyleNames="highlight-title">
-              <bh:Text ui:field="discussionText" />
-            </bh:Div>
-            <bh:Div ui:field="discussionThreadsContainer" />
-          </g:FlowPanel>
-        </b:Column>
-      </b:Row>
+        </MUI:Grid>
+      </MUI:Grid>
+      <g:FlowPanel ui:field="discussionContainer" addStyleNames="margin-top-10">
+        <bh:Div addStyleNames="highlight-title">
+          <bh:Text ui:field="discussionText" />
+        </bh:Div>
+        <bh:Div ui:field="discussionThreadsContainer" />
+      </g:FlowPanel>
     </bh:Div>
     <g:SimplePanel ui:field="fileModifiedAndCreatedContainer" />
   </g:FlowPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
@@ -4,6 +4,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -56,8 +57,8 @@
           addStyleNames="margin-top-15"
           ui:field="tableWidgetContainer"
         />
-        <b:Row>
-          <b:Column size="XS_12" ui:field="provenanceContainer">
+        <MUI:Grid container="true">
+          <MUI:Grid xs="12" ui:field="provenanceContainer">
             <g:FlowPanel addStyleNames="margin-bottom-15 margin-top-15">
               <bh:Div addStyleNames="highlight-title">
                 <bh:Text>Provenance</bh:Text>
@@ -73,8 +74,8 @@
                 addStyleNames="margin-top-10 margin-bottom-10"
               />
             </g:FlowPanel>
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
       </g:FlowPanel>
     </bh:Div>
     <g:SimplePanel ui:field="tableModifiedAndCreatedContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TabsViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/ChallengeWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/ChallengeWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorModalViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:bd="urn:import:org.gwtbootstrap3.extras.datetimepicker.client.ui"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationFinderViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationFinderViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationRowWidget.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/EvaluationRowWidget.ui.xml
@@ -1,8 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -10,8 +10,8 @@
     fluid="true"
     addStyleNames="light-border padding-10 margin-bottom-10"
   >
-    <b:Row>
-      <b:Column size="XS_12">
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12">
         <b:Heading size="H4">
           <bh:Text ui:field="evaluationNameText" />
           <b:Button
@@ -54,10 +54,10 @@
           />
         </b:Heading>
         <bh:Div ui:field="submitToEvaluationContainer" />
-      </b:Column>
-    </b:Row>
-    <b:Row>
-      <b:Column size="XS_12" addStyleNames="margin-top-10">
+      </MUI:Grid>
+    </MUI:Grid>
+    <MUI:Grid container="true">
+      <MUI:Grid xs="12" addStyleNames="margin-top-10">
         <b:FormGroup>
           <b:FormLabel
             text="Description"
@@ -147,7 +147,7 @@
             </b:FormGroup>
           </bh:Div>
         </bh:Div>
-      </b:Column>
-    </b:Row>
+      </MUI:Grid>
+    </MUI:Grid>
   </b:Container>
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/googlemap/GoogleMapViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/googlemap/GoogleMapViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/lazyload/LazyLoadWikiWidgetWrapperViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/lazyload/LazyLoadWikiWidgetWrapperViewImpl.ui.xml
@@ -1,10 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Span>
     <bh:Span ui:field="loadingUI" text="Loading..." />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/login/LoginModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/login/LoginModalViewImpl.ui.xml
@@ -1,10 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <!-- Dialog for gathering user credentials -->

--- a/src/main/resources/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <w:ReactComponent ui:field="srcLoginContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/pagination/BasicPaginationViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/pagination/BasicPaginationViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/profile/EmailAddressesWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/profile/EmailAddressesWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/profile/ProfileCertifiedValidatedViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/profile/ProfileCertifiedValidatedViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.ui.xml
@@ -3,6 +3,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -19,44 +20,45 @@
           addStyleNames="imageUploader"
         />
       </bh:Div>
+      <MUI:Grid container="true" />
       <bh:Div
         addStyleNames="profileFormContainer overflowHidden"
         paddingTop="40"
         paddingLeft="40"
         paddingRight="50"
       >
-        <b:Row>
-          <b:Column size="MD_12,LG_6">
+        <MUI:Grid container="true">
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="firstName">First Name</b:FormLabel>
               <bh:Paragraph ui:field="firstNameRenderer" />
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="lastName">Last Name</b:FormLabel>
               <bh:Paragraph ui:field="lastNameRenderer" />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="currentPosition">Current Position</b:FormLabel>
               <bh:Paragraph ui:field="currentPositionRenderer" />
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="currentAffiliation">
                 Current Affiliation
               </b:FormLabel>
               <bh:Paragraph ui:field="currentAffiliationRenderer" />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="XS_12">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid xs="12">
             <b:FormGroup>
               <b:FormLabel for="bio">Bio</b:FormLabel>
               <bh:Paragraph
@@ -64,17 +66,17 @@
                 addStyleNames="whitespace-prewrap"
               />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup ui:field="usernameFormGroup">
               <b:FormLabel for="username">Username</b:FormLabel>
               <bh:Paragraph ui:field="usernameRenderer" />
               <b:HelpBlock ui:field="usernameHelpBlock" />
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup ui:field="linkFormGroup">
               <b:FormLabel for="link">Website</b:FormLabel>
               <bh:Div>
@@ -82,24 +84,24 @@
               </bh:Div>
               <b:HelpBlock ui:field="linkHelpBlock" />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="industry">Industry/Discipline</b:FormLabel>
               <bh:Paragraph ui:field="industryRenderer" />
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="MD_12,LG_6">
+          </MUI:Grid>
+          <MUI:Grid md="12" lg="6">
             <b:FormGroup>
               <b:FormLabel for="location">City, Country</b:FormLabel>
               <bh:Paragraph ui:field="locationRenderer" />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="MD_12,LG_6" ui:field="emailAddressContainer">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid md="12" lg="6" ui:field="emailAddressContainer">
             <b:FormGroup>
               <b:FormLabel>Email Address</b:FormLabel>
               <bh:Div
@@ -108,18 +110,18 @@
                 addStyleNames="truncate"
               />
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="MD_12,LG_6" ui:field="orcIDContainer">
+          </MUI:Grid>
+          <MUI:Grid md="12" lg="6" ui:field="orcIDContainer">
             <b:FormGroup>
               <b:FormLabel for="orcId">ORCID</b:FormLabel>
               <bh:Div>
                 <b:Anchor ui:field="orcIdLink" target="_blank" />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="XS_12" ui:field="accountTypeContainer">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid xs="12" ui:field="accountTypeContainer">
             <b:FormGroup>
               <b:FormLabel for="accountType">Account Type</b:FormLabel>
               <w:ReactComponent
@@ -127,8 +129,8 @@
                 addStyleNames="accountLevelBadgesContainer margin-top-5"
               />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
 
         <bh:Div ui:field="synAlertContainer" />
         <bh:Div marginTop="45" marginBottom="50" ui:field="commandsContainer">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/refresh/RefreshAlertViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/refresh/RefreshAlertViewImpl.ui.xml
@@ -1,10 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:e="urn:import:org.sagebionetworks.web.client.widget.entity"
 >
   <bh:Div addStyleNames="entityRefreshAlert" visible="false">
     <b:Alert type="INFO">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/search/SearchBoxViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/search/SearchBoxViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/sharing/AccessControlListModalWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/sharing/AccessControlListModalWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/sharing/AclAddPeoplePanel.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/sharing/AclAddPeoplePanel.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
 >
   <bh:Div>
     <b:Heading

--- a/src/main/resources/org/sagebionetworks/web/client/widget/sharing/OpenDataViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/sharing/OpenDataViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/sharing/PublicPrivateBadgeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/sharing/PublicPrivateBadgeViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
 >
   <bh:Div addStyleNames="inline-block">
     <b:Tooltip title="Anyone on the internet can access" placement="BOTTOM">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/sharing/SharingPermissionsGridViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/sharing/SharingPermissionsGridViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/subscription/TopicRowWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/subscription/TopicRowWidgetViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/subscription/TopicWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/subscription/TopicWidgetViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/TableEntityListGroupItem.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/TableEntityListGroupItem.ui.xml
@@ -2,8 +2,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/TableListWidgetViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/download/CreateDownloadPageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/download/CreateDownloadPageViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/download/DownloadFilePageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/download/DownloadFilePageViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Form ui:field="form" method="GET">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityContainerListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityContainerListWidgetViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/EntityViewScopeWidgetViewImpl.ui.xml
@@ -2,13 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:HTMLPanel>
     <g:SimplePanel ui:field="viewScopeContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/FileViewOptions.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/SubmissionViewScopeWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/fileview/SubmissionViewScopeWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/CSVOptionsViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/CSVOptionsViewImpl.ui.xml
@@ -1,12 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Panel>
@@ -14,45 +10,45 @@
       <bh:Div>
         <b:FormGroup>
           <b:FormLabel for="separator">Separator</b:FormLabel>
-          <b:Row>
-            <b:Column size="MD_2">
+          <MUI:Grid container="true">
+            <MUI:Grid md="2">
               <b:Radio name="separator" ui:field="commaRadio">Comma</b:Radio>
-            </b:Column>
-            <b:Column size="MD_2">
+            </MUI:Grid>
+            <MUI:Grid md="2">
               <b:Radio name="separator" ui:field="tabRadio">Tab</b:Radio>
-            </b:Column>
-            <b:Column size="MD_2">
+            </MUI:Grid>
+            <MUI:Grid md="2">
               <b:Radio name="separator" ui:field="otherRadio">Other</b:Radio>
-            </b:Column>
-            <b:Column size="MD_2">
+            </MUI:Grid>
+            <MUI:Grid md="2">
               <b:TextBox name="separator" ui:field="otherTextBox" />
-            </b:Column>
-          </b:Row>
+            </MUI:Grid>
+          </MUI:Grid>
         </b:FormGroup>
         <b:FormGroup>
           <b:FormLabel>Escape Character</b:FormLabel>
-          <b:Row>
-            <b:Column size="MD_2">
+          <MUI:Grid container="true">
+            <MUI:Grid md="2">
               <b:Radio
                 name="escapeCharacter"
                 ui:field="escapeCharacterBackslashRadio"
               >
                 Backslash
               </b:Radio>
-            </b:Column>
-            <b:Column size="MD_2">
+            </MUI:Grid>
+            <MUI:Grid md="2">
               <b:Radio
                 name="escapeCharacter"
                 ui:field="escapeCharacterOtherRadio"
               >
                 Other
               </b:Radio>
-            </b:Column>
+            </MUI:Grid>
 
-            <b:Column size="MD_2">
+            <MUI:Grid md="2">
               <b:TextBox maxLength="1" ui:field="escapeCharacterOtherTextBox" />
-            </b:Column>
-          </b:Row>
+            </MUI:Grid>
+          </MUI:Grid>
         </b:FormGroup>
         <b:FormGroup>
           <b:CheckBox ui:field="firstLineHeader">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVAppendPageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVAppendPageViewImpl.ui.xml
@@ -2,12 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <bh:Div>
     <g:SimplePanel ui:field="trackerPanel" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVFinishPageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVFinishPageViewImpl.ui.xml
@@ -2,10 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVPreviewPageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadCSVPreviewPageViewImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <ui:with

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadPreviewViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/upload/UploadPreviewViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/wizard/ModalWizardViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/modal/wizard/ModalWizardViewImpl.ui.xml
@@ -2,13 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <!-- Dialog for creating a new table -->
   <b:Modal closable="true" dataBackdrop="STATIC" dataKeyboard="true">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/QueryInputViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/QueryInputViewImpl.ui.xml
@@ -2,13 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <g:HTMLPanel addStyleNames="queryInput">
     <b:InputGroup ui:field="queryInputGroup" visible="false">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/TotalVisibleResultsWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/TotalVisibleResultsWidgetViewImpl.ui.xml
@@ -1,13 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bt="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/QueryResultEditorViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <!-- This modal dialog will contain the editor for query results -->
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/RowFormViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/RowFormViewImpl.ui.xml
@@ -1,10 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div ui:field="form" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/RowViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/RowViewImpl.ui.xml
@@ -1,11 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <t:TableRow>
     <t:TableData>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/SortableTableHeaderImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/SortableTableHeaderImpl.ui.xml
@@ -1,13 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
   xmlns:bt="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bt:TableHeader addStyleNames="whitespace-nowrap position-relative">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/StaticTableHeaderImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/StaticTableHeaderImpl.ui.xml
@@ -1,13 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
   xmlns:bt="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bt:TableHeader addStyleNames="whitespace-nowrap">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TablePageViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TablePageViewImpl.ui.xml
@@ -2,11 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <bh:Div>
     <bh:Div ui:field="loadingUI" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWikiWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/TableQueryResultWikiWidgetViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/CellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/CellEditorViewImpl.ui.xml
@@ -1,11 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:FormGroup ui:field="formGroup" addStyleNames="margin-bottom-0-imp">
     <b:TextBox ui:field="textBox" styleName="form-control min-width-140" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellEditorViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bd="urn:import:org.gwtbootstrap3.extras.datetimepicker.client.ui"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellRendererViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/DateCellRendererViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Text ui:field="text" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/EntityIdCellRendererViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/EntityIdCellRendererViewImpl.ui.xml
@@ -1,10 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/FileCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/FileCellEditorViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <g:HTMLPanel>
     <b:FormGroup ui:field="formGroup" addStyleNames="margin-bottom-0-imp">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/FileCellRendererViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/FileCellRendererViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <g:HTMLPanel>
     <bh:Span ui:field="loadingUI">Loading...</bh:Span>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/JSONListCellEditorViewImpl.ui.xml
@@ -3,8 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:FormGroup ui:field="formGroup" addStyleNames="margin-bottom-0-imp">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/LargeStringCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/LargeStringCellEditorViewImpl.ui.xml
@@ -1,11 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:FormGroup ui:field="formGroup" addStyleNames="margin-bottom-0-imp">
     <b:TextArea ui:field="textArea" visibleLines="5" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/ListCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/ListCellEditorViewImpl.ui.xml
@@ -1,9 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:ListBox ui:field="listBox" />
 </ui:UiBinder>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/NumberCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/NumberCellEditorViewImpl.ui.xml
@@ -1,12 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <b:FormGroup ui:field="formGroup" addStyleNames="margin-bottom-0-imp">
     <b:TextBox ui:field="textBox" styleName="form-control min-width-42" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/RadioCellEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/cell/RadioCellEditorViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div ui:field="container" addStyleNames="margin-left-5" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultDateRangeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultDateRangeViewImpl.ui.xml
@@ -3,8 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:bd="urn:import:org.gwtbootstrap3.extras.datetimepicker.client.ui"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultRangeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultRangeViewImpl.ui.xml
@@ -3,10 +3,7 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:b3="urn:import:org.gwtbootstrap3.extras.slider.client.ui"
 >
   <bh:Div>
     <bh:Div addStyleNames="margin-top-15 margin-bottom-5">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultSliderRangeViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultSliderRangeViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:b3="urn:import:org.gwtbootstrap3.extras.slider.client.ui"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultValuesViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/results/facets/FacetColumnResultValuesViewImpl.ui.xml
@@ -1,10 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <bh:Div>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelTableRowEditorViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelTableRowEditorViewImpl.ui.xml
@@ -4,7 +4,6 @@
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
-  xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
   <t:TableRow>
     <t:TableData addStyleNames="vertical-align-middle">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelTableRowViewerImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelTableRowViewerImpl.ui.xml
@@ -1,8 +1,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenMembershipRequestWidget.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenMembershipRequestWidget.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow addStyleNames="border-bottom-1" height="55px">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenMembershipRequestsWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenMembershipRequestsWidgetViewImpl.ui.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenTeamInvitationWidget.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenTeamInvitationWidget.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow addStyleNames="border-bottom-1" height="55px">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenTeamInvitationsWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenTeamInvitationsWidgetViewImpl.ui.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:table="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenUserInvitationWidget.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/OpenUserInvitationWidget.ui.xml
@@ -3,7 +3,6 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <t:TableRow addStyleNames="border-bottom-1" height="55px">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/SelectTeamModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/SelectTeamModalViewImpl.ui.xml
@@ -1,7 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamDeleteModalWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamDeleteModalWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamEditModalWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamEditModalWidgetViewImpl.ui.xml
@@ -2,10 +2,8 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >
@@ -72,8 +70,8 @@
         </b:FormGroup>
         <b:FormGroup addStyleNames="margin-top-20">
           <b:FormLabel for="uploadWidget">Upload new icon</b:FormLabel>
-          <b:Row b:id="uploadWidget">
-            <b:Column size="MD_4">
+          <MUI:Grid b:id="uploadWidget">
+            <MUI:Grid md="4">
               <bh:Div ui:field="iconContainer">
                 <b:Icon
                   ui:field="defaultIcon"
@@ -104,11 +102,11 @@
                 size="16px"
                 visible="false"
               />
-            </b:Column>
-            <b:Column size="MD_8">
+            </MUI:Grid>
+            <MUI:Grid md="8">
               <g:SimplePanel ui:field="uploadWidgetPanel" />
-            </b:Column>
-          </b:Row>
+            </MUI:Grid>
+          </MUI:Grid>
         </b:FormGroup>
       </b:FieldSet>
       <g:SimplePanel ui:field="synAlertPanel" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamLeaveModalWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamLeaveModalWidgetViewImpl.ui.xml
@@ -2,11 +2,7 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <b:Modal

--- a/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamProjectsModalWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/team/controller/TeamProjectsModalWidgetViewImpl.ui.xml
@@ -3,7 +3,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:tr="urn:import:org.sagebionetworks.web.client.widget.table.v2.results"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/CroppedImageUploadViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/CroppedImageUploadViewImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleLink.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleLink.ui.xml
@@ -1,10 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.widget"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleListViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleListViewImpl.ui.xml
@@ -1,6 +1,5 @@
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:s="urn:import:org.sagebionetworks.web.client.widget"

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleUploadViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileHandleUploadViewImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileInputViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/FileInputViewImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
 >
   <g:HTMLPanel>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/upload/ImageUploadViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/upload/ImageUploadViewImpl.ui.xml
@@ -2,8 +2,6 @@
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
   xmlns:g="urn:import:com.google.gwt.user.client.ui"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
 >

--- a/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationIDCardViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationIDCardViewImpl.ui.xml
@@ -1,11 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:s="urn:import:org.sagebionetworks.web.client.view"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
-  xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
 >
   <b:Modal title="Validated Synapse Profile" closable="false" ui:field="modal">
     <b:ModalBody addStyleNames="bg-primary color-white">

--- a/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionModalViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionModalViewImpl.ui.xml
@@ -1,11 +1,8 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-  xmlns:a="urn:import:org.sagebionetworks.web.client.widget.table.v2"
-  xmlns:bg="urn:import:org.gwtbootstrap3.client.ui.gwt"
+  xmlns:MUI="urn:import:org.sagebionetworks.web.client.jsinterop.mui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"
   xmlns:w="urn:import:org.sagebionetworks.web.client.widget"
@@ -52,8 +49,8 @@
           text="Public profile information"
           addStyleNames="color-white"
         />
-        <b:Row>
-          <b:Column size="SM_6">
+        <MUI:Grid container="true">
+          <MUI:Grid sm="6">
             <b:FormGroup>
               <b:FormLabel>First name</b:FormLabel>
               <bh:Div addStyleNames="whiteBackground rounded">
@@ -64,8 +61,8 @@
                 />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="SM_6">
+          </MUI:Grid>
+          <MUI:Grid sm="6">
             <b:FormGroup>
               <b:FormLabel>Last name</b:FormLabel>
               <bh:Div addStyleNames="whiteBackground rounded">
@@ -76,10 +73,10 @@
                 />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="SM_6">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid sm="6">
             <b:FormGroup>
               <b:FormLabel>Affiliation</b:FormLabel>
               <bh:Div addStyleNames="whiteBackground rounded">
@@ -90,8 +87,8 @@
                 />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-          <b:Column size="SM_6">
+          </MUI:Grid>
+          <MUI:Grid sm="6">
             <b:FormGroup>
               <b:FormLabel>Location</b:FormLabel>
               <bh:Div addStyleNames="whiteBackground rounded">
@@ -102,10 +99,10 @@
                 />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
-        <b:Row>
-          <b:Column size="SM_12">
+          </MUI:Grid>
+        </MUI:Grid>
+        <MUI:Grid container="true">
+          <MUI:Grid sm="12">
             <b:FormGroup>
               <b:FormLabel>ORCID</b:FormLabel>
               <bh:Div>
@@ -116,8 +113,8 @@
                 />
               </bh:Div>
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
       </bh:Div>
       <bh:Div
         ui:field="actOnly"
@@ -128,14 +125,14 @@
           The following will only be visible to the Sage Bionetworks Access and
           Compliance Team upon submission.
         </bh:Paragraph>
-        <b:Row>
-          <b:Column size="SM_12">
+        <MUI:Grid container="true">
+          <MUI:Grid sm="12">
             <b:FormGroup>
               <b:FormLabel>Email</b:FormLabel>
               <bh:Div ui:field="emailAddresses" />
             </b:FormGroup>
-          </b:Column>
-        </b:Row>
+          </MUI:Grid>
+        </MUI:Grid>
         <b:FormGroup ui:field="uploadedFilesUI">
           <b:FormLabel>
             Upload your signed and initialed Synapse Pledge AND your

--- a/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionRowViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionRowViewImpl.ui.xml
@@ -1,8 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder
   xmlns:ui="urn:ui:com.google.gwt.uibinder"
-  xmlns:g="urn:import:com.google.gwt.user.client.ui"
-  xmlns:c="urn:import:com.google.gwt.user.cellview.client"
   xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
   xmlns:bh="urn:import:org.gwtbootstrap3.client.ui.html"
   xmlns:t="urn:import:org.sagebionetworks.web.client.view.bootstrap.table"

--- a/src/main/webapp/Portal.html
+++ b/src/main/webapp/Portal.html
@@ -157,7 +157,6 @@
       // The Bootstrap 3 custom theme CSS is loaded through swc.scss
       // Note: we alias to bootstrap3 because we rely on Bootstrap 4 to be in node_modules/bootstrap to compile our scss (via synapse-react-client).
       loadJs(cdnEndpoint + 'generated/bootstrap/dist/js/bootstrap.min.js')
-      loadJs(cdnEndpoint + 'generated/bootstrap/dist/js/npm.js')
       loadJs(cdnEndpoint + 'js/back-forward-nav-handler.js')
       loadJs(cdnEndpoint + 'generated/moment.min.js')
       loadJs(cdnEndpoint + 'generated/jsplumb.min.js')
@@ -188,6 +187,7 @@
       loadJs(cdnEndpoint + 'generated/pica.min.js')
       loadJs(reactPath)
       loadJs(reactDomPath)
+      loadJs(cdnEndpoint + 'generated/material-ui.production.min.js')
       loadJs(cdnEndpoint + 'generated/react-transition-group.min.js')
       loadJs(cdnEndpoint + 'generated/prop-types.min.js')
       loadJs(cdnEndpoint + 'generated/react-measure.js')


### PR DESCRIPTION
Main logical changes to review can be seen [here](https://github.com/Sage-Bionetworks/SynapseWebClient/pull/5498/files/7c4c2bc6974a78a44d46e40ca7ba2d98bf843018..e59a0d00ab6379be73e8292975ee727dc2ea293b). 


All changes:

* Reapply "Merge pull request #5433 from nickgros/SWC-6882b" - adds back MUI Grid2 replacement for GWTBootstrap3 Row/Column widgets
* Rename ReactNode to ReactElement
  * ReactElement describes the object explicitly returned by React.createElement, while ReactNode describes anything that React can render (including ReactElement).  For our purposes, ReactElement is more appropriate to use.
* Add ReactComponentV2 that better handles managing a component tree
  * Added abstract class ReactComponentV2 and refined logic to more cleanly and properly handle component tree management. Specifically, the class now:
    * Keeps track of appended DOM elements and removes those previously appended before each render
    * After the widget is removed, all child implementers of ReactComponentV2 are re-rendered, allowing them to clean up resources
* Updated ReactComponent to remove ability to append children, more closely resembling previous version (ReactComponentDiv)
* Improved generic types for React JsInterop bindings