### PR TITLE
SWC-7040 - Bump Java version to 11

### DIFF
--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -3,10 +3,10 @@ description: 'Build SWC'
 runs:
   using: 'composite'
   steps:
-    - name: Set up JDK 17
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'corretto'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -3,11 +3,11 @@ description: 'Build SWC'
 runs:
   using: 'composite'
   steps:
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: '8'
-        distribution: 'temurin'
+        java-version: '17'
+        distribution: 'corretto'
         cache: maven
     - name: Build with Maven
       shell: bash

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.17.0",
+    "concurrently": "^8.2.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.0.1",
     "husky": ">=6",
@@ -54,16 +55,17 @@
     "prettier": "^3.2.5",
     "prettier-plugin-java": "2.5.0",
     "typescript": "5.1.6",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "wait-on": "^8.0.0"
   },
   "lint-staged": {
     "*.{*}": "prettier --write"
   },
   "scripts": {
     "build": "mvn -B package --file pom.xml",
-    "dev": "npm-run-all --parallel dev:tomcat dev:codeserver",
-    "dev:tomcat": "docker pull tomcat:9.0; docker run --name swc-dev --rm -p 8888:8080 -v \"/$(pwd)/target/portal-develop-SNAPSHOT/:/usr/local/tomcat/webapps/ROOT/\" -v \"/$HOME/.m2/settings.xml\":/root/.m2/settings.xml tomcat:9.0",
-    "dev:codeserver": "mvn gwt:run-codeserver -Dgwt.compiler.skip=true -Dnoserver=true -Dwar=/$(pwd)/target/portal-develop-SNAPSHOT -Dstyle=PRETTY",
+    "dev": "concurrently -k -n \"CODESERVER,TOMCAT\" -c \"auto,auto\" \"yarn dev:codeserver\" \"yarn dev:tomcat\"",
+    "dev:codeserver": "mvn clean gwt:run-codeserver",
+    "dev:tomcat": "wait-on tcp:9876 && docker pull tomcat:9.0; docker run --name swc-dev --rm -p 8888:8080 -v \"/$(pwd)/target/portal-develop-SNAPSHOT/:/usr/local/tomcat/webapps/ROOT/\" -v \"/$HOME/.m2/settings.xml\":/root/.m2/settings.xml tomcat:9.0",
     "docker:start": "docker pull tomcat:9.0; docker run --name swc-tomcat -d --rm -p 8888:8080 -v \"/$(pwd)/target/portal-develop-SNAPSHOT.war:/usr/local/tomcat/webapps/ROOT.war\" -v \"/$(pwd)/e2e_workflow/settings.xml\":/root/.m2/settings.xml tomcat:9.0",
     "docker:stop": "docker stop swc-tomcat",
     "prepare": "husky install",

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
                 src/main/webapp/sass:src/main/webapp/generated
               </arguments>
             </configuration>
-            <phase>compile</phase>
+            <phase>process-resources</phase>
           </execution>
         </executions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
   <properties>
     <!-- Synapse Web Client -->
     <!-- GWT needs at least java 1.5 -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <webappDirectory>
       ${project.build.directory}/${project.build.finalName}
     </webappDirectory>
     <synapse.version>499.0</synapse.version>
     <gwtVersion>2.11.0</gwtVersion>
     <org.springframework.version>5.3.37</org.springframework.version>
-    <guiceVersion>3.0</guiceVersion>
+    <guiceVersion>6.0.0</guiceVersion>
     <ginVersion>2.1.2</ginVersion>
     <xstream.version>1.3.1</xstream.version>
     <schema-to-pojo.version>0.6.10</schema-to-pojo.version>
@@ -242,6 +242,12 @@
         <version>3.3.2</version>
         <configuration>
           <filesets>
+            <fileset>
+              <directory>gwt-unitCache</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+            </fileset>
             <fileset>
               <!-- Clean dir where we copy JS/CSS from node_modules -->
               <directory>src/main/webapp/generated</directory>
@@ -587,6 +593,20 @@
       </plugin>
     </plugins>
   </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${guiceVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-servlet</artifactId>
+        <version>${guiceVersion}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.gwt.eventbinder</groupId>
@@ -784,16 +804,22 @@
       <version>${guiceVersion}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-servlet</artifactId>
+      <version>${guiceVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+      <version>${guiceVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.gwt.inject</groupId>
       <artifactId>gin</artifactId>
       <version>${ginVersion}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-servlet</artifactId>
-      <version>${guiceVersion}</version>
-    </dependency>
+
     <!-- This provides the GWT MVP framework -->
     <dependency>
       <groupId>com.gwtplatform</groupId>
@@ -906,8 +932,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,8 @@
 
   <properties>
     <!-- Synapse Web Client -->
-    <!-- GWT needs at least java 1.5 -->
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <webappDirectory>
       ${project.build.directory}/${project.build.finalName}
     </webappDirectory>
@@ -208,12 +207,15 @@
               <goal>compile</goal>
               <goal>test</goal>
               <goal>i18n</goal>
+              <goal>run-codeserver</goal>
             </goals>
           </execution>
         </executions>
         <!-- Plugin configuration. There are many available options, see gwt-maven-plugin 
 					documentation at codehaus.org -->
         <configuration>
+          <workDir>${project.build.directory}/gwt/codeserver</workDir>
+          <launcherDir>${webappDirectory}</launcherDir>
           <runTarget>Portal.html</runTarget>
           <hostedWebapp>${webappDirectory}</hostedWebapp>
           <i18nMessagesBundle>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <!-- Synapse Web Client -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <webappDirectory>
       ${project.build.directory}/${project.build.finalName}
     </webappDirectory>

--- a/src/test/java/org/sagebionetworks/web/client/SynapseJavascriptClientTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/SynapseJavascriptClientTest.java
@@ -80,7 +80,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.exceptions.SynapseTooManyRequestsException;
 import org.sagebionetworks.repo.model.EntityChildrenRequest;
 import org.sagebionetworks.repo.model.ErrorResponseCode;
@@ -138,7 +138,7 @@ import org.sagebionetworks.web.shared.exceptions.TooManyRequestsException;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
 import org.sagebionetworks.web.shared.exceptions.UnknownErrorException;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SynapseJavascriptClientTest {
 
   SynapseJavascriptClient client;
@@ -225,9 +225,7 @@ public class SynapseJavascriptClientTest {
     when(mockJsniUtils.getAccessTokenCookieUrl())
       .thenReturn(SESSION_COOKIE_URL);
 
-    when(
-      mockRequestBuilder.sendRequest(anyString(), any(RequestCallback.class))
-    )
+    when(mockRequestBuilder.sendRequest(any(), any(RequestCallback.class)))
       .thenReturn(mockRequest1, mockRequest2);
     client =
       new SynapseJavascriptClient(
@@ -1211,7 +1209,7 @@ public class SynapseJavascriptClientTest {
 
     client.deleteEntityById("syn111", null);
 
-    verify(mockRequestBuilder).sendRequest(anyString(), any());
+    verify(mockRequestBuilder).sendRequest(any(), any());
 
     // verify no requests are associated to the current URL
     assertNull(client.getCancellableRequests(currentUrl));

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.auth.LoginRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
@@ -54,7 +54,7 @@ import org.sagebionetworks.web.shared.exceptions.ForbiddenException;
 import org.sagebionetworks.web.shared.exceptions.UnknownErrorException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AuthenticationControllerImplTest {
 
   public static final String ACCESS_TOKEN = "1111";

--- a/src/test/java/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParserTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/widget/CommaSeparatedValuesParserTest.java
@@ -9,11 +9,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.widget.csv.PapaCSVParser;
 import org.sagebionetworks.web.client.widget.csv.PapaParseResult;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CommaSeparatedValuesParserTest extends TestCase {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetTest.java
@@ -10,11 +10,11 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.jsinterop.EntityModalProps;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityModalWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetTest.java
@@ -10,12 +10,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.jsinterop.EntityViewScopeEditorModalProps;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityViewScopeEditorModalWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetTest.java
@@ -10,12 +10,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.jsinterop.SqlDefinedTableEditorModalProps;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SqlDefinedEditorModalWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/ClientPropertiesTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/ClientPropertiesTest.java
@@ -5,10 +5,10 @@ import static org.sagebionetworks.web.client.ClientProperties.fixResourceToCdnEn
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.resources.WebResource;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ClientPropertiesTest {
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/DateTimeUtilsImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/DateTimeUtilsImplTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.unitclient;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,12 +21,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.DateTimeUtilsImpl;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.Moment;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DateTimeUtilsImplTest {
 
   @Mock
@@ -111,7 +112,7 @@ public class DateTimeUtilsImplTest {
 
     d = new Date();
     dateTimeUtils.getRelativeTime(d);
-    verify(mockMoment).getRelativeTime(anyString());
+    verify(mockMoment).getRelativeTime(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/GlobalApplicationStateImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/GlobalApplicationStateImplTest.java
@@ -121,7 +121,7 @@ public class GlobalApplicationStateImplTest {
     AsyncMockStubber
       .callSuccessWith("v1")
       .when(mockJsClient)
-      .getSynapseVersions(any(AsyncCallback.class));
+      .getSynapseVersions(any());
 
     globalApplicationState =
       new GlobalApplicationStateImpl(
@@ -398,15 +398,15 @@ public class GlobalApplicationStateImplTest {
     globalApplicationState.pushCurrentPlace(mockPlace);
     // should have set the last place (to the current), and the current place (as requested)
     verify(mockSessionStorage)
-      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), anyString());
+      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), any());
     verify(mockGWT).newItem(newToken, false);
 
     // if I push the same place again, it should not push the history state again
-    when(mockAppPlaceHistoryMapper.getPlace(anyString())).thenReturn(mockPlace);
+    when(mockAppPlaceHistoryMapper.getPlace(any())).thenReturn(mockPlace);
     globalApplicationState.pushCurrentPlace(mockPlace);
     // verify that these were still only called once
     verify(mockSessionStorage)
-      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), anyString());
+      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), any());
     verify(mockGWT).newItem(newToken, false);
   }
 
@@ -418,15 +418,15 @@ public class GlobalApplicationStateImplTest {
     globalApplicationState.replaceCurrentPlace(mockPlace);
     // should have set the last place (to the current), and the current place (as requested)
     verify(mockSessionStorage)
-      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), anyString());
+      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), any());
     verify(mockGWT).replaceItem(newToken, false);
 
     // if I push the same place again, it should not push the history state again
-    when(mockAppPlaceHistoryMapper.getPlace(anyString())).thenReturn(mockPlace);
+    when(mockAppPlaceHistoryMapper.getPlace(any())).thenReturn(mockPlace);
     globalApplicationState.replaceCurrentPlace(mockPlace);
     // verify that these were still only called once
     verify(mockSessionStorage)
-      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), anyString());
+      .setItem(eq(GlobalApplicationStateImpl.LAST_PLACE), any());
     verify(mockGWT).replaceItem(newToken, false);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SessionDetector;
@@ -19,7 +19,7 @@ import org.sagebionetworks.web.client.cache.ClientCache;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.utils.Callback;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SessionDetectorTest {
 
   SessionDetector sessionDetector;

--- a/src/test/java/org/sagebionetworks/web/unitclient/mvp/AppActivityMapperTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/mvp/AppActivityMapperTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -33,7 +33,7 @@ import org.sagebionetworks.web.client.security.AuthenticationController;
  * @author jmhill
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AppActivityMapperTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTAccessApprovalsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTAccessApprovalsPresenterTest.java
@@ -186,10 +186,10 @@ public class ACTAccessApprovalsPresenterTest {
     verify(mockView).setLoadMoreContainer(mockLoadMoreContainer);
     verify(mockView).setShowHideButton(mockShowHideAccessRequirementButton);
     verify(mockView).setAccessRequirementWidget(mockAccessRequirementWidget);
-    verify(mockView).setSubmitterPickerWidget(any(Widget.class));
-    verify(mockView).setSelectedSubmitterUserBadge(any(Widget.class));
-    verify(mockView).setAccessorPickerWidget(any(Widget.class));
-    verify(mockView).setSelectedAccessorUserBadge(any(Widget.class));
+    verify(mockView).setSubmitterPickerWidget(any());
+    verify(mockView).setSelectedSubmitterUserBadge(any());
+    verify(mockView).setAccessorPickerWidget(any());
+    verify(mockView).setSelectedAccessorUserBadge(any());
     verify(mockView).setPresenter(presenter);
     verify(mockSubmitterSuggestWidget)
       .addItemSelectedHandler(any(CallbackP.class));

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTDataAccessSubmissionDashboardPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTDataAccessSubmissionDashboardPresenterTest.java
@@ -81,7 +81,7 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
 
   @Test
   public void testConstructor() {
-    verify(mockView, times(3)).add(any(Widget.class));
+    verify(mockView, times(3)).add(any());
     verify(mockView).addTitle(TITLE);
     verify(mockNoResultsDiv).setText(NO_RESULTS);
     verify(mockNoResultsDiv).addStyleName("min-height-400");
@@ -92,8 +92,7 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
     Callback callback = captor.getValue();
     callback.invoke();
     verify(mockSynAlert).clear();
-    verify(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+    verify(mockDataAccessClient).getOpenSubmissions(any(), any());
   }
 
   @Test
@@ -103,7 +102,7 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
     verify(mockLoadMoreContainer).clear();
     verify(mockSynAlert).clear();
     verify(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any(AsyncCallback.class));
   }
 
   @Test
@@ -112,10 +111,12 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any());
+
     presenter.loadMore();
+
     verify(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any(AsyncCallback.class));
     InOrder inOrder = inOrder(mockSynAlert);
     inOrder.verify(mockSynAlert).clear();
     inOrder.verify(mockSynAlert).handleException(ex);
@@ -129,10 +130,12 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
     AsyncMockStubber
       .callSuccessWith(page)
       .when(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any());
+
     presenter.loadMore();
+
     verify(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any(AsyncCallback.class));
     verify(mockSynAlert).clear();
     verify(mockNoResultsDiv).setVisible(true);
     verify(mockLoadMoreContainer, never()).add(any(Widget.class));
@@ -149,17 +152,19 @@ public class ACTDataAccessSubmissionDashboardPresenterTest {
     AsyncMockStubber
       .callSuccessWith(page)
       .when(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any());
     when(mockGinInjector.getOpenSubmissionWidget())
       .thenReturn(mockOpenSubmissionWidget);
+
     presenter.loadMore();
+
     verify(mockDataAccessClient)
-      .getOpenSubmissions(anyString(), any(AsyncCallback.class));
+      .getOpenSubmissions(any(), any(AsyncCallback.class));
     verify(mockSynAlert).clear();
     verify(mockNoResultsDiv, atLeastOnce()).setVisible(false);
     verify(mockGinInjector).getOpenSubmissionWidget();
     verify(mockOpenSubmissionWidget).configure(openSubmission);
-    verify(mockLoadMoreContainer).add(any(Widget.class));
+    verify(mockLoadMoreContainer).add(any());
     verify(mockLoadMoreContainer).setIsMore(true);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTDataAccessSubmissionsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTDataAccessSubmissionsPresenterTest.java
@@ -173,18 +173,18 @@ public class ACTDataAccessSubmissionsPresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockACTAccessRequirement)
       .when(mockJsClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+      .getAccessRequirement(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockDataAccessSubmissionPage)
       .when(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
     when(mockDataAccessSubmissionPage.getResults())
       .thenReturn(Collections.singletonList(mockDataAccessSubmission));
@@ -267,13 +267,13 @@ public class ACTDataAccessSubmissionsPresenterTest {
     verify(mockLoadMoreContainer).setIsProcessing(true);
     verify(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
+        any(),
         eq(ACCESSOR_ID),
-        eq((String) null),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        eq(null),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
 
     // verify DataAccessSubmission widget is created/configured for the submission (based on the
@@ -293,13 +293,13 @@ public class ACTDataAccessSubmissionsPresenterTest {
     presenter.loadMore();
     verify(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
+        any(),
         eq(ACCESSOR_ID),
         eq(NEXT_PAGE_TOKEN),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
     verify(mockLoadMoreContainer).setIsMore(false);
     verify(mockView).setProjectedExpirationDateVisible(false);
@@ -334,13 +334,13 @@ public class ACTDataAccessSubmissionsPresenterTest {
     verify(mockPlace).removeParam(ACCESSOR_ID_PARAM);
     verify(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
-        eq((String) null),
-        eq((String) null),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        any(),
+        eq(null),
+        eq(null),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
   }
 
@@ -356,13 +356,13 @@ public class ACTDataAccessSubmissionsPresenterTest {
 
     verify(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
+        any(),
         eq(USER_ID_SELECTED),
-        eq((String) null),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        eq(null),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
   }
 
@@ -373,13 +373,13 @@ public class ACTDataAccessSubmissionsPresenterTest {
       .callFailureWith(ex)
       .when(mockJsClient)
       .getDataAccessSubmissions(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(SubmissionState.class),
-        any(SubmissionOrder.class),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
         anyBoolean(),
-        any(AsyncCallback.class)
+        any()
       );
     presenter.loadData();
     verify(mockSynAlert).handleException(ex);

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ACTPresenterTest.java
@@ -112,13 +112,7 @@ public class ACTPresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockVerificationPagedResults)
       .when(mockUserProfileClient)
-      .listVerificationSubmissions(
-        any(VerificationStateEnum.class),
-        anyLong(),
-        anyLong(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .listVerificationSubmissions(any(), any(), any(), any(), any());
     when(mockVerificationPagedResults.getResults())
       .thenReturn(Collections.singletonList(mockVerificationSubmission));
     when(mockGinInjector.getVerificationSubmissionWidget())
@@ -130,10 +124,10 @@ public class ACTPresenterTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setSynAlert(any());
     verify(mockView).setStates(anyList());
-    verify(mockView).setUserPickerWidget(any(Widget.class));
-    verify(mockView).setSelectedUserBadge(any(Widget.class));
+    verify(mockView).setUserPickerWidget(any());
+    verify(mockView).setSelectedUserBadge(any());
     verify(mockPeopleSuggestBox).setTypeFilter(TypeFilter.USERS_ONLY);
   }
 
@@ -142,13 +136,13 @@ public class ACTPresenterTest {
     widget.loadData();
     verify(mockLoadMoreWidgetContainer).clear();
     verify(mockSynapseAlert).clear();
-    verify(mockGlobalApplicationState).pushCurrentPlace(any(Place.class));
+    verify(mockGlobalApplicationState).pushCurrentPlace(any());
     verify(mockGinInjector).getVerificationSubmissionWidget();
     boolean isACTMember = true;
     boolean isModal = false;
     verify(mockVerificationSubmissionWidget)
       .configure(mockVerificationSubmission, isACTMember, isModal);
-    verify(mockLoadMoreWidgetContainer).add(any(Widget.class));
+    verify(mockLoadMoreWidgetContainer).add(any());
     verify(mockVerificationSubmissionWidget).show();
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessRequirementPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessRequirementPresenterTest.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.repo.model.RestrictableObjectType;
@@ -30,7 +30,7 @@ import org.sagebionetworks.web.client.widget.accessrequirements.AccessRequiremen
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AccessRequirementPresenterTest {
 
   AccessRequirementPresenter presenter;
@@ -89,8 +89,8 @@ public class AccessRequirementPresenterTest {
 
   @Test
   public void testConstruction() {
-    verify(mockArDiv).add(any(Widget.class));
-    verify(mockView).add(any(Widget.class));
+    verify(mockArDiv).add(any());
+    verify(mockView).add(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessRequirementsPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/AccessRequirementsPresenterTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.unitclient.presenter;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
@@ -176,9 +177,9 @@ public class AccessRequirementsPresenterTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView, atLeastOnce()).add(any(Widget.class));
-    verify(mockView, atLeastOnce()).addTitle(any(Widget.class));
-    verify(mockView, atLeastOnce()).addAboveBody(any(Widget.class));
+    verify(mockView, atLeastOnce()).add(any());
+    verify(mockView, atLeastOnce()).addTitle(anyString());
+    verify(mockView, atLeastOnce()).addAboveBody(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ChangeUsernamePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ChangeUsernamePresenterTest.java
@@ -97,7 +97,7 @@ public class ChangeUsernamePresenterTest {
     verify(mockSynapseClient)
       .updateUserProfile(any(UserProfile.class), any(AsyncCallback.class));
     verify(mockAuthenticationController).updateCachedProfile(eq(profile));
-    verify(mockCallback).onSuccess(any(Void.class));
+    verify(mockCallback).onSuccess(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/DataAccessManagementPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/DataAccessManagementPresenterTest.java
@@ -8,12 +8,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.place.DataAccessManagementPlace;
 import org.sagebionetworks.web.client.presenter.DataAccessManagementPresenter;
 import org.sagebionetworks.web.client.view.DataAccessManagementView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DataAccessManagementPresenterTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/DownloadCartPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/DownloadCartPresenterTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.search.query.KeyRange;
 import org.sagebionetworks.repo.model.search.query.KeyValue;
@@ -49,7 +49,7 @@ import org.sagebionetworks.web.client.widget.sharing.AccessControlListModalWidge
 import org.sagebionetworks.web.shared.SearchQueryUtils;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DownloadCartPresenterTest {
 
   DownloadCartPresenter presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EmailInvitationPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EmailInvitationPresenterTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.InviteeVerificationSignedToken;
 import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.MembershipInvtnSignedToken;
@@ -40,7 +40,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.shared.exceptions.ForbiddenException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EmailInvitationPresenterTest {
 
   public static final String CURRENT_USER_ID = "987387483";

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/EntityPresenterTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
@@ -59,7 +59,7 @@ import org.sagebionetworks.web.client.widget.team.OpenTeamInvitationsWidget;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityPresenterTest {
 
   @Mock
@@ -254,13 +254,7 @@ public class EntityPresenterTest {
     verify(mockView).setEntityPageTopVisible(true);
     verify(mockEntityPageTop, atLeastOnce()).clearState();
     verify(mockEntityPageTop)
-      .configure(
-        eq(eb),
-        eq(versionNumber),
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
-      );
+      .configure(eq(eb), eq(versionNumber), any(), any(), any());
     verify(mockView, times(2)).setEntityPageTopWidget(mockEntityPageTop);
     verify(mockView).setOpenTeamInvitesWidget(mockOpenInviteWidget);
     verify(mockHeaderWidget).refresh();
@@ -276,7 +270,7 @@ public class EntityPresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockFileEntity)
       .when(mockSynapseJavascriptClient)
-      .getEntity(anyString(), any(AsyncCallback.class));
+      .getEntity(any(), any());
 
     entityPresenter.setPlace(mockPlace);
 
@@ -307,13 +301,7 @@ public class EntityPresenterTest {
     verify(mockView).setEntityPageTopVisible(true);
     verify(mockEntityPageTop, atLeastOnce()).clearState();
     verify(mockEntityPageTop)
-      .configure(
-        eq(eb),
-        eq(versionNumber),
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
-      );
+      .configure(eq(eb), eq(versionNumber), any(), any(), any());
 
     verify(mockView, times(2)).setEntityPageTopWidget(mockEntityPageTop);
   }
@@ -431,9 +419,9 @@ public class EntityPresenterTest {
       .configure(
         eq(eb),
         eq(null), // verify the draft version is loaded
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
+        any(),
+        any(),
+        any()
       );
   }
 
@@ -450,9 +438,9 @@ public class EntityPresenterTest {
       .configure(
         eq(eb),
         eq(latestSnapshotVersionNumber), // verify the latest snapshot version is loaded
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
+        any(),
+        any(),
+        any()
       );
   }
 
@@ -489,9 +477,9 @@ public class EntityPresenterTest {
       .configure(
         eq(eb),
         eq(null), // verify the draft version is loaded because there are no snapshots
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
+        any(),
+        any(),
+        any()
       );
   }
 
@@ -514,9 +502,9 @@ public class EntityPresenterTest {
       .configure(
         eq(eb),
         eq(null), // verify the draft version is loaded
-        any(EntityHeader.class),
-        any(EntityArea.class),
-        anyString()
+        any(),
+        any(),
+        any()
       );
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ErrorPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ErrorPresenterTest.java
@@ -8,14 +8,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.place.ErrorPlace;
 import org.sagebionetworks.web.client.presenter.ErrorPresenter;
 import org.sagebionetworks.web.client.view.ErrorView;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ErrorPresenterTest {
 
   ErrorPresenter presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/HomePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/HomePresenterTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.place.Home;
@@ -24,7 +24,7 @@ import org.sagebionetworks.web.client.presenter.HomePresenter;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.view.HomeView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class HomePresenterTest {
 
   HomePresenter presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/MapPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/MapPresenterTest.java
@@ -41,8 +41,8 @@ public class MapPresenterTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setMap(any(Widget.class));
-    verify(mockView).setTeamBadge(any(Widget.class));
+    verify(mockView).setMap(any());
+    verify(mockView).setTeamBadge(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/NewAccountPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/NewAccountPresenterTest.java
@@ -231,9 +231,9 @@ public class NewAccountPresenterTest {
         any(AsyncCallback.class)
       );
 
-    ArgumentCaptor<AsyncCallback<UserProfile>> captor = new ArgumentCaptor<
-      AsyncCallback<UserProfile>
-    >();
+    ArgumentCaptor<AsyncCallback<UserProfile>> captor = ArgumentCaptor.forClass(
+      AsyncCallback.class
+    );
     verify(mockAuthController)
       .setNewAccessToken(eq(testSessionToken), captor.capture());
     AsyncCallback<UserProfile> onSetNewAccessToken = captor.getValue();

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/PasswordResetSignedTokenPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/PasswordResetSignedTokenPresenterTest.java
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.JoinTeamSignedToken;
 import org.sagebionetworks.repo.model.auth.ChangePasswordWithToken;
 import org.sagebionetworks.repo.model.auth.PasswordResetSignedToken;
@@ -31,7 +31,7 @@ import org.sagebionetworks.web.client.view.PasswordResetSignedTokenView;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class PasswordResetSignedTokenPresenterTest {
 
   PasswordResetSignedTokenPresenter presenter;
@@ -107,7 +107,7 @@ public class PasswordResetSignedTokenPresenterTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setSynAlertWidget(any(Widget.class));
+    verify(mockView).setSynAlertWidget(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/PeopleSearchPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/PeopleSearchPresenterTest.java
@@ -108,7 +108,7 @@ public class PeopleSearchPresenterTest {
       );
     verify(mockView).setSearchTerm(searchTerm);
     verify(mockPortalGinInjector, times(3)).getUserBadgeWidget();
-    verify(mockLoadMoreWidgetContainer, times(3)).add(any(Widget.class));
+    verify(mockLoadMoreWidgetContainer, times(3)).add(any());
   }
 
   @Test
@@ -117,13 +117,7 @@ public class PeopleSearchPresenterTest {
     AsyncMockStubber
       .callFailureWith(caught)
       .when(mockSynapseJavascriptClient)
-      .getUserGroupHeadersByPrefix(
-        anyString(),
-        any(TypeFilter.class),
-        anyLong(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getUserGroupHeadersByPrefix(any(), any(), anyLong(), anyLong(), any());
     presenter.setPlace(mockPlace);
     verify(mockSynAlert).handleException(caught);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -194,35 +194,26 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockUserBundle)
       .when(mockSynapseJavascriptClient)
-      .getUserBundle(anyLong(), anyInt(), any(AsyncCallback.class));
+      .getUserBundle(any(), anyInt(), any());
     when(mockPrincipalAliasResponse.getPrincipalId())
       .thenReturn(targetUserIdLong);
     AsyncMockStubber
       .callSuccessWith(mockPrincipalAliasResponse)
       .when(mockSynapseJavascriptClient)
-      .getPrincipalAlias(
-        any(PrincipalAliasRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getPrincipalAlias(any(), any());
     when(mockUserBundle.getUserProfile()).thenReturn(userProfile);
     when(mockUserBundle.getIsCertified()).thenReturn(true);
     when(mockUserBundle.getIsVerified()).thenReturn(false);
     when(mockUserBundle.getORCID()).thenReturn(ORC_ID);
     // by default, we only have a single page of results
     when(mockPaginatedTeamIds.getNextPageToken()).thenReturn(null);
-    when(
-      mockSynapseJavascriptClient.getUserTeams(
-        anyString(),
-        anyBoolean(),
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getUserTeams(any(), anyBoolean(), any()))
       .thenReturn(
         getDoneFuture(mockPaginatedTeamIds),
         getDoneFuture(mockPaginatedTeamIdsPage2)
       );
     myTeams = getUserTeams();
-    when(mockSynapseJavascriptClient.listTeams(anyList()))
+    when(mockSynapseJavascriptClient.listTeams(any()))
       .thenReturn(getDoneFuture(myTeams));
     teamIds = getTeamIds(myTeams);
     when(mockPaginatedTeamIds.getTeamIds()).thenReturn(teamIds);
@@ -249,45 +240,24 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockProjectHeaderList)
       .when(mockSynapseJavascriptClient)
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(mockProjectHeaderList)
       .when(mockSynapseJavascriptClient)
-      .getUserProjects(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getUserProjects(any(), anyInt(), any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(mockProjectHeaderList)
       .when(mockSynapseJavascriptClient)
-      .getProjectsForTeam(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getProjectsForTeam(any(), anyInt(), any(), any(), any(), any());
 
     AsyncMockStubber
       .callSuccessWith(myFavorites)
       .when(mockSynapseJavascriptClient)
-      .getFavorites(any(AsyncCallback.class));
+      .getFavorites(any());
 
     // set up create project test
     when(mockProject.getId()).thenReturn("syn88888888");
-    when(mockSynapseJavascriptClient.createEntity(any(Entity.class)))
+    when(mockSynapseJavascriptClient.createEntity(any()))
       .thenReturn(getDoneFuture(mockProject));
 
     // set up create team test
@@ -295,7 +265,7 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockTeam)
       .when(mockSynapseJavascriptClient)
-      .createTeam(any(Team.class), any(AsyncCallback.class));
+      .createTeam(any(), any());
 
     org.sagebionetworks.reflection.model.PaginatedResults<
       EntityHeader
@@ -345,7 +315,7 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callSuccessWith(testChallenges)
       .when(mockSynapseJavascriptClient)
-      .getChallenges(anyString(), anyInt(), anyInt(), any(AsyncCallback.class));
+      .getChallenges(any(), anyInt(), anyInt(), any());
   }
 
   @Test
@@ -474,7 +444,7 @@ public class ProfilePresenterTest {
     // also verify that it is asking for the correct teams
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(captor.capture(), anyBoolean(), anyString());
+      .getUserTeams(captor.capture(), anyBoolean(), any());
     verify(mockSynapseJavascriptClient).listTeams(anyList());
     assertEquals("456", captor.getValue());
   }
@@ -514,7 +484,7 @@ public class ProfilePresenterTest {
     profilePresenter.refreshProjects();
     assertNull(profilePresenter.getProjectNextPageToken());
     verify(mockInjector).getLoadMoreProjectsWidgetContainer();
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockLoadMoreContainer, times(2)).setIsMore(false);
     verify(mockLoadMoreContainer).configure(any(Callback.class));
   }
@@ -524,19 +494,19 @@ public class ProfilePresenterTest {
     profilePresenter.setIsOwner(true);
     // when setting the filter to all, it should ask for all of my projects
     profilePresenter.setProjectFilterAndRefresh(ProjectFilterEnum.ALL, null);
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).setAllProjectsFilterSelected();
     verify(mockView).showProjectFiltersUI();
     verify(mockSynapseJavascriptClient)
       .getMyProjects(
         eq(ProjectListType.ALL),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+    verify(mockLoadMoreContainer, times(2)).add(any());
     verify(mockView).setLastActivityOnColumnVisible(true);
     verify(mockLoadMoreContainer, never()).clear();
 
@@ -551,17 +521,10 @@ public class ProfilePresenterTest {
     profilePresenter.setIsOwner(false);
     // when setting the filter to all, it should ask for all of their projects
     profilePresenter.setProjectFilterAndRefresh(ProjectFilterEnum.ALL, null);
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockSynapseJavascriptClient)
-      .getUserProjects(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+      .getUserProjects(any(), anyInt(), any(), any(), any(), any());
+    verify(mockLoadMoreContainer, times(2)).add(any());
   }
 
   @Test
@@ -569,17 +532,10 @@ public class ProfilePresenterTest {
     profilePresenter.setIsOwner(false);
     // when setting the filter to all, it should ask for all of their projects
     profilePresenter.setProjectFilterAndRefresh(null, null);
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockSynapseJavascriptClient)
-      .getUserProjects(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+      .getUserProjects(any(), anyInt(), any(), any(), any(), any());
+    verify(mockLoadMoreContainer, times(2)).add(any());
   }
 
   @Test
@@ -587,27 +543,13 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callFailureWith(new Exception("unhandled"))
       .when(mockSynapseJavascriptClient)
-      .getUserProjects(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getUserProjects(any(), anyInt(), any(), any(), any(), any());
     profilePresenter.setIsOwner(false);
     // when setting the filter to all, it should ask for all of their projects
     profilePresenter.setProjectFilterAndRefresh(null, null);
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockSynapseJavascriptClient)
-      .getUserProjects(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getUserProjects(any(), anyInt(), any(), any(), any(), any());
     verify(mockSynAlert).handleException(any(Exception.class));
   }
 
@@ -620,19 +562,19 @@ public class ProfilePresenterTest {
       ProjectFilterEnum.CREATED_BY_ME,
       null
     );
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).showProjectFiltersUI();
     verify(mockView).setMyProjectsFilterSelected();
     verify(mockSynapseJavascriptClient)
       .getMyProjects(
         eq(ProjectListType.CREATED),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+    verify(mockLoadMoreContainer, times(2)).add(any());
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
 
@@ -644,7 +586,7 @@ public class ProfilePresenterTest {
       ProjectFilterEnum.FAVORITES,
       null
     );
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).showProjectFiltersUI();
     verify(mockView).setFavoritesFilterSelected();
     verify(mockSynapseJavascriptClient).getFavorites(any(AsyncCallback.class));
@@ -659,19 +601,19 @@ public class ProfilePresenterTest {
       ProjectFilterEnum.SHARED_DIRECTLY_WITH_ME,
       null
     );
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).showProjectFiltersUI();
     verify(mockView).setSharedDirectlyWithMeFilterSelected();
     verify(mockSynapseJavascriptClient)
       .getMyProjects(
         eq(ProjectListType.PARTICIPATED),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+    verify(mockLoadMoreContainer, times(2)).add(any());
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
 
@@ -684,11 +626,11 @@ public class ProfilePresenterTest {
       ProjectFilterEnum.FAVORITES,
       null
     );
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).setFavoritesFilterSelected();
     verify(mockView).setFavoritesHelpPanelVisible(true);
-    verify(mockSynapseJavascriptClient).getFavorites(any(AsyncCallback.class));
-    verify(mockLoadMoreContainer, never()).add(any(Widget.class));
+    verify(mockSynapseJavascriptClient).getFavorites(any());
+    verify(mockLoadMoreContainer, never()).add(any());
     verify(mockView).setLastActivityOnColumnVisible(false);
   }
 
@@ -699,19 +641,12 @@ public class ProfilePresenterTest {
 
     // when setting the filter to all, it should ask for all of my projects
     profilePresenter.setProjectFilterAndRefresh(ProjectFilterEnum.TEAM, teamId);
-    verify(mockView).setProjectContainer(any(Widget.class));
+    verify(mockView).setProjectContainer(any());
     verify(mockView).showProjectFiltersUI();
     verify(mockView).setTeamsFilterSelected();
     verify(mockSynapseJavascriptClient)
-      .getProjectsForTeam(
-        eq(teamId),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
-    verify(mockLoadMoreContainer, times(2)).add(any(Widget.class));
+      .getProjectsForTeam(eq(teamId), anyInt(), any(), any(), any(), any());
+    verify(mockLoadMoreContainer, times(2)).add(any());
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
 
@@ -722,14 +657,7 @@ public class ProfilePresenterTest {
     AsyncMockStubber
       .callFailureWith(new Exception("failed"))
       .when(mockSynapseJavascriptClient)
-      .getProjectsForTeam(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getProjectsForTeam(any(), anyInt(), any(), any(), any(), any());
     profilePresenter.setProjectFilterAndRefresh(ProjectFilterEnum.TEAM, "123");
     verify(mockSynAlert).handleException(any(Exception.class));
   }
@@ -745,10 +673,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.CREATED),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     profilePresenter.setProjectFilterAndRefresh(
       ProjectFilterEnum.CREATED_BY_ME,
@@ -766,10 +694,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.ALL),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockView).setLastActivityOnColumnVisible(true);
     verify(mockGlobalApplicationState).pushCurrentPlace(any(Place.class));
@@ -785,10 +713,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.CREATED),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
@@ -806,10 +734,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.PARTICIPATED),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
@@ -827,10 +755,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.TEAM),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockView).setLastActivityOnColumnVisible(true);
   }
@@ -853,10 +781,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.ALL),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     profilePresenter.getMyProjects(
       ProjectListType.ALL,
@@ -867,10 +795,10 @@ public class ProfilePresenterTest {
       .getMyProjects(
         eq(ProjectListType.ALL),
         anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockSynAlert).handleException(any(Exception.class));
   }
@@ -941,53 +869,52 @@ public class ProfilePresenterTest {
     profilePresenter.sort(ProjectListSortColumn.LAST_ACTIVITY);
     verify(mockSynapseJavascriptClient)
       .getUserProjects(
-        anyString(),
+        any(),
         anyInt(),
-        anyString(),
+        any(),
         eq(ProjectListSortColumn.LAST_ACTIVITY),
         eq(SortDirection.ASC),
-        any(AsyncCallback.class)
+        any()
       );
 
     profilePresenter.sort(ProjectListSortColumn.LAST_ACTIVITY);
     verify(mockSynapseJavascriptClient)
       .getUserProjects(
-        anyString(),
+        any(),
         anyInt(),
-        anyString(),
+        any(),
         eq(ProjectListSortColumn.LAST_ACTIVITY),
         eq(SortDirection.DESC),
-        any(AsyncCallback.class)
+        any()
       );
 
     profilePresenter.sort(ProjectListSortColumn.PROJECT_NAME);
     verify(mockSynapseJavascriptClient)
       .getUserProjects(
-        anyString(),
+        any(),
         anyInt(),
-        anyString(),
+        any(),
         eq(ProjectListSortColumn.PROJECT_NAME),
         eq(SortDirection.ASC),
-        any(AsyncCallback.class)
+        any()
       );
 
     profilePresenter.sort(ProjectListSortColumn.PROJECT_NAME);
     verify(mockSynapseJavascriptClient)
       .getUserProjects(
-        anyString(),
+        any(),
         anyInt(),
-        anyString(),
+        any(),
         eq(ProjectListSortColumn.PROJECT_NAME),
         eq(SortDirection.DESC),
-        any(AsyncCallback.class)
+        any()
       );
   }
 
   @Test
   public void testCreateTeam() {
     profilePresenter.createTeamAfterPrompt("valid name");
-    verify(mockSynapseJavascriptClient)
-      .createTeam(any(Team.class), any(AsyncCallback.class));
+    verify(mockSynapseJavascriptClient).createTeam(any(), any());
     // inform user of success, and go to new team page
     verify(mockView).showInfo(anyString());
     verify(mockPlaceChanger)
@@ -1055,13 +982,14 @@ public class ProfilePresenterTest {
   @Test
   public void testRefreshChallenges() {
     profilePresenter.showTab(ProfileArea.CHALLENGES, true);
+
     verify(mockView).clearChallenges();
     assertEquals(
       ProfilePresenter.CHALLENGE_PAGE_SIZE,
       profilePresenter.getCurrentChallengeOffset()
     );
     verify(mockView, times(2)).showChallengesLoading(anyBoolean());
-    verify(mockView).addChallengeWidget(any(Widget.class));
+    verify(mockView).addChallengeWidget(any());
   }
 
   public ArrayList<Team> setupUserTeams(
@@ -1078,20 +1006,14 @@ public class ProfilePresenterTest {
 
     teamIds = getTeamIds(teams);
     when(mockPaginatedTeamIds.getTeamIds()).thenReturn(teamIds);
-    when(
-      mockSynapseJavascriptClient.getUserTeams(
-        anyString(),
-        anyBoolean(),
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getUserTeams(any(), anyBoolean(), any()))
       .thenReturn(getDoneFuture(mockPaginatedTeamIds));
-    when(mockSynapseJavascriptClient.listTeams(anyList()))
+    when(mockSynapseJavascriptClient.listTeams(any()))
       .thenReturn(getDoneFuture(teams));
     AsyncMockStubber
       .callSuccessWith(openRequestNumberPerTeam)
       .when(mockSynapseJavascriptClient)
-      .getOpenMembershipRequestCount(anyString(), any(AsyncCallback.class));
+      .getOpenMembershipRequestCount(any(), any());
     return teams;
   }
 
@@ -1133,13 +1055,7 @@ public class ProfilePresenterTest {
     String userId = "23938473";
     profilePresenter.setCurrentUserId(userId);
     Exception ex = new Exception("unhandled exception");
-    when(
-      mockSynapseJavascriptClient.getUserTeams(
-        anyString(),
-        anyBoolean(),
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getUserTeams(any(), anyBoolean(), any()))
       .thenReturn(getFailedFuture(ex));
 
     profilePresenter.getTeamBundles();
@@ -1201,7 +1117,7 @@ public class ProfilePresenterTest {
 
     verifyLoadMoreTeamsConfiguredAndLoading();
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockSynapseJavascriptClient).listTeams(anyList());
     verify(mockTeamListWidget, times(2)).addTeam(any(Team.class));
     verify(mockView, never()).addTeamsFilterTeam(any(Team.class));
@@ -1217,7 +1133,7 @@ public class ProfilePresenterTest {
 
     verifyLoadMoreTeamsConfiguredAndLoading();
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockSynapseJavascriptClient).listTeams(anyList());
     verify(mockTeamListWidget, times(2)).addTeam(any(Team.class));
   }
@@ -1228,18 +1144,12 @@ public class ProfilePresenterTest {
     String errorMessage = "error loading teams";
 
     Exception ex = new Exception(errorMessage);
-    when(
-      mockSynapseJavascriptClient.getUserTeams(
-        anyString(),
-        anyBoolean(),
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getUserTeams(any(), anyBoolean(), any()))
       .thenReturn(getFailedFuture(ex));
     profilePresenter.showTab(ProfileArea.TEAMS, true);
     verifyLoadMoreTeamsConfiguredAndLoading();
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockSynAlert).handleException(ex);
   }
 
@@ -1269,7 +1179,7 @@ public class ProfilePresenterTest {
         ProfileArea.PROJECTS.name().toLowerCase()
       );
     verify(mockSynapseJavascriptClient, times(2))
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockSynapseJavascriptClient, times(2)).listTeams(anyList());
     verify(mockView, atLeastOnce()).setTeamsFilterVisible(true);
     // filters are added, but teams not added to team list (in teams tab).
@@ -1283,7 +1193,7 @@ public class ProfilePresenterTest {
     setPlaceMyProfile("456");
     invokeGetMyTeamsCallback();
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockSynapseJavascriptClient, never()).listTeams(anyList());
 
     verify(mockView).setTeamsFilterVisible(false);
@@ -1293,18 +1203,12 @@ public class ProfilePresenterTest {
   public void testGetTeamFiltersError() {
     String errorMessage = "error loading teams";
     Exception ex = new Exception(errorMessage);
-    when(
-      mockSynapseJavascriptClient.getUserTeams(
-        anyString(),
-        anyBoolean(),
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getUserTeams(any(), anyBoolean(), any()))
       .thenReturn(getFailedFuture(ex));
     setPlaceMyProfile("456");
     invokeGetMyTeamsCallback();
     verify(mockSynapseJavascriptClient)
-      .getUserTeams(anyString(), anyBoolean(), anyString());
+      .getUserTeams(any(), anyBoolean(), any());
     verify(mockView).setTeamsFilterVisible(false);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/QuizPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/QuizPresenterTest.java
@@ -8,12 +8,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.presenter.QuizPresenter;
 import org.sagebionetworks.web.client.view.CertificationQuizView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class QuizPresenterTest {
 
   QuizPresenter presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.search.query.KeyRange;
 import org.sagebionetworks.repo.model.search.query.KeyValue;
 import org.sagebionetworks.repo.model.search.query.SearchQuery;
@@ -41,7 +41,7 @@ import org.sagebionetworks.web.client.widget.LoadMoreWidgetContainer;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.shared.SearchQueryUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SearchPresenterTest {
 
   SearchPresenter searchPresenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SignedTokenPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SignedTokenPresenterTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.JoinTeamSignedToken;
 import org.sagebionetworks.repo.model.ResponseMessage;
@@ -44,7 +44,7 @@ import org.sagebionetworks.web.client.widget.user.UserBadge;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SignedTokenPresenterTest {
 
   SignedTokenPresenter presenter;
@@ -116,28 +116,24 @@ public class SignedTokenPresenterTest {
     AsyncMockStubber
       .callSuccessWith(responseMessage)
       .when(mockSynapseClient)
-      .handleSignedToken(
-        any(SignedTokenInterface.class),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .handleSignedToken(any(), any(), any());
 
     // by default, decode into a JoinTeamSignedToken
     AsyncMockStubber
       .callSuccessWith(defaultToken)
       .when(mockSynapseClient)
-      .hexDecodeAndDeserialize(anyString(), any(AsyncCallback.class));
+      .hexDecodeAndDeserialize(any(), any());
 
-    verify(mockView).setSynapseAlert(any(Widget.class));
+    verify(mockView).setSynapseAlert(any());
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setUnsubscribingUserBadge(any(Widget.class));
+    verify(mockView).setUnsubscribingUserBadge(any());
     // by default, the team has no access requirements (so it should just handle the signed token like
     // any other signed token request).
     accessRequirements = new ArrayList<AccessRequirement>();
     AsyncMockStubber
       .callSuccessWith(accessRequirements)
       .when(mockSynapseClient)
-      .getTeamAccessRequirements(anyString(), any(AsyncCallback.class));
+      .getTeamAccessRequirements(any(), any());
     when(mockGlobalApplicationState.getPlaceChanger())
       .thenReturn(mockPlaceChanger);
   }
@@ -232,7 +228,7 @@ public class SignedTokenPresenterTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .getTeamAccessRequirements(anyString(), any(AsyncCallback.class));
+      .getTeamAccessRequirements(any(), any());
     presenter.setPlace(testPlace);
 
     verify(mockSynapseAlert).handleException(ex);
@@ -244,12 +240,12 @@ public class SignedTokenPresenterTest {
     AsyncMockStubber
       .callSuccessWith(new JoinTeamSignedToken())
       .when(mockSynapseClient)
-      .hexDecodeAndDeserialize(anyString(), any(AsyncCallback.class));
+      .hexDecodeAndDeserialize(any(), any());
     presenter.setPlace(testPlace);
 
     // verify rpc attempt, and simulate an UnauthorizedException
     verify(mockSynapseClient)
-      .getTeamAccessRequirements(anyString(), asyncCaptor.capture());
+      .getTeamAccessRequirements(any(), asyncCaptor.capture());
     Exception ex = new UnauthorizedException("bad session");
     asyncCaptor.getValue().onFailure(ex);
     verify(mockAuthenticationController).logoutUser();
@@ -257,7 +253,7 @@ public class SignedTokenPresenterTest {
 
     // verify that it tried to call rpc again
     verify(mockSynapseClient, times(2))
-      .getTeamAccessRequirements(anyString(), asyncCaptor.capture());
+      .getTeamAccessRequirements(any(), asyncCaptor.capture());
     // if the second attempt is successful, then it should try to handle the signed token.
     asyncCaptor.getAllValues().get(1).onSuccess(accessRequirements);
     verify(mockSynapseClient)
@@ -274,12 +270,12 @@ public class SignedTokenPresenterTest {
     AsyncMockStubber
       .callSuccessWith(new JoinTeamSignedToken())
       .when(mockSynapseClient)
-      .hexDecodeAndDeserialize(anyString(), any(AsyncCallback.class));
+      .hexDecodeAndDeserialize(any(), any());
     presenter.setPlace(testPlace);
 
     // verify rpc attempt, and simulate an UnauthorizedException
     verify(mockSynapseClient)
-      .getTeamAccessRequirements(anyString(), asyncCaptor.capture());
+      .getTeamAccessRequirements(any(), asyncCaptor.capture());
     Exception ex = new UnauthorizedException("bad session");
     asyncCaptor.getValue().onFailure(ex);
     verify(mockAuthenticationController).logoutUser();
@@ -287,7 +283,7 @@ public class SignedTokenPresenterTest {
 
     // verify that it tried to call rpc again
     verify(mockSynapseClient, times(2))
-      .getTeamAccessRequirements(anyString(), asyncCaptor.capture());
+      .getTeamAccessRequirements(any(), asyncCaptor.capture());
     // if it runs into another error (even if it's an UnauthorizedException) it should not try again.
     asyncCaptor.getAllValues().get(1).onFailure(ex);
     verify(mockSynapseAlert).handleException(ex);

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SubscriptionPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SubscriptionPresenterTest.java
@@ -74,8 +74,8 @@ public class SubscriptionPresenterTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setSynAlert(any(Widget.class));
-    verify(mockView).setTopicWidget(any(Widget.class));
+    verify(mockView).setSynAlert(any());
+    verify(mockView).setTopicWidget(any());
     verify(mockTopicWidget).addStyleNames(anyString());
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SynapseForumPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SynapseForumPresenterTest.java
@@ -74,13 +74,6 @@ public class SynapseForumPresenterTest {
     presenter.setPlace(mockPlace);
     presenter.showForum(entityId);
     verify(mockForumWidget)
-      .configure(
-        anyString(),
-        any(ParameterizedToken.class),
-        eq(DEFAULT_IS_MODERATOR),
-        any(EntityActionMenu.class),
-        any(CallbackP.class),
-        any(Callback.class)
-      );
+      .configure(any(), any(), eq(DEFAULT_IS_MODERATOR), any(), any(), any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SynapseWikiPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SynapseWikiPresenterTest.java
@@ -58,13 +58,8 @@ public class SynapseWikiPresenterTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockSynapseClient)
-      .hasAccess(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .hasAccess(any(), any(), any(), any());
     presenter.setPlace(testPlace);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/TeamPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/TeamPresenterTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Team;
 import org.sagebionetworks.repo.model.TeamMemberTypeFilterOptions;
 import org.sagebionetworks.repo.model.TeamMembershipStatus;
@@ -48,7 +48,7 @@ import org.sagebionetworks.web.client.widget.team.controller.TeamProjectsModalWi
 import org.sagebionetworks.web.shared.TeamBundle;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TeamPresenterTest {
 
   TeamPresenter presenter;
@@ -176,12 +176,7 @@ public class TeamPresenterTest {
     AsyncMockStubber
       .callSuccessWith(mockTeamBundle)
       .when(mockSynClient)
-      .getTeamBundle(
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .getTeamBundle(any(), any(), anyBoolean(), any());
 
     // team bundle
     when(mockTeamBundle.getTeam()).thenReturn(mockTeam);
@@ -206,14 +201,14 @@ public class TeamPresenterTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setSynAlertWidget(any(Widget.class));
-    verify(mockView).setInviteMemberWidget(any(Widget.class));
-    verify(mockView).setJoinTeamWidget(any(Widget.class));
-    verify(mockView).setOpenMembershipRequestWidget(any(Widget.class));
-    verify(mockView).setOpenUserInvitationsWidget(any(Widget.class));
-    verify(mockView).setManagerListWidget(any(Widget.class));
-    verify(mockView).setMemberListWidget(any(Widget.class));
-    verify(mockView).setMap(any(Widget.class));
+    verify(mockView).setSynAlertWidget(any());
+    verify(mockView).setInviteMemberWidget(any());
+    verify(mockView).setJoinTeamWidget(any());
+    verify(mockView).setOpenMembershipRequestWidget(any());
+    verify(mockView).setOpenUserInvitationsWidget(any());
+    verify(mockView).setManagerListWidget(any());
+    verify(mockView).setMemberListWidget(any());
+    verify(mockView).setMap(any());
   }
 
   @Test
@@ -221,12 +216,7 @@ public class TeamPresenterTest {
     AsyncMockStubber
       .callFailureWith(caught)
       .when(mockSynClient)
-      .getTeamBundle(
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .getTeamBundle(any(), any(), anyBoolean(), any());
     presenter.refresh(teamId);
     verify(mockSynAlert).clear();
     verify(mockSynAlert).handleException(caught);
@@ -320,11 +310,11 @@ public class TeamPresenterTest {
         eq(teamId),
         anyBoolean(),
         eq(mockTeamMembershipStatus),
-        any(Callback.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
         anyBoolean()
       );
     verify(mockOpenMembershipRequestsWidget).setVisible(false);
@@ -398,19 +388,13 @@ public class TeamPresenterTest {
     presenter.refreshOpenMembershipRequests();
     verify(mockOpenMembershipRequestsWidget).clear();
     verify(mockOpenMembershipRequestsWidget)
-      .configure(anyString(), callbackCaptor.capture());
+      .configure(any(), callbackCaptor.capture());
     Callback callback = callbackCaptor.getValue();
     callback.invoke();
     // reconfigured widget, and refreshed
     verify(mockOpenMembershipRequestsWidget, times(2))
-      .configure(anyString(), eq(callback));
-    verify(mockSynClient)
-      .getTeamBundle(
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .configure(any(), eq(callback));
+    verify(mockSynClient).getTeamBundle(any(), any(), anyBoolean(), any());
     // never reconfigures open invites (no need to refresh)
     verify(mockOpenUserInvitationsWidget, never())
       .configure(anyString(), eq(callback));
@@ -421,19 +405,13 @@ public class TeamPresenterTest {
     presenter.refreshOpenUserInvitations();
     verify(mockOpenUserInvitationsWidget).clear();
     verify(mockOpenUserInvitationsWidget)
-      .configure(anyString(), callbackCaptor.capture());
+      .configure(any(), callbackCaptor.capture());
     Callback callback = callbackCaptor.getValue();
     callback.invoke();
     // reconfigured widget, and refreshed
     verify(mockOpenUserInvitationsWidget, times(2))
-      .configure(anyString(), eq(callback));
-    verify(mockSynClient)
-      .getTeamBundle(
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .configure(any(), eq(callback));
+    verify(mockSynClient).getTeamBundle(any(), any(), anyBoolean(), any());
     // never reconfigures open membership requests (no need to refresh)
     verify(mockOpenMembershipRequestsWidget, never())
       .configure(anyString(), eq(callback));
@@ -446,7 +424,7 @@ public class TeamPresenterTest {
     presenter.showDeleteModal();
 
     verify(mockDeleteModal).setRefreshCallback(any(Callback.class));
-    verify(mockView).addWidgets(any(Widget.class));
+    verify(mockView).addWidgets(any());
     verify(mockDeleteModal).configure(mockTeam);
     verify(mockDeleteModal).showDialog();
   }
@@ -458,7 +436,7 @@ public class TeamPresenterTest {
     presenter.showEditModal();
 
     verify(mockEditModal).setRefreshCallback(any(Callback.class));
-    verify(mockView).addWidgets(any(Widget.class));
+    verify(mockView).addWidgets(any());
     verify(mockEditModal).configureAndShow(mockTeam);
   }
 
@@ -469,7 +447,7 @@ public class TeamPresenterTest {
     presenter.showLeaveModal();
 
     verify(mockLeaveModal).setRefreshCallback(any(Callback.class));
-    verify(mockView).addWidgets(any(Widget.class));
+    verify(mockView).addWidgets(any());
     verify(mockLeaveModal).configure(mockTeam);
     verify(mockLeaveModal).showDialog();
   }
@@ -480,7 +458,7 @@ public class TeamPresenterTest {
 
     presenter.showTeamProjectsModal();
 
-    verify(mockView).addWidgets(any(Widget.class));
+    verify(mockView).addWidgets(any());
     verify(mockTeamProjectsModalWidget).configureAndShow(mockTeam);
   }
 
@@ -560,11 +538,11 @@ public class TeamPresenterTest {
         eq(teamId),
         anyBoolean(),
         eq(mockTeamMembershipStatus),
-        any(Callback.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
         anyBoolean()
       );
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/TeamSearchPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/TeamSearchPresenterTest.java
@@ -138,7 +138,7 @@ public class TeamSearchPresenterTest {
     verify(mockView).setSearchTerm(searchTerm);
     // add both test teams
     verify(mockPortalGinInjector, times(2)).getBigTeamBadgeWidget();
-    verify(mockLoadMoreWidgetContainer, times(2)).add(any(Widget.class));
+    verify(mockLoadMoreWidgetContainer, times(2)).add(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/TrashPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/TrashPresenterTest.java
@@ -9,14 +9,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.place.Trash;
 import org.sagebionetworks.web.client.presenter.TrashPresenter;
 import org.sagebionetworks.web.client.view.TrashView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TrashPresenterTest {
 
   TrashPresenter presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/WikiDiffPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/WikiDiffPresenterTest.java
@@ -129,7 +129,7 @@ public class WikiDiffPresenterTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setSynAlert(any(IsWidget.class));
+    verify(mockView).setSynAlert(any());
     verify(mockResourceLoader).isLoaded(DIFF_LIB_JS);
     verify(mockResourceLoader).requires(anyList(), any(AsyncCallback.class));
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/utils/GovernanceServiceHelperTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/utils/GovernanceServiceHelperTest.java
@@ -57,7 +57,7 @@ public class GovernanceServiceHelperTest {
     );
     verify(mockSynapseClient)
       .createAccessApproval(any(AccessApproval.class), eq(mockCallback));
-    verify(mockCallback).onSuccess(any(AccessApproval.class));
+    verify(mockCallback).onSuccess(any());
   }
 
   @Test
@@ -83,7 +83,7 @@ public class GovernanceServiceHelperTest {
     // also check the captured entity wrapper to verify the approval object
     verify(mockSynapseClient)
       .createAccessApproval(any(AccessApproval.class), eq(mockCallback));
-    verify(mockCallback).onSuccess(any(AccessApproval.class));
+    verify(mockCallback).onSuccess(any());
 
     AccessApproval capturedWrapper = captor.getValue();
     assertEquals(accessRequirementId, capturedWrapper.getRequirementId());

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/DownloadSpeedTesterImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/DownloadSpeedTesterImplTest.java
@@ -89,18 +89,15 @@ public class DownloadSpeedTesterImplTest {
     AsyncMockStubber
       .callSuccessWith(mockFileEntity)
       .when(mockJsClient)
-      .getEntity(anyString(), any(AsyncCallback.class));
+      .getEntity(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockFileResult)
       .when(mockFileHandleAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+      .getFileResult(any(), any());
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
 
     downloadSpeedTester =
       new DownloadSpeedTesterImpl(
@@ -128,7 +125,7 @@ public class DownloadSpeedTesterImplTest {
   public void testHappyCase() {
     downloadSpeedTester.testDownloadSpeed(mockCallback);
 
-    verify(mockCallback).onSuccess(anyDouble());
+    verify(mockCallback).onSuccess(any());
   }
 
   @Test
@@ -228,8 +225,7 @@ public class DownloadSpeedTesterImplTest {
 
     // verify it runs the test
     verify(mockJsClient).getEntity(anyString(), any(AsyncCallback.class));
-    verify(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
-    verify(mockCallback).onSuccess(anyDouble());
+    verify(mockRequestBuilder).sendRequest(any(), any());
+    verify(mockCallback).onSuccess(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/FileHandleWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/FileHandleWidgetTest.java
@@ -85,7 +85,7 @@ public class FileHandleWidgetTest {
     // loading shown first
     order.verify(mockView).setLoadingVisible(true);
     order.verify(mockView).setLoadingVisible(false);
-    verify(mockView).setAnchor(eq(FILE_NAME), anyString());
+    verify(mockView).setAnchor(eq(FILE_NAME), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/LoadMoreWidgetContainerTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/LoadMoreWidgetContainerTest.java
@@ -6,12 +6,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.LoadMoreWidgetContainer;
 import org.sagebionetworks.web.client.widget.LoadMoreWidgetContainerView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class LoadMoreWidgetContainerTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/ACTAccessRequirementWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/ACTAccessRequirementWidgetTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ACTAccessRequirement;
 import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.repo.model.UserProfile;
@@ -53,7 +53,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ACTAccessRequirementWidgetTest {
 
   public static final String SUBJECT_OBJECT_ID = "syn981612";
@@ -198,8 +198,8 @@ public class ACTAccessRequirementWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setWikiTermsWidget(any(Widget.class));
-    verify(mockView).setEditAccessRequirementWidget(any(Widget.class));
+    verify(mockView).setWikiTermsWidget(any());
+    verify(mockView).setEditAccessRequirementWidget(any());
     verify(mockWikiPageWidget).setModifiedCreatedByHistoryVisible(false);
   }
 
@@ -229,12 +229,7 @@ public class ACTAccessRequirementWidgetTest {
 
     widget.setRequirement(mockACTAccessRequirement, mockRefreshCallback);
 
-    verify(mockWikiPageWidget)
-      .configure(
-        any(WikiPageKey.class),
-        eq(false),
-        any(WikiPageWidget.Callback.class)
-      );
+    verify(mockWikiPageWidget).configure(any(), eq(false), any());
     verify(mockView).setAccessRequirementName(ACCESS_REQUIREMENT_NAME);
     verify(mockView, never()).setTerms(anyString());
     verify(mockView, never()).showTermsUI();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/IntendedDataUseReportButtonTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/IntendedDataUseReportButtonTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.utils.CallbackP;
@@ -24,7 +24,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.entity.renderer.IntendedDataUseReportWidget;
 import org.sagebionetworks.web.client.widget.modal.DialogView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class IntendedDataUseReportButtonTest {
 
   public static final Long AR_ID = 8888L;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/ManagedACTAccessRequirementWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/ManagedACTAccessRequirementWidgetTest.java
@@ -195,8 +195,8 @@ public class ManagedACTAccessRequirementWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setWikiTermsWidget(any(Widget.class));
-    verify(mockView).setEditAccessRequirementWidget(any(Widget.class));
+    verify(mockView).setWikiTermsWidget(any());
+    verify(mockView).setEditAccessRequirementWidget(any());
     verify(mockWikiPageWidget).setModifiedCreatedByHistoryVisible(false);
     verify(mockView).setIDUReportButton(mockIduReportButton);
   }
@@ -224,12 +224,7 @@ public class ManagedACTAccessRequirementWidgetTest {
 
     widget.setRequirement(mockManagedACTAccessRequirement, mockRefreshCallback);
 
-    verify(mockWikiPageWidget)
-      .configure(
-        any(WikiPageKey.class),
-        eq(false),
-        any(WikiPageWidget.Callback.class)
-      );
+    verify(mockWikiPageWidget).configure(any(), eq(false), any());
     verify(mockView).setWikiTermsWidgetVisible(true);
     verify(mockView).setAccessRequirementName(ACCESS_REQUIREMENT_NAME);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/SelfSignAccessRequirementWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/SelfSignAccessRequirementWidgetTest.java
@@ -174,20 +174,15 @@ public class SelfSignAccessRequirementWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setWikiTermsWidget(any(Widget.class));
-    verify(mockView).setEditAccessRequirementWidget(any(Widget.class));
+    verify(mockView).setWikiTermsWidget(any());
+    verify(mockView).setEditAccessRequirementWidget(any());
     verify(mockWikiPageWidget).setModifiedCreatedByHistoryVisible(false);
   }
 
   @Test
   public void testSetRequirementWithWikiTerms() {
     widget.setRequirement(mockAccessRequirement, mockRefreshCallback);
-    verify(mockWikiPageWidget)
-      .configure(
-        any(WikiPageKey.class),
-        eq(false),
-        any(WikiPageWidget.Callback.class)
-      );
+    verify(mockWikiPageWidget).configure(any(), eq(false), any());
     verify(mockTeamSubjectsWidget).configure(mockSubjectIds);
     verify(mockEntitySubjectsWidget).configure(mockSubjectIds);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/TermsOfUseAccessRequirementWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/TermsOfUseAccessRequirementWidgetTest.java
@@ -146,8 +146,8 @@ public class TermsOfUseAccessRequirementWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setWikiTermsWidget(any(Widget.class));
-    verify(mockView).setEditAccessRequirementWidget(any(Widget.class));
+    verify(mockView).setWikiTermsWidget(any());
+    verify(mockView).setEditAccessRequirementWidget(any());
     verify(mockWikiPageWidget).setModifiedCreatedByHistoryVisible(false);
   }
 
@@ -171,12 +171,7 @@ public class TermsOfUseAccessRequirementWidgetTest {
   @Test
   public void testSetRequirementWithWikiTerms() {
     widget.setRequirement(mockTermsOfUseAccessRequirement, mockRefreshCallback);
-    verify(mockWikiPageWidget)
-      .configure(
-        any(WikiPageKey.class),
-        eq(false),
-        any(WikiPageWidget.Callback.class)
-      );
+    verify(mockWikiPageWidget).configure(any(), eq(false), any());
     verify(mockView, never()).setTerms(anyString());
     verify(mockView, never()).showTermsUI();
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/approval/AccessorGroupWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/approval/AccessorGroupWidgetTest.java
@@ -17,7 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.dataaccess.AccessApprovalNotification;
 import org.sagebionetworks.repo.model.dataaccess.AccessApprovalNotificationResponse;
@@ -36,7 +36,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.user.UserBadge;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AccessorGroupWidgetTest {
 
   AccessorGroupWidget widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateBasicAccessRequirementStep2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateBasicAccessRequirementStep2Test.java
@@ -93,7 +93,7 @@ public class CreateBasicAccessRequirementStep2Test {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setWikiPageRenderer(any(IsWidget.class));
+    verify(mockView).setWikiPageRenderer(any());
     verify(mockView).setPresenter(widget);
     verify(mockWikiPageRenderer).setModifiedCreatedByHistoryVisible(false);
     verify(mockWikiMarkdownEditor).setDeleteButtonVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep2Test.java
@@ -123,9 +123,9 @@ public class CreateManagedACTAccessRequirementStep2Test {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setWikiPageRenderer(any(IsWidget.class));
-    verify(mockView).setDUCTemplateUploadWidget(any(IsWidget.class));
-    verify(mockView).setDUCTemplateWidget(any(IsWidget.class));
+    verify(mockView).setWikiPageRenderer(any());
+    verify(mockView).setDUCTemplateUploadWidget(any());
+    verify(mockView).setDUCTemplateWidget(any());
     verify(mockView).setPresenter(widget);
     verify(mockWikiPageRenderer).setModifiedCreatedByHistoryVisible(false);
     verify(mockWikiMarkdownEditor).setDeleteButtonVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3Test.java
@@ -8,14 +8,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ManagedACTAccessRequirement;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateManagedACTAccessRequirementStep3;
 import org.sagebionetworks.web.client.widget.accessrequirements.createaccessrequirement.CreateManagedACTAccessRequirementStep3View;
 import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalPage.ModalPresenter;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CreateManagedACTAccessRequirementStep3Test {
 
   CreateManagedACTAccessRequirementStep3 widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/ACTDataAccessSubmissionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/ACTDataAccessSubmissionWidgetTest.java
@@ -131,7 +131,7 @@ public class ACTDataAccessSubmissionWidgetTest {
     when(mockResearchProjectSnapshot.getIntendedDataUseStatement())
       .thenReturn(INTENDED_DATA_USE);
     when(mockResearchProjectSnapshot.getProjectLead()).thenReturn(PROJECT_LEAD);
-    when(mockDateTimeUtils.getDateTimeString(any(Date.class)))
+    when(mockDateTimeUtils.getDateTimeString(any()))
       .thenReturn(SMALL_DATE_STRING);
 
     widget =
@@ -151,16 +151,11 @@ public class ACTDataAccessSubmissionWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockDataAccessSubmission)
       .when(mockClient)
-      .updateDataAccessSubmissionState(
-        anyString(),
-        any(SubmissionState.class),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .updateDataAccessSubmissionState(any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(mockUserProfile)
       .when(mockUserProfileAsyncHandler)
-      .getUserProfile(anyString(), any(AsyncCallback.class));
+      .getUserProfile(any(), any());
   }
 
   @Test
@@ -216,7 +211,7 @@ public class ACTDataAccessSubmissionWidgetTest {
     verify(mockUserBadge).configure(change1, mockUserProfile);
     verify(mockUserBadge).configure(change2, mockUserProfile);
 
-    verify(mockView, times(2)).addAccessors(any(IsWidget.class), anyString());
+    verify(mockView, times(2)).addAccessors(any(), any());
     // verify other documents
     verify(mockFileHandleList).clear();
     verify(mockFileHandleList, times(2)).addFileLink(fhaCaptor.capture());
@@ -285,7 +280,7 @@ public class ACTDataAccessSubmissionWidgetTest {
     verify(mockView).clearAccessors();
     verify(mockGinInjector).getUserBadgeItem();
     verify(mockUserBadge).configure(change1, mockUserProfile);
-    verify(mockView).addAccessors(any(IsWidget.class), anyString());
+    verify(mockView).addAccessors(any(), any());
     // verify view
     verify(mockView).setIsRenewal(true);
     verify(mockView).setRenewalColumnsVisible(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/OpenSubmissionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/OpenSubmissionWidgetTest.java
@@ -71,8 +71,7 @@ public class OpenSubmissionWidgetTest {
 
     Callback callback = captor.getValue();
     callback.invoke();
-    verify(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+    verify(mockClient).getAccessRequirement(any(), any());
   }
 
   @Test
@@ -81,10 +80,9 @@ public class OpenSubmissionWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+      .getAccessRequirement(any(), any());
     widget.loadAccessRequirement();
-    verify(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+    verify(mockClient).getAccessRequirement(any(), any());
     InOrder inOrder = inOrder(mockSynapseAlert);
     inOrder.verify(mockSynapseAlert).clear();
     inOrder.verify(mockSynapseAlert).handleException(ex);
@@ -97,13 +95,12 @@ public class OpenSubmissionWidgetTest {
     AsyncMockStubber
       .callSuccessWith(actAccessRequirement)
       .when(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+      .getAccessRequirement(any(), any());
     widget.loadAccessRequirement();
-    verify(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+    verify(mockClient).getAccessRequirement(any(), any());
     verify(mockSynapseAlert).clear();
     verify(mockAccessRequirementWidget)
-      .setRequirement(eq(actAccessRequirement), any(Callback.class));
+      .setRequirement(eq(actAccessRequirement), any());
   }
 
   @Test
@@ -113,10 +110,9 @@ public class OpenSubmissionWidgetTest {
     AsyncMockStubber
       .callSuccessWith(touAccessRequirement)
       .when(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+      .getAccessRequirement(any(), any());
     widget.loadAccessRequirement();
-    verify(mockClient)
-      .getAccessRequirement(anyString(), any(AsyncCallback.class));
+    verify(mockClient).getAccessRequirement(any(), any());
     InOrder inOrder = inOrder(mockSynapseAlert);
     inOrder.verify(mockSynapseAlert).clear();
     ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/RejectDataAccessRequestModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/RejectDataAccessRequestModalTest.java
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.file.FileResult;
@@ -36,7 +36,7 @@ import org.sagebionetworks.web.client.widget.entity.act.RejectDataAccessRequestM
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RejectDataAccessRequestModalTest {
 
   RejectDataAccessRequestModal widget;
@@ -102,14 +102,11 @@ public class RejectDataAccessRequestModalTest {
     AsyncMockStubber
       .callSuccessWith(mockFileEntity)
       .when(mockJsClient)
-      .getEntity(anyString(), any(AsyncCallback.class));
+      .getEntity(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockFileResult)
       .when(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+      .getFileResult(any(), any());
 
     widget =
       new RejectDataAccessRequestModal(
@@ -122,7 +119,7 @@ public class RejectDataAccessRequestModalTest {
   private void verifyRequestBuilderCall() {
     try {
       verify(mockRequestBuilder)
-        .sendRequest(anyString(), requestCallbackCaptor.capture());
+        .sendRequest(any(), requestCallbackCaptor.capture());
       requestCallbackCaptor.getValue().onResponseReceived(null, mockResponse);
     } catch (RequestException e) {
       fail("request builder sendRequest failed");
@@ -140,12 +137,8 @@ public class RejectDataAccessRequestModalTest {
     widget.show(getReasonCallback);
 
     // verify/assert
-    verify(mockJsClient).getEntity(anyString(), any(AsyncCallback.class));
-    verify(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+    verify(mockJsClient).getEntity(any(), any());
+    verify(mockPresignedURLAsyncHandler).getFileResult(any(), any());
     verifyRequestBuilderCall();
     verify(mockView).clear();
     verify(mockView).show();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/RejectReasonWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/accessrequirements/submission/RejectReasonWidgetTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.file.FileResult;
@@ -35,7 +35,7 @@ import org.sagebionetworks.web.client.widget.entity.act.RejectReasonWidget;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RejectReasonWidgetTest {
 
   RejectReasonWidget widget;
@@ -117,7 +117,7 @@ public class RejectReasonWidgetTest {
   private void verifyRequestBuilderCall() {
     try {
       verify(mockRequestBuilder)
-        .sendRequest(anyString(), requestCallbackCaptor.capture());
+        .sendRequest(any(), requestCallbackCaptor.capture());
       requestCallbackCaptor.getValue().onResponseReceived(null, mockResponse);
     } catch (RequestException e) {
       fail("request builder sendRequest failed");

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/clienthelp/FileClientsHelpTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/clienthelp/FileClientsHelpTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.widget.clienthelp.FileClientsHelp;
 import org.sagebionetworks.web.client.widget.clienthelp.FileClientsHelpView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FileClientsHelpTest {
 
   FileClientsHelp widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListItemWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListItemWidgetTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.unitclient.widget.discussion;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
@@ -77,7 +78,7 @@ public class DiscussionThreadListItemWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(discussionThreadWidget);
-    verify(mockView).setThreadAuthor(any(Widget.class));
+    verify(mockView).setThreadAuthor(any());
   }
 
   @Test
@@ -85,12 +86,12 @@ public class DiscussionThreadListItemWidgetTest {
     discussionThreadWidget.configure(mockThreadBundle);
     verify(mockView).setTitle(title);
     verify(mockView).clearActiveAuthors();
-    verify(mockView).addActiveAuthor(any(Widget.class));
+    verify(mockView).addActiveAuthor(any());
     verify(mockView).setNumberOfViews("2");
-    verify(mockView).setLastActivity(anyString());
+    verify(mockView).setLastActivity(any());
     verify(mockGinInjector).getUserBadgeWidget();
-    verify(mockDateTimeUtils).getRelativeTime(any(Date.class));
-    verify(mockAuthorWidget).configure(anyString());
+    verify(mockDateTimeUtils).getRelativeTime(any());
+    verify(mockAuthorWidget).configure((String) eq(null));
     verify(mockView).setPinnedIconVisible(false);
     verify(mockView)
       .setThreadUrl(TopicUtils.buildThreadLink(PROJECT_ID, THREAD_ID));
@@ -123,7 +124,6 @@ public class DiscussionThreadListItemWidgetTest {
       mockThreadIdClickedCallback
     );
     discussionThreadWidget.onClickThread();
-    verify(mockThreadIdClickedCallback)
-      .invoke(any(DiscussionThreadBundle.class));
+    verify(mockThreadIdClickedCallback).invoke(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListWidgetTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.discussion.DiscussionFilter;
 import org.sagebionetworks.repo.model.discussion.DiscussionThreadBundle;
 import org.sagebionetworks.repo.model.discussion.DiscussionThreadOrder;
@@ -40,7 +40,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.refresh.DiscussionThreadCountAlert;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DiscussionThreadListWidgetTest {
 
   @Mock
@@ -104,7 +104,7 @@ public class DiscussionThreadListWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(discussionThreadListWidget);
-    verify(mockView).setAlert(any(Widget.class));
+    verify(mockView).setAlert(any());
   }
 
   @SuppressWarnings("unchecked")
@@ -293,7 +293,7 @@ public class DiscussionThreadListWidgetTest {
     discussionThreadListWidget.scrollToThread("invalidid");
     verify(mockView, never()).scrollIntoView(any(Widget.class));
     discussionThreadListWidget.scrollToThread(threadId);
-    verify(mockView).scrollIntoView(any(Widget.class));
+    verify(mockView).scrollIntoView(any());
     verify(mockSynapseJavascriptClient)
       .getThread(anyString(), any(AsyncCallback.class));
     verify(mockDiscussionThreadWidget).configure(mockDiscussionThreadBundle);
@@ -344,7 +344,7 @@ public class DiscussionThreadListWidgetTest {
         any(DiscussionFilter.class),
         any(AsyncCallback.class)
       );
-    verify(mockThreadsContainer).add(any(Widget.class));
+    verify(mockThreadsContainer).add(any());
     verify(mockGinInjector).createThreadListItemWidget();
     verify(mockDiscussionThreadWidget)
       .configure(any(DiscussionThreadBundle.class));
@@ -360,7 +360,7 @@ public class DiscussionThreadListWidgetTest {
       .when(mockSynapseJavascriptClient)
       .getThread(anyString(), any(AsyncCallback.class));
     discussionThreadListWidget.scrollToThread(threadId);
-    verify(mockView).scrollIntoView(any(Widget.class));
+    verify(mockView).scrollIntoView(any());
     verify(mockSynapseJavascriptClient)
       .getThread(anyString(), any(AsyncCallback.class));
     verify(mockDiscussionThreadWidget, never())
@@ -478,7 +478,7 @@ public class DiscussionThreadListWidgetTest {
         any(DiscussionFilter.class),
         any(AsyncCallback.class)
       );
-    verify(mockThreadsContainer).add(any(Widget.class));
+    verify(mockThreadsContainer).add(any());
     verify(mockGinInjector).createThreadListItemWidget();
     verify(mockDiscussionThreadWidget)
       .configure(any(DiscussionThreadBundle.class));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/ForumWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/ForumWidgetTest.java
@@ -218,13 +218,13 @@ public class ForumWidgetTest {
   @SuppressWarnings({ "unchecked" })
   @Test
   public void testConstruction() {
-    verify(mockView).setThreadList(any(Widget.class));
-    verify(mockView).setNewThreadModal(any(Widget.class));
+    verify(mockView).setThreadList(any());
+    verify(mockView).setNewThreadModal(any());
     verify(mockView).setPresenter(forumWidget);
-    verify(mockView).setAlert(any(Widget.class));
-    verify(mockView).setSingleThread(any(Widget.class));
-    verify(mockView).setSubscribeButton(any(Widget.class));
-    verify(mockView).setSubscribersWidget(any(Widget.class));
+    verify(mockView).setAlert(any());
+    verify(mockView).setSingleThread(any());
+    verify(mockView).setSubscribeButton(any());
+    verify(mockView).setSubscribersWidget(any());
 
     ArgumentCaptor<Callback> captor = ArgumentCaptor.forClass(Callback.class);
     verify(mockSubscribeButtonWidget).setOnSubscribeCallback(captor.capture());
@@ -241,13 +241,7 @@ public class ForumWidgetTest {
       CallbackP.class
     );
     verify(mockAvailableThreadListWidget)
-      .configure(
-        anyString(),
-        anyBoolean(),
-        anySet(),
-        captorP.capture(),
-        any(DiscussionFilter.class)
-      );
+      .configure(any(), any(), any(), captorP.capture(), any());
 
     Set<String> moderatorIds = new HashSet<String>();
     Callback deleteCallback = null;
@@ -300,10 +294,10 @@ public class ForumWidgetTest {
     callbackCaptor.getValue().invoke();
     verify(mockAvailableThreadListWidget)
       .configure(
-        anyString(),
-        anyBoolean(),
-        anySet(),
-        any(CallbackP.class),
+        any(),
+        any(),
+        any(),
+        any(),
         eq(DiscussionFilter.EXCLUDE_DELETED)
       );
     verify(mockSubscribersWidget).configure(any(Topic.class));
@@ -316,10 +310,10 @@ public class ForumWidgetTest {
     callbackCaptor.getValue().invoke();
     verify(mockAvailableThreadListWidget)
       .configure(
-        anyString(),
-        anyBoolean(),
-        anySet(),
-        any(CallbackP.class),
+        any(),
+        any(),
+        any(),
+        any(),
         eq(DiscussionFilter.EXCLUDE_DELETED)
       );
     verify(mockSubscribersWidget).configure(any(Topic.class));
@@ -502,10 +496,9 @@ public class ForumWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockDiscussionThreadBundle)
       .when(mockSynapseJavascriptClient)
-      .getThread(anyString(), any(AsyncCallback.class));
+      .getThread(any(), any());
     threadIdClickedCallback.invoke(mockDiscussionThreadBundle);
-    verify(mockSynapseJavascriptClient)
-      .getThread(eq(threadId), any(AsyncCallback.class));
+    verify(mockSynapseJavascriptClient).getThread(eq(threadId), any());
 
     // going back to the forum should cause the thread list to reconfigure if thread was deleted
     reset(mockAvailableThreadListWidget);
@@ -515,10 +508,10 @@ public class ForumWidgetTest {
     );
     verify(mockDiscussionThreadWidget)
       .configure(
-        any(DiscussionThreadBundle.class),
-        anyString(),
+        any(),
+        any(),
         anyBoolean(),
-        anySet(),
+        any(),
         eq(mockActionMenuWidget),
         onShowAllThreadsCallback.capture()
       );

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/NewReplyWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/NewReplyWidgetTest.java
@@ -218,8 +218,8 @@ public class NewReplyWidgetTest {
 
   @Test
   public void testConstructor() {
-    verify(mockView).setAlert(any(Widget.class));
-    verify(mockView).setMarkdownEditor(any(Widget.class));
+    verify(mockView).setAlert(any());
+    verify(mockView).setMarkdownEditor(any());
     verify(mockView).setPresenter(newReplyWidget);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/ReplyWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/ReplyWidgetTest.java
@@ -140,9 +140,9 @@ public class ReplyWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(replyWidget);
-    verify(mockView).setAuthor(any(Widget.class));
-    verify(mockView).setAlert(any(Widget.class));
-    verify(mockView).setEditReplyModal(any(Widget.class));
+    verify(mockView).setAuthor(any());
+    verify(mockView).setAlert(any());
+    verify(mockView).setEditReplyModal(any());
     verify(mockCopyTextModal).setTitle(ReplyWidget.REPLY_URL);
   }
 
@@ -396,11 +396,11 @@ public class ReplyWidgetTest {
     AsyncMockStubber
       .callSuccessWith(url)
       .when(mockSynapseJavascriptClient)
-      .getReplyUrl(anyString(), any(AsyncCallback.class));
+      .getReplyUrl(any(), any());
     RequestBuilderMockStubber
       .callOnError(null, new Exception())
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     replyWidget.configure(
       bundle,
       canModerate,
@@ -415,7 +415,7 @@ public class ReplyWidgetTest {
         WebConstants.CONTENT_TYPE,
         WebConstants.TEXT_PLAIN_CHARSET_UTF8
       );
-    verify(mockSynAlert).handleException(any(Throwable.class));
+    verify(mockSynAlert).handleException(any());
     verify(mockMarkdownWidget, never()).configure(anyString());
     verify(mockView).setDeleteIconVisibility(false);
     verify(mockView).setLoadingMessageVisible(true);
@@ -445,11 +445,11 @@ public class ReplyWidgetTest {
     AsyncMockStubber
       .callSuccessWith(url)
       .when(mockSynapseJavascriptClient)
-      .getReplyUrl(anyString(), any(AsyncCallback.class));
+      .getReplyUrl(any(), any());
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     replyWidget.configure(
       bundle,
       canModerate,
@@ -458,7 +458,7 @@ public class ReplyWidgetTest {
       isThreadDeleted
     );
     verify(mockSynAlert).clear();
-    verify(mockRequestBuilder).configure(eq(RequestBuilder.GET), anyString());
+    verify(mockRequestBuilder).configure(eq(RequestBuilder.GET), any());
     verify(mockRequestBuilder)
       .setHeader(
         WebConstants.CONTENT_TYPE,

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/SingleDiscussionThreadWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/SingleDiscussionThreadWidgetTest.java
@@ -221,14 +221,14 @@ public class SingleDiscussionThreadWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(discussionThreadWidget);
-    verify(mockView).setAlert(any(Widget.class));
-    verify(mockView).setAuthor(any(Widget.class));
-    verify(mockView).setSubscribeButtonWidget(any(Widget.class));
-    verify(mockView).setSubscribersWidget(any(Widget.class));
+    verify(mockView).setAlert(any());
+    verify(mockView).setAuthor(any());
+    verify(mockView).setSubscribeButtonWidget(any());
+    verify(mockView).setSubscribersWidget(any());
     verify(mockSubscribeButtonWidget).showIconOnly();
     verify(mockRepliesContainer).configure(any(Callback.class));
-    verify(mockView).setNewReplyContainer(any(Widget.class));
-    verify(mockView).setSecondNewReplyContainer(any(Widget.class));
+    verify(mockView).setNewReplyContainer(any());
+    verify(mockView).setSecondNewReplyContainer(any());
   }
 
   @Test
@@ -286,7 +286,7 @@ public class SingleDiscussionThreadWidgetTest {
     verify(mockView).setEditedLabelVisible(false);
     verify(mockView).setPinIconVisible(false);
     verify(mockView).setUnpinIconVisible(false);
-    verify(mockView).setRefreshAlert(any(Widget.class));
+    verify(mockView).setRefreshAlert(any());
     verify(mockRefreshAlert).setRefreshCallback(any(Callback.class));
     verify(mockRefreshAlert).configure(threadId);
     verify(mockView).setDeletedThreadVisible(false);
@@ -470,7 +470,7 @@ public class SingleDiscussionThreadWidgetTest {
     verify(mockView).setEditedLabelVisible(false);
     verify(mockView, never()).setPinIconVisible(false);
     verify(mockView, never()).setUnpinIconVisible(false);
-    verify(mockView).setRefreshAlert(any(Widget.class));
+    verify(mockView).setRefreshAlert(any());
     verify(mockRefreshAlert).setRefreshCallback(any(Callback.class));
     verify(mockRefreshAlert).configure(threadId);
     verify(mockView).setDeletedThreadVisible(true);
@@ -1084,7 +1084,7 @@ public class SingleDiscussionThreadWidgetTest {
     verify(mockSynapseJavascriptClient)
       .getReply(eq(replyId), any(AsyncCallback.class));
     verify(mockView).setDeleteIconVisible(false);
-    verify(mockRepliesContainer).add(any(Widget.class));
+    verify(mockRepliesContainer).add(any());
     verify(mockReplyIdCallback).invoke(replyId);
   }
 
@@ -1136,21 +1136,13 @@ public class SingleDiscussionThreadWidgetTest {
     verify(mockRepliesContainer).clear();
     verify(mockView).setShowAllRepliesButtonVisible(false);
     verify(mockSynapseJavascriptClient)
-      .getRepliesForThread(
-        anyString(),
-        anyLong(),
-        anyLong(),
-        any(DiscussionReplyOrder.class),
-        anyBoolean(),
-        any(DiscussionFilter.class),
-        any(AsyncCallback.class)
-      );
-    verify(mockRefreshAlert).configure(anyString());
+      .getRepliesForThread(any(), any(), any(), any(), any(), any(), any());
+    verify(mockRefreshAlert).configure(any());
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testLoadmoreSuccess() {
+  public void testLoadMoreSuccess() {
     boolean isDeleted = false;
     boolean canModerate = false;
     boolean isEdited = false;
@@ -1202,7 +1194,7 @@ public class SingleDiscussionThreadWidgetTest {
         any(AsyncCallback.class)
       );
     verify(mockRepliesContainer, atLeastOnce()).clear();
-    verify(mockRepliesContainer, times(2)).add(any(Widget.class));
+    verify(mockRepliesContainer, times(2)).add(any());
     verify(mockGinInjector, times(2)).createReplyWidget();
     verify(mockView).setDeleteIconVisible(false);
     verify(mockView).setSecondNewReplyContainerVisible(true);
@@ -1374,7 +1366,7 @@ public class SingleDiscussionThreadWidgetTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testLoadmoreHasNextPage() {
+  public void testLoadMoreHasNextPage() {
     boolean isDeleted = false;
     boolean canModerate = false;
     boolean isEdited = false;
@@ -1397,15 +1389,7 @@ public class SingleDiscussionThreadWidgetTest {
     AsyncMockStubber
       .callSuccessWith(bundleList)
       .when(mockSynapseJavascriptClient)
-      .getRepliesForThread(
-        anyString(),
-        anyLong(),
-        anyLong(),
-        any(DiscussionReplyOrder.class),
-        anyBoolean(),
-        any(DiscussionFilter.class),
-        any(AsyncCallback.class)
-      );
+      .getRepliesForThread(any(), any(), any(), any(), any(), any(), any());
     discussionThreadWidget.configure(
       threadBundle,
       REPLY_ID_NULL,
@@ -1416,17 +1400,9 @@ public class SingleDiscussionThreadWidgetTest {
     );
     verify(mockSynAlert, atLeastOnce()).clear();
     verify(mockSynapseJavascriptClient)
-      .getRepliesForThread(
-        anyString(),
-        anyLong(),
-        anyLong(),
-        any(DiscussionReplyOrder.class),
-        anyBoolean(),
-        any(DiscussionFilter.class),
-        any(AsyncCallback.class)
-      );
+      .getRepliesForThread(any(), any(), any(), any(), any(), any(), any());
     verify(mockRepliesContainer, atLeastOnce()).clear();
-    verify(mockRepliesContainer, times(2)).add(any(Widget.class));
+    verify(mockRepliesContainer, times(2)).add(any());
     verify(mockGinInjector, times(2)).createReplyWidget();
     verify(mockView).setDeleteIconVisible(false);
   }
@@ -1506,11 +1482,11 @@ public class SingleDiscussionThreadWidgetTest {
     AsyncMockStubber
       .callSuccessWith(url)
       .when(mockSynapseJavascriptClient)
-      .getThreadUrl(anyString(), any(AsyncCallback.class));
+      .getThreadUrl(any(), any());
     RequestBuilderMockStubber
       .callOnError(null, new Exception())
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     discussionThreadWidget.configure(
       bundle,
       REPLY_ID_NULL,
@@ -1560,11 +1536,11 @@ public class SingleDiscussionThreadWidgetTest {
     AsyncMockStubber
       .callSuccessWith(url)
       .when(mockSynapseJavascriptClient)
-      .getThreadUrl(anyString(), any(AsyncCallback.class));
+      .getThreadUrl(any(), any());
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     discussionThreadWidget.configure(
       bundle,
       REPLY_ID_NULL,
@@ -1581,7 +1557,7 @@ public class SingleDiscussionThreadWidgetTest {
         WebConstants.TEXT_PLAIN_CHARSET_UTF8
       );
     verify(mockSynAlert, never()).handleException(any(Throwable.class));
-    verify(mockMarkdownWidget).configure(anyString());
+    verify(mockMarkdownWidget).configure(any());
     verify(mockView).setDeleteIconVisible(false);
     // edit thread modal is not configured until edit
     verify(mockEditThreadModal, never())
@@ -1657,20 +1633,17 @@ public class SingleDiscussionThreadWidgetTest {
     verify(mockPopupUtils).showConfirmDelete(anyString(), captor.capture());
     captor.getValue().invoke();
     verify(mockSynAlert).clear();
-    verify(mockDiscussionForumClientAsync)
-      .markThreadAsDeleted(anyString(), any(AsyncCallback.class));
+    verify(mockDiscussionForumClientAsync).markThreadAsDeleted(any(), any());
   }
 
   @Test
   public void testOnClickRestoreThread() {
     discussionThreadWidget.onClickRestore();
     ArgumentCaptor<Callback> captor = ArgumentCaptor.forClass(Callback.class);
-    verify(mockPopupUtils)
-      .showConfirmDialog(anyString(), anyString(), captor.capture());
+    verify(mockPopupUtils).showConfirmDialog(any(), any(), captor.capture());
     captor.getValue().invoke();
     verify(mockSynAlert).clear();
-    verify(mockDiscussionForumClientAsync)
-      .restoreThread(anyString(), any(AsyncCallback.class));
+    verify(mockDiscussionForumClientAsync).restoreThread(any(), any());
   }
 
   @SuppressWarnings("unchecked")
@@ -1853,7 +1826,7 @@ public class SingleDiscussionThreadWidgetTest {
       mockThreadIdClickedCallback
     );
     discussionThreadWidget.onClickThread();
-    verify(mockThreadIdClickedCallback).invoke(anyString());
+    verify(mockThreadIdClickedCallback).invoke(any());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/SubscribersWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/SubscribersWidgetTest.java
@@ -81,11 +81,11 @@ public class SubscribersWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockSubscriberPagedResults)
       .when(mockSynapseJavascriptClient)
-      .getSubscribers(any(Topic.class), anyString(), any(AsyncCallback.class));
+      .getSubscribers(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(TEST_SUBSCRIBER_COUNT)
       .when(mockSynapseJavascriptClient)
-      .getSubscribersCount(any(Topic.class), any(AsyncCallback.class));
+      .getSubscribersCount(any(), any());
     when(mockTopic.getObjectType()).thenReturn(SubscriptionObjectType.FORUM);
     when(mockTopic.getObjectId()).thenReturn(TEST_OBJECT_ID);
     subscribers = new ArrayList<String>();
@@ -96,8 +96,8 @@ public class SubscribersWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSynapseAlert(any(Widget.class));
-    verify(mockView).setUserListContainer(any(Widget.class));
+    verify(mockView).setSynapseAlert(any());
+    verify(mockView).setUserListContainer(any());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class SubscribersWidgetTest {
     verify(mockSynAlert).clear();
     verify(mockLoadMoreWidgetContainer).clear();
     verify(mockView).showDialog();
-    verify(mockLoadMoreWidgetContainer).add(any(Widget.class));
+    verify(mockLoadMoreWidgetContainer).add(any());
     verify(mockLoadMoreWidgetContainer).setIsMore(true);
   }
 
@@ -179,7 +179,7 @@ public class SubscribersWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseJavascriptClient)
-      .getSubscribers(any(Topic.class), anyString(), any(AsyncCallback.class));
+      .getSubscribers(any(), any(), any());
 
     widget.loadMoreSubscribers();
     verify(mockSynAlert).handleException(ex);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/EditDiscussionThreadModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/EditDiscussionThreadModalTest.java
@@ -82,9 +82,9 @@ public class EditDiscussionThreadModalTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(modal);
-    verify(mockView).setAlert(any(Widget.class));
+    verify(mockView).setAlert(any());
     verify(mockView).setModalTitle(anyString());
-    verify(mockView).setMarkdownEditor(any(Widget.class));
+    verify(mockView).setMarkdownEditor(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/EditReplyModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/EditReplyModalTest.java
@@ -81,9 +81,9 @@ public class EditReplyModalTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(modal);
-    verify(mockView).setAlert(any(Widget.class));
+    verify(mockView).setAlert(any());
     verify(mockView).setModalTitle(anyString());
-    verify(mockView).setMarkdownEditor(any(Widget.class));
+    verify(mockView).setMarkdownEditor(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/NewDiscussionThreadModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/modal/NewDiscussionThreadModalTest.java
@@ -87,9 +87,9 @@ public class NewDiscussionThreadModalTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(modal);
-    verify(mockView).setAlert(any(Widget.class));
+    verify(mockView).setAlert(any());
     verify(mockView).setModalTitle(anyString());
-    verify(mockView).setMarkdownEditor(any(Widget.class));
+    verify(mockView).setMarkdownEditor(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerCommitListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerCommitListWidgetTest.java
@@ -101,21 +101,14 @@ public class DockerCommitListWidgetTest {
   public void testConstructor() {
     verify(mockView).setPresenter(dockerCommitListWidget);
     verify(mockView).setCommitsContainer(mockCommitsContainer);
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setSynAlert(any());
     ArgumentCaptor<Callback> captor = ArgumentCaptor.forClass(Callback.class);
     verify(mockCommitsContainer).configure(captor.capture());
     Callback callback = captor.getValue();
     callback.invoke();
     verify(mockSynAlert).clear();
     verify(mockJsClient)
-      .getDockerTaggedCommits(
-        anyString(),
-        anyLong(),
-        anyLong(),
-        any(DockerCommitSortBy.class),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .getDockerTaggedCommits(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -175,7 +168,7 @@ public class DockerCommitListWidgetTest {
         anyBoolean(),
         any(AsyncCallback.class)
       );
-    verify(mockCommitsContainer).add(any(Widget.class));
+    verify(mockCommitsContainer).add(any());
     // only a single value was returned, so there must not be more
     verify(mockCommitsContainer).setIsMore(false);
     verify(mockCommitsContainer, never()).setIsMore(true);
@@ -207,7 +200,7 @@ public class DockerCommitListWidgetTest {
     dockerCommitList.add(commit);
     dockerCommitListWidget.configure(entityId, withRadio);
     verify(mockCommitRow).configure(commit);
-    verify(mockRadioWidget).add(any(Widget.class));
+    verify(mockRadioWidget).add(any());
     verify(mockRadioWidget).setGroupName(id);
     verify(mockRadioWidget).addClickHandler(any(ClickHandler.class));
     verify(mockCommitsContainer).clear();
@@ -221,7 +214,7 @@ public class DockerCommitListWidgetTest {
         anyBoolean(),
         any(AsyncCallback.class)
       );
-    verify(mockCommitsContainer).add(any(Widget.class));
+    verify(mockCommitsContainer).add(any());
     verify(mockCommitsContainer).setIsMore(false);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoListWidgetTest.java
@@ -103,7 +103,7 @@ public class DockerRepoListWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setMembersContainer(mockMembersContainer);
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setSynAlert(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/DockerRepoWidgetTest.java
@@ -115,12 +115,12 @@ public class DockerRepoWidgetTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setWikiPage(any(Widget.class));
-    verify(mockView).setProvenance(any(Widget.class));
-    verify(mockView).setEntityMetadata(any(Widget.class));
-    verify(mockView).setModifiedCreatedBy(any(Widget.class));
-    verify(mockView).setTitlebar(any(Widget.class));
-    verify(mockView).setDockerCommitListWidget(any(Widget.class));
+    verify(mockView).setWikiPage(any());
+    verify(mockView).setProvenance(any());
+    verify(mockView).setEntityMetadata(any());
+    verify(mockView).setModifiedCreatedBy(any());
+    verify(mockView).setTitlebar(any());
+    verify(mockView).setDockerCommitListWidget(any());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/modal/AddExternalRepositoryModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/docker/modal/AddExternalRepositoryModalTest.java
@@ -48,7 +48,7 @@ public class AddExternalRepositoryModalTest {
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(modal);
-    verify(mockView).setAlert(any(Widget.class));
+    verify(mockView).setAlert(any());
     verify(mockView).setModalTitle(ADD_EXTERNAL_REPO_MODAL_TITLE);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/doi/CreateOrUpdateDoiModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/doi/CreateOrUpdateDoiModalTest.java
@@ -26,7 +26,7 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.ObjectType;
@@ -53,7 +53,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.shared.asynch.AsynchType;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CreateOrUpdateDoiModalTest {
 
   private static final String objectId = "syn123";

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/doi/DoiWidgetV2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/doi/DoiWidgetV2Test.java
@@ -15,14 +15,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.doi.v2.DoiAssociation;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.widget.doi.DoiWidgetV2;
 import org.sagebionetworks.web.client.widget.doi.DoiWidgetV2View;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DoiWidgetV2Test {
 
   private DoiWidgetV2 doiWidget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ContainerItemCountWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ContainerItemCountWidgetTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityChildrenRequest;
 import org.sagebionetworks.repo.model.EntityChildrenResponse;
 import org.sagebionetworks.repo.model.EntityType;
@@ -32,7 +32,7 @@ import org.sagebionetworks.web.client.widget.entity.ContainerItemCountWidget;
 import org.sagebionetworks.web.client.widget.entity.ContainerItemCountWidgetView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ContainerItemCountWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditFileMetadataModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditFileMetadataModalWidgetTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.file.FileHandle;
@@ -30,7 +30,7 @@ import org.sagebionetworks.web.client.widget.entity.EditFileMetadataModalView;
 import org.sagebionetworks.web.client.widget.entity.EditFileMetadataModalWidgetImpl;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EditFileMetadataModalWidgetTest {
 
   @Mock
@@ -168,25 +168,14 @@ public class EditFileMetadataModalWidgetTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
 
     // save button
     widget.onPrimary();
     verify(mockView).setLoading(true);
     verify(mockView).hide();
     verify(mockCallback).invoke();
-    verify(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+    verify(mockJsClient).updateEntity(any(), any(), any(), any());
     verify(mockFileEntity).setName(NEW_NAME);
   }
 
@@ -241,12 +230,7 @@ public class EditFileMetadataModalWidgetTest {
     AsyncMockStubber
       .callFailureWith(error)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
     // save button
     widget.onPrimary();
     verify(mockView).setLoading(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditProjectMetadataModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditProjectMetadataModalWidgetTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -22,7 +22,7 @@ import org.sagebionetworks.web.client.widget.entity.EditProjectMetadataModalView
 import org.sagebionetworks.web.client.widget.entity.EditProjectMetadataModalWidgetImpl;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EditProjectMetadataModalWidgetTest {
 
   @Mock
@@ -61,12 +61,7 @@ public class EditProjectMetadataModalWidgetTest {
     AsyncMockStubber
       .callSuccessWith(new Project())
       .when(mockSynapseJavascriptClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
   }
 
   @Test
@@ -153,12 +148,7 @@ public class EditProjectMetadataModalWidgetTest {
     AsyncMockStubber
       .callFailureWith(error)
       .when(mockSynapseJavascriptClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
     // save button
     widget.onPrimary();
     verify(mockView).setLoading(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditRegisterTeamDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EditRegisterTeamDialogTest.java
@@ -47,14 +47,11 @@ public class EditRegisterTeamDialogTest {
     AsyncMockStubber
       .callSuccessWith(challengeTeam)
       .when(mockChallengeClient)
-      .updateRegisteredChallengeTeam(
-        any(ChallengeTeam.class),
-        any(AsyncCallback.class)
-      );
+      .updateRegisteredChallengeTeam(any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockChallengeClient)
-      .unregisterChallengeTeam(anyString(), any(AsyncCallback.class));
+      .unregisterChallengeTeam(any(), any());
   }
 
   @Test
@@ -92,9 +89,8 @@ public class EditRegisterTeamDialogTest {
 
     // click Unregister
     widget.onUnregister();
-    verify(mockChallengeClient)
-      .unregisterChallengeTeam(anyString(), any(AsyncCallback.class));
-    verify(mockView).showInfo(anyString());
+    verify(mockChallengeClient).unregisterChallengeTeam(any(), any());
+    verify(mockView).showInfo(any());
     verify(mockCallback).invoke();
     verify(mockView).hideModal();
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityBadgeTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.FileEntity;
@@ -56,7 +56,7 @@ import org.sagebionetworks.web.client.widget.lazyload.LazyLoadHelper;
 import org.sagebionetworks.web.shared.PublicPrincipalIds;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityBadgeTest {
 
   private static final String USER_ID = "12430";

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityListRowBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityListRowBadgeTest.java
@@ -121,7 +121,7 @@ public class EntityListRowBadgeTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setCreatedByWidget(any(Widget.class));
+    verify(mockView).setCreatedByWidget(any());
   }
 
   private EntityBundle setupEntity(Entity entity) {
@@ -189,7 +189,7 @@ public class EntityListRowBadgeTest {
     verify(mockView).setEntityType(EntityType.project);
     verify(mockView).setEntityLink(entityName, "/Synapse:" + entityId);
     verify(mockUserBadge).configure(createdByUserId);
-    verify(mockView).setCreatedOn(anyString());
+    verify(mockView).setCreatedOn(any());
     verify(mockView).setDescription(description);
     verify(mockView, never()).showAddToDownloadList();
     verify(mockView).setVersion(EntityListRowBadge.N_A);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityMetadataTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityMetadataTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.ObjectType;
@@ -46,7 +46,7 @@ import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenu;
 import org.sagebionetworks.web.client.widget.entity.restriction.v2.RestrictionWidget;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityMetadataTest {
 
   @Mock
@@ -374,7 +374,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(uploadDestinations)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText("s3://testBucket/testBaseKey");
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -394,7 +394,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(uploadDestinations)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText("gs://testBucket/testBaseKey");
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -413,7 +413,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(uploadDestinations)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText("sftp://testUrl.com");
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -432,7 +432,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(uploadDestinations)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText("testUrl.com");
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -455,7 +455,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(uploadDestinations)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText(endpointUrl + "/" + bucket);
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -467,7 +467,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockView).setUploadDestinationText("Synapse Storage");
     verify(mockView).setUploadDestinationPanelVisible(false);
@@ -479,7 +479,7 @@ public class EntityMetadataTest {
     AsyncMockStubber
       .callFailureWith(new Exception("This is an exception!"))
       .when(mockJsClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
     widget.configureStorageLocation(folderEntity);
     verify(mockJSNI).consoleLog("This is an exception!");
     verify(mockView).setUploadDestinationPanelVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityPageTopTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityPageTopTest.java
@@ -28,7 +28,7 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
@@ -73,7 +73,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.Tabs;
 import org.sagebionetworks.web.client.widget.entity.tabs.WikiTab;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityPageTopTest {
 
   @Mock
@@ -249,16 +249,11 @@ public class EntityPageTopTest {
     AsyncMockStubber
       .callSuccessWith(mockProjectBundle)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleFromCache(anyString(), any(AsyncCallback.class));
+      .getEntityBundleFromCache(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockEntityBundle)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleForVersion(
-        anyString(),
-        anyLong(),
-        any(EntityBundleRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getEntityBundleForVersion(any(), any(), any(), any());
 
     when(mockProjectBundle.getEntity()).thenReturn(mockProjectEntity);
     when(mockProjectEntity.getId()).thenReturn(projectEntityId);
@@ -279,27 +274,27 @@ public class EntityPageTopTest {
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseJavascriptClient)
-      .isWiki(anyString(), any(AsyncCallback.class));
+      .isWiki(any(), any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseJavascriptClient)
-      .isFileOrFolder(anyString(), any(AsyncCallback.class));
+      .isFileOrFolder(any(), any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseJavascriptClient)
-      .isTable(anyString(), any(AsyncCallback.class));
+      .isTable(any(), any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseJavascriptClient)
-      .isEntityRefCollectionView(anyString(), any(AsyncCallback.class));
+      .isEntityRefCollectionView(any(), any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseClientAsync)
-      .isChallenge(anyString(), any(AsyncCallback.class));
+      .isChallenge(any(), any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseJavascriptClient)
-      .isDocker(anyString(), any(AsyncCallback.class));
+      .isDocker(any(), any());
 
     when(mockWikiInnerTab.isTabListItemVisible()).thenReturn(true);
     when(mockFilesInnerTab.isTabListItemVisible()).thenReturn(true);
@@ -322,9 +317,9 @@ public class EntityPageTopTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setTabs(any(Widget.class));
-    verify(mockView).setProjectMetadata(any(Widget.class));
-    verify(mockView).setProjectActionMenu(any(Widget.class));
+    verify(mockView).setTabs(any());
+    verify(mockView).setProjectMetadata(any());
+    verify(mockView).setProjectActionMenu(any());
     verify(mockTabs).addTab(mockFilesInnerTab);
     verify(mockTabs).addTab(mockWikiInnerTab);
     verify(mockTabs).addTab(mockTablesInnerTab);
@@ -715,7 +710,7 @@ public class EntityPageTopTest {
     AsyncMockStubber
       .callFailureWith(projectLoadError)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleFromCache(anyString(), any(AsyncCallback.class));
+      .getEntityBundleFromCache(any(), any());
     Synapse.EntityArea area = null;
     String areaToken = null;
     Long versionNumber = 5L;
@@ -753,11 +748,9 @@ public class EntityPageTopTest {
         any(WikiPageWidget.Callback.class)
       );
     verify(mockTablesTab).setProject(projectEntityId, null, projectLoadError);
-    verify(mockTablesTab)
-      .configure(any(EntityBundle.class), eq(null), eq(areaToken));
+    verify(mockTablesTab).configure(any(), eq(null), eq(areaToken));
     verify(mockDatasetsTab).setProject(projectEntityId, null, projectLoadError);
-    verify(mockDatasetsTab)
-      .configure(any(EntityBundle.class), eq(null), eq(areaToken));
+    verify(mockDatasetsTab).configure(any(), eq(null), eq(areaToken));
     verify(mockChallengeTab).configure(projectEntityId, projectName, null);
     verify(mockDiscussionTab)
       .configure(projectEntityId, projectName, null, null, canModerate);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntitySearchBoxTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntitySearchBoxTest.java
@@ -17,7 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.search.Hit;
 import org.sagebionetworks.repo.model.search.SearchResults;
 import org.sagebionetworks.repo.model.search.query.SearchQuery;
@@ -31,7 +31,7 @@ import org.sagebionetworks.web.client.widget.entity.EntitySearchBoxView;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntitySearchBoxTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EvaluationFinderTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EvaluationFinderTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -37,7 +37,7 @@ import org.sagebionetworks.web.client.widget.pagination.BasicPaginationWidget;
 import org.sagebionetworks.web.client.widget.pagination.PageChangeListener;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EvaluationFinderTest {
 
   @Mock
@@ -89,22 +89,15 @@ public class EvaluationFinderTest {
     AsyncMockStubber
       .callSuccessWith(evaluationListPage)
       .when(mockJsClient)
-      .getEvaluations(
-        anyBoolean(),
-        any(ACCESS_TYPE.class),
-        anyList(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getEvaluations(any(), any(), any(), any(), any(), any());
   }
 
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSynAlert(any(IsWidget.class));
-    verify(mockView).setEvaluationList(any(IsWidget.class));
-    verify(mockView).setPaginationWidget(any(IsWidget.class));
+    verify(mockView).setSynAlert(any());
+    verify(mockView).setEvaluationList(any());
+    verify(mockView).setPaginationWidget(any());
   }
 
   @Test
@@ -187,14 +180,7 @@ public class EvaluationFinderTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockJsClient)
-      .getEvaluations(
-        anyBoolean(),
-        any(ACCESS_TYPE.class),
-        anyList(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getEvaluations(any(), any(), any(), any(), any(), any());
 
     widget.configure(isActiveOnly, access, mockSelectedEvaluationCallback);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EvaluationSubmitterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EvaluationSubmitterTest.java
@@ -146,22 +146,11 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(returnSubmission)
       .when(mockChallengeClient)
-      .createIndividualSubmission(
-        any(Submission.class),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .createIndividualSubmission(any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(returnSubmission)
       .when(mockChallengeClient)
-      .createTeamSubmission(
-        any(Submission.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .createTeamSubmission(any(), any(), any(), any(), any());
 
     ArrayList<Evaluation> evaluationList = new ArrayList<Evaluation>();
     e1 = new Evaluation();
@@ -177,13 +166,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(evaluationList)
       .when(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
 
     entity = new FileEntity();
     entity.setVersionNumber(5l);
@@ -194,7 +177,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(entity)
       .when(mockSynapseJavascriptClient)
-      .getEntity(anyString(), any(AsyncCallback.class));
+      .getEntity(any(), any());
 
     requirements = new PaginatedResults<TermsOfUseAccessRequirement>();
     requirements.setTotalNumberOfResults(0);
@@ -207,7 +190,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callFailureWith(new NotFoundException())
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
 
     setupTeamSubmissionEligibility();
     when(mockGWTWrapper.getHostPageBaseURL()).thenReturn(HOST_PAGE_URL);
@@ -227,11 +210,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(testTeamSubmissionEligibility)
       .when(mockChallengeClient)
-      .getTeamSubmissionEligibility(
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .getTeamSubmissionEligibility(any(), any(), any());
   }
 
   @Test
@@ -243,12 +222,7 @@ public class EvaluationSubmitterTest {
     submitter.onNextClicked(null, null, e1);
     // should invoke submission directly without terms of use
     verify(mockChallengeClient)
-      .createIndividualSubmission(
-        any(Submission.class),
-        anyString(),
-        eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
-      );
+      .createIndividualSubmission(any(), any(), eq(HOST_PAGE_URL), any());
 
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     // submitted status shown
@@ -285,9 +259,9 @@ public class EvaluationSubmitterTest {
     verify(mockChallengeClient)
       .createIndividualSubmission(
         captor.capture(),
-        anyString(),
+        any(),
         eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
+        any()
       );
     Submission submission = captor.getValue();
     assertNull(submission.getContributors());
@@ -303,22 +277,12 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callFailureWith(new Exception("unhandled exception"))
       .when(mockChallengeClient)
-      .createIndividualSubmission(
-        any(Submission.class),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .createIndividualSubmission(any(), any(), any(), any());
 
     submitter.onNextClicked(null, null, e1);
     // Should invoke once directly without terms of use
     verify(mockChallengeClient)
-      .createIndividualSubmission(
-        any(Submission.class),
-        anyString(),
-        eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
-      );
+      .createIndividualSubmission(any(), any(), eq(HOST_PAGE_URL), any());
 
     // submitted status shown
     verify(mockView).showErrorMessage(anyString());
@@ -332,24 +296,11 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(evaluationList)
       .when(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     submitter.configure(entity, null, null);
     verify(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
-    verify(mockView)
-      .showModal1(anyBoolean(), any(FormParams.class), any(List.class));
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
+    verify(mockView).showModal1(anyBoolean(), any(), any());
   }
 
   @Test
@@ -361,24 +312,11 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(evaluationList)
       .when(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     submitter.configure(entity, null, null);
     verify(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
-    verify(mockView)
-      .showModal1(anyBoolean(), any(FormParams.class), any(List.class));
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
+    verify(mockView).showModal1(anyBoolean(), any(), any());
   }
 
   @Test
@@ -389,22 +327,10 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(evaluationList)
       .when(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     submitter.configure(entity, null, null);
     verify(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     // no evaluations to join error message
     verify(mockView).showErrorMessage(anyString());
   }
@@ -416,22 +342,10 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callFailureWith(caught)
       .when(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     submitter.configure(entity, null, null);
     verify(mockSynapseJavascriptClient)
-      .getAvailableEvaluations(
-        anySet(),
-        anyBoolean(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getAvailableEvaluations(any(), anyBoolean(), any(), any(), any());
     // no evaluations to join error message
     verify(mockSynAlert).handleException(caught);
   }
@@ -457,7 +371,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(testChallenge)
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
     Team testTeam = new Team();
     testTeam.setId("80");
     testTeam.setName("test team");
@@ -465,7 +379,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(submissionTeams)
       .when(mockChallengeClient)
-      .getSubmissionTeams(anyString(), anyString(), any(AsyncCallback.class));
+      .getSubmissionTeams(any(), any(), any());
 
     Evaluation testEvaluation = new Evaluation();
     testEvaluation.setContentSource("syn9999");
@@ -518,13 +432,7 @@ public class EvaluationSubmitterTest {
     submitter.onDoneClicked();
     verify(mockView).setSubmitButtonLoading();
     verify(mockChallengeClient)
-      .createTeamSubmission(
-        any(Submission.class),
-        anyString(),
-        anyString(),
-        eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
-      );
+      .createTeamSubmission(any(), any(), any(), eq(HOST_PAGE_URL), any());
   }
 
   private void configureSubmitter() {
@@ -540,12 +448,12 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(testChallenge)
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
     List<Team> submissionTeams = Collections.emptyList();
     AsyncMockStubber
       .callSuccessWith(submissionTeams)
       .when(mockChallengeClient)
-      .getSubmissionTeams(anyString(), anyString(), any(AsyncCallback.class));
+      .getSubmissionTeams(any(), any(), any());
 
     Evaluation testEvaluation = new Evaluation();
     testEvaluation.setContentSource("syn9999");
@@ -634,7 +542,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callFailureWith(new ForbiddenException())
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
     submitter.onNextClicked(
       new Reference(),
       "named submission",
@@ -642,12 +550,7 @@ public class EvaluationSubmitterTest {
     );
     verify(mockView).hideModal1();
     verify(mockChallengeClient)
-      .createIndividualSubmission(
-        any(Submission.class),
-        anyString(),
-        eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
-      );
+      .createIndividualSubmission(any(), any(), eq(HOST_PAGE_URL), any());
   }
 
   @Test
@@ -713,7 +616,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(testChallenge)
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
     Team testTeam = new Team();
     testTeam.setId("80");
     testTeam.setName("test team");
@@ -721,7 +624,7 @@ public class EvaluationSubmitterTest {
     AsyncMockStubber
       .callSuccessWith(submissionTeams)
       .when(mockChallengeClient)
-      .getSubmissionTeams(anyString(), anyString(), any(AsyncCallback.class));
+      .getSubmissionTeams(any(), any(), any());
 
     Evaluation testEvaluation = new Evaluation();
     testEvaluation.setContentSource("syn9999");
@@ -749,10 +652,10 @@ public class EvaluationSubmitterTest {
     verify(mockChallengeClient)
       .createTeamSubmission(
         captor.capture(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         eq(HOST_PAGE_URL),
-        any(AsyncCallback.class)
+        any()
       );
     assertNotNull(captor.getValue().getDockerDigest());
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/HtmlPreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/HtmlPreviewWidgetTest.java
@@ -130,14 +130,11 @@ public class HtmlPreviewWidgetTest {
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockFileResult)
       .when(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+      .getFileResult(any(), any());
     when(mockFileResult.getPreSignedURL()).thenReturn(PRESIGNED_URL);
     when(mockFileHandle.getContentSize()).thenReturn(2L);
     when(mockFileHandle.getId()).thenReturn(FILE_HANDLE_ID);
@@ -174,10 +171,7 @@ public class HtmlPreviewWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+      .getFileResult(any(), any());
 
     previewWidget.configure(ENTITY_ID, mockFileHandle);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownEditorWidgetTest.java
@@ -232,7 +232,7 @@ public class MarkdownEditorWidgetTest {
     presenter.getFormattingGuideWikiKey(mockCallback);
     // service was called
     verify(mockSynapseClient).getPageNameToWikiKeyMap(any(AsyncCallback.class));
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -722,8 +722,7 @@ public class MarkdownEditorWidgetTest {
   @Test
   public void testPreview() throws Exception {
     presenter.previewClicked();
-    verify(mockMarkdownWidget)
-      .configure(anyString(), any(WikiPageKey.class), any(Long.class));
+    verify(mockMarkdownWidget).configure(any(), any(), any());
     verify(mockView).showPreview();
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/MarkdownWidgetTest.java
@@ -71,11 +71,11 @@ public class MarkdownWidgetTest {
     mockWidgetRendererPresenter = mock(WidgetRendererPresenter.class);
     when(
       mockWidgetRegistrar.getWidgetRendererForWidgetDescriptor(
-        any(WikiPageKey.class),
-        anyString(),
-        anyMap(),
-        any(Callback.class),
-        any(Long.class)
+        any(),
+        any(),
+        any(),
+        any(),
+        any()
       )
     )
       .thenReturn(mockWidgetRendererPresenter);
@@ -107,8 +107,7 @@ public class MarkdownWidgetTest {
   public void testConfigureSuccess() {
     String sampleHTML = "<h1>heading</h1><p>foo baz bar</p>";
 
-    when(mockMarkdownIt.markdown2Html(anyString(), anyString()))
-      .thenReturn(sampleHTML);
+    when(mockMarkdownIt.markdown2Html(any(), any())).thenReturn(sampleHTML);
     // only the first getElementById called by each getElementById finds its target so it doesn't look
     // forever but still can be verified
     when(
@@ -157,14 +156,14 @@ public class MarkdownWidgetTest {
     verify(mockWidgetRegistrar)
       .getWidgetRendererForWidgetDescriptor(
         Mockito.eq(mockWikiPageKey),
-        anyString(),
-        anyMap(),
-        any(Callback.class),
-        any(Long.class)
+        any(),
+        any(),
+        any(),
+        any()
       );
     verify(mockView)
       .addWidget(
-        any(Widget.class),
+        any(),
         Mockito.contains(WidgetConstants.DIV_ID_WIDGET_PREFIX + "0")
       );
     // removes text inserted by markdown processor (usually "<Synapse widget>" text node, but is
@@ -178,9 +177,8 @@ public class MarkdownWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockWikiPage)
       .when(mockSynapseJavascriptClient)
-      .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
-    when(mockMarkdownIt.markdown2Html(anyString(), anyString()))
-      .thenReturn(sampleHTML);
+      .getV2WikiPageAsV1(any(), any());
+    when(mockMarkdownIt.markdown2Html(any(), any())).thenReturn(sampleHTML);
     // only the first getElementById called by each getElementById finds its target so it doesn't look
     // forever but still can be verified
     when(
@@ -206,7 +204,7 @@ public class MarkdownWidgetTest {
     );
     verify(mockView).callbackWhenAttached(callbackCaptor.capture());
     callbackCaptor.getValue().invoke();
-    verify(mockWikiPageKey).setWikiPageId(anyString());
+    verify(mockWikiPageKey).setWikiPageId(any());
 
     verify(mockMarkdownIt).markdown2Html(anyString(), anyString());
     verify(mockView, Mockito.times(2)).setEmptyVisible(false);
@@ -225,16 +223,10 @@ public class MarkdownWidgetTest {
     verify(mockWidgetRegistrar).getWidgetContentType(elementContentType);
     verify(mockWidgetRegistrar).getWidgetDescriptor(elementContentType);
     verify(mockWidgetRegistrar)
-      .getWidgetRendererForWidgetDescriptor(
-        any(WikiPageKey.class),
-        anyString(),
-        anyMap(),
-        any(Callback.class),
-        any(Long.class)
-      );
+      .getWidgetRendererForWidgetDescriptor(any(), any(), any(), any(), any());
     verify(mockView)
       .addWidget(
-        any(Widget.class),
+        any(),
         Mockito.contains(WidgetConstants.DIV_ID_WIDGET_PREFIX + "0")
       );
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/NbConvertPreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/NbConvertPreviewWidgetTest.java
@@ -136,20 +136,17 @@ public class NbConvertPreviewWidgetTest {
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     when(mockSynapseJSNIUtils.sanitizeHtml(anyString()))
       .thenReturn(SANITIZED_HTML);
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseClient)
-      .isUserAllowedToRenderHTML(anyString(), any(AsyncCallback.class));
+      .isUserAllowedToRenderHTML(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockFileResult)
       .when(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+      .getFileResult(any(), any());
     when(mockFileResult.getPreSignedURL()).thenReturn(PRESIGNED_URL);
     when(mockGwt.encodeQueryString(PRESIGNED_URL))
       .thenReturn(ENCODED_PRESIGNED_URL);
@@ -296,11 +293,7 @@ public class NbConvertPreviewWidgetTest {
     previewWidget.onShowFullContent();
 
     // verify it asks for a fresh presigned url, and opens it (to download)
-    verify(mockPresignedURLAsyncHandler)
-      .getFileResult(
-        any(FileHandleAssociation.class),
-        any(AsyncCallback.class)
-      );
+    verify(mockPresignedURLAsyncHandler).getFileResult(any(), any());
     verify(mockView).openInNewWindow(PRESIGNED_URL);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/PreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/PreviewWidgetTest.java
@@ -180,39 +180,25 @@ public class PreviewWidgetTest {
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     when(mockSynapseAlert.isUserLoggedIn()).thenReturn(true);
 
     AsyncMockStubber
       .callSuccessWith(testBundle)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundle(
-        anyString(),
-        any(EntityBundleRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getEntityBundle(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(testBundle)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleForVersion(
-        anyString(),
-        anyLong(),
-        any(EntityBundleRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getEntityBundleForVersion(any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(TARGET_FILE_PRESIGNED_URL)
       .when(mockSynapseJavascriptClient)
-      .getFileEntityTemporaryUrlForVersion(
-        anyString(),
-        anyLong(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .getFileEntityTemporaryUrlForVersion(any(), any(), anyBoolean(), any());
     AsyncMockStubber
       .callSuccessWith(mockParseResults)
       .when(mockSynapseClient)
-      .parseCsv(anyString(), anyChar(), any(AsyncCallback.class));
+      .parseCsv(any(), anyChar(), any());
     // create empty wiki descriptor
     descriptor = new HashMap<String, String>();
   }
@@ -226,7 +212,7 @@ public class PreviewWidgetTest {
     previewWidget.configure(testBundle);
     previewWidget.asWidget();
 
-    verify(mockView).addSynapseAlertWidget(any(Widget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).showError(anyString());
   }
 
@@ -273,7 +259,7 @@ public class PreviewWidgetTest {
 
     previewWidget.configure(testBundle);
 
-    verify(mockView).addSynapseAlertWidget(any(IsWidget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).showError(statusText);
   }
 
@@ -427,7 +413,7 @@ public class PreviewWidgetTest {
     testFileHandleList.add(fh);
     previewWidget.configure(testBundle);
     previewWidget.asWidget();
-    verify(mockView).setPreviewWidget(any(Widget.class));
+    verify(mockView).setPreviewWidget(any());
   }
 
   @Test
@@ -543,7 +529,7 @@ public class PreviewWidgetTest {
     descriptor.put(WidgetConstants.WIDGET_ENTITY_ID_KEY, entityId);
     previewWidget.configure(null, descriptor, null, null);
 
-    verify(mockView).addSynapseAlertWidget(any(Widget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).showError(anyString());
   }
 
@@ -563,7 +549,7 @@ public class PreviewWidgetTest {
     previewWidget.configure(null, descriptor, null, null);
 
     // verify that it tries to get the entity bundle (without version)
-    verify(mockView).addSynapseAlertWidget(any(Widget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).handleException(any(Exception.class));
   }
 
@@ -672,7 +658,7 @@ public class PreviewWidgetTest {
 
     verify(mockSynapseClient)
       .parseCsv(eq(csvPreviewText), eq(delimiter), any(AsyncCallback.class));
-    verify(mockView).addSynapseAlertWidget(any(Widget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).handleException(ex);
   }
 
@@ -683,7 +669,7 @@ public class PreviewWidgetTest {
 
     previewWidget.configure(testBundle);
 
-    verify(mockView).addSynapseAlertWidget(any(IsWidget.class));
+    verify(mockView).addSynapseAlertWidget(any());
     verify(mockSynapseAlert).showLogin();
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ProjectBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/ProjectBadgeTest.java
@@ -141,8 +141,8 @@ public class ProjectBadgeTest {
     widget.configure(header);
     verify(mockView).configure(eq(name), anyString());
     verify(mockView).setLastActivityVisible(true);
-    verify(mockView).setLastActivityText(anyString());
-    verify(mockView).setFavoritesWidget(any(Widget.class));
+    verify(mockView).setLastActivityText(any());
+    verify(mockView).setFavoritesWidget(any());
     verify(mockFavoriteWidget).asWidget();
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RegisterTeamDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RegisterTeamDialogTest.java
@@ -149,13 +149,9 @@ public class RegisterTeamDialogTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockChallengeClient)
-      .getRegistratableTeams(
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .getRegistratableTeams(any(), any(), any());
     widget.configure(CHALLENGE_ID, mockCallback);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -196,10 +192,7 @@ public class RegisterTeamDialogTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockChallengeClient)
-      .registerChallengeTeam(
-        any(ChallengeTeam.class),
-        any(AsyncCallback.class)
-      );
+      .registerChallengeTeam(any(), any());
     widget.configure(CHALLENGE_ID, mockCallback);
     widget.onOk();
     verify(mockChallengeClient)
@@ -207,6 +200,6 @@ public class RegisterTeamDialogTest {
         any(ChallengeTeam.class),
         any(AsyncCallback.class)
       );
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RenameEntityModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/RenameEntityModalWidgetTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.table.TableEntity;
@@ -35,7 +35,7 @@ import org.sagebionetworks.web.client.widget.entity.PromptForValuesModalView;
 import org.sagebionetworks.web.client.widget.entity.RenameEntityModalWidgetImpl;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RenameEntityModalWidgetTest {
 
   @Mock
@@ -157,12 +157,7 @@ public class RenameEntityModalWidgetTest {
     AsyncMockStubber
       .callSuccessWith(new TableEntity())
       .when(mockJsClient)
-      .updateEntity(
-        entityCaptor.capture(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(entityCaptor.capture(), any(), any(), any());
     verify(mockView)
       .configureAndShow(
         anyString(),
@@ -192,12 +187,7 @@ public class RenameEntityModalWidgetTest {
     AsyncMockStubber
       .callFailureWith(error)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
 
     verify(mockView)
       .configureAndShow(
@@ -226,12 +216,7 @@ public class RenameEntityModalWidgetTest {
     AsyncMockStubber
       .callSuccessWith(new TableEntity())
       .when(mockJsClient)
-      .updateEntity(
-        entityCaptor.capture(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(entityCaptor.capture(), any(), any(), any());
 
     String newDescription = "a new description";
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/SubmissionViewScopeWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/SubmissionViewScopeWidgetTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.Entity;
@@ -32,7 +32,7 @@ import org.sagebionetworks.web.client.widget.table.modal.fileview.SubmissionView
 import org.sagebionetworks.web.client.widget.table.modal.fileview.SubmissionViewScopeWidgetView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SubmissionViewScopeWidgetTest {
 
   @Mock
@@ -99,31 +99,19 @@ public class SubmissionViewScopeWidgetTest {
     AsyncMockStubber
       .callSuccessWith(evaluations)
       .when(mockJsClient)
-      .getEvaluations(
-        anyBoolean(),
-        any(ACCESS_TYPE.class),
-        anyList(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getEvaluations(any(), any(), any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(mockSubmissionView)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
   }
 
   @Test
   public void testConstructor() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSynAlert(any(IsWidget.class));
-    verify(mockView).setSubmissionViewScopeEditor(any(IsWidget.class));
-    verify(mockView).setEvaluationListWidget(any(IsWidget.class));
+    verify(mockView).setSynAlert(any());
+    verify(mockView).setSubmissionViewScopeEditor(any());
+    verify(mockView).setEvaluationListWidget(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/TutorialWizardTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/TutorialWizardTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -25,7 +25,7 @@ import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 /**
  * Unit test for wiki attachments widget
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TutorialWizardTest {
 
   TutorialWizard presenter;
@@ -103,8 +103,8 @@ public class TutorialWizardTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     presenter.configure("syn1234", null);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/VersionHistoryWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/VersionHistoryWidgetTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.FileEntity;
@@ -59,7 +59,7 @@ import org.sagebionetworks.web.shared.PaginatedResults;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class VersionHistoryWidgetTest {
 
   public static final Long CURRENT_FILE_VERSION = 8888L;
@@ -112,7 +112,7 @@ public class VersionHistoryWidgetTest {
     doAnswer(invocationOnMock -> {
         // when setVisible is called, update the isVisible mock to return the last value passed to setVisible
         return when(mockView.isVisible())
-          .thenReturn(invocationOnMock.getArgumentAt(0, Boolean.class));
+          .thenReturn(invocationOnMock.getArgument(0));
       })
       .when(mockView)
       .setVisible(anyBoolean());
@@ -130,7 +130,7 @@ public class VersionHistoryWidgetTest {
 
     vb = new FileEntity();
     vb.setId(entityId);
-    vb.setVersionNumber(new Long(1));
+    vb.setVersionNumber(1L);
     vb.setVersionLabel("");
     vb.setVersionComment("");
     vb.setIsLatestVersion(true);
@@ -150,7 +150,7 @@ public class VersionHistoryWidgetTest {
     AsyncMockStubber
       .callSuccessWith(vb)
       .when(mockSynapseJavascriptClient)
-      .getEntity(anyString(), any(AsyncCallback.class));
+      .getEntity(any(), any());
 
     List<VersionInfo> versions = new ArrayList<VersionInfo>();
     VersionInfo v1 = new VersionInfo();
@@ -162,23 +162,13 @@ public class VersionHistoryWidgetTest {
     AsyncMockStubber
       .callSuccessWith(versions)
       .when(mockJsClient)
-      .getEntityVersions(
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getEntityVersions(any(), anyInt(), anyInt(), any());
     when(mockGlobalApplicationState.getPlaceChanger())
       .thenReturn(mockPlaceChanger);
     AsyncMockStubber
       .callSuccessWith(vb)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
   }
 
   @Test
@@ -235,12 +225,7 @@ public class VersionHistoryWidgetTest {
     versionHistoryWidget.updateVersionInfo(testLabel, testComment);
     ArgumentCaptor<Entity> entityCaptor = ArgumentCaptor.forClass(Entity.class);
     verify(mockJsClient)
-      .updateEntity(
-        entityCaptor.capture(),
-        anyString(),
-        anyBoolean(),
-        (AsyncCallback<Entity>) any()
-      );
+      .updateEntity(entityCaptor.capture(), any(), any(), any());
     VersionableEntity capturedEntity =
       (VersionableEntity) entityCaptor.getValue();
     assertEquals(testComment, capturedEntity.getVersionComment());
@@ -276,18 +261,13 @@ public class VersionHistoryWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockJsClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(Entity.class), any(), any(), any(AsyncCallback.class));
     versionHistoryWidget.updateVersionInfo(testLabel, testComment);
     verify(mockJsClient)
       .updateEntity(
         any(Entity.class),
-        anyString(),
-        anyBoolean(),
+        any(),
+        any(),
         (AsyncCallback<Entity>) any()
       );
     verify(mockSynAlert).handleException(ex);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiAttachmentsTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiAttachmentsTest.java
@@ -91,14 +91,11 @@ public class WikiAttachmentsTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockSynapseClient)
-      .getV2WikiAttachmentHandles(
-        any(WikiPageKey.class),
-        any(AsyncCallback.class)
-      );
+      .getV2WikiAttachmentHandles(any(), any());
     presenter.configure(
       new WikiPageKey("syn1234", ObjectType.ENTITY.toString(), "")
     );
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiHistoryWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiHistoryWidgetTest.java
@@ -82,12 +82,7 @@ public class WikiHistoryWidgetTest {
     AsyncMockStubber
       .callSuccessWith(paginatedHistory)
       .when(mockSynapseClient)
-      .getV2WikiHistory(
-        any(WikiPageKey.class),
-        any(Long.class),
-        any(Long.class),
-        any(AsyncCallback.class)
-      );
+      .getV2WikiHistory(any(), any(), any(), any());
 
     UserGroupHeaderResponsePage responsePage =
       new UserGroupHeaderResponsePage();
@@ -142,13 +137,8 @@ public class WikiHistoryWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .getV2WikiHistory(
-        any(WikiPageKey.class),
-        any(Long.class),
-        any(Long.class),
-        any(AsyncCallback.class)
-      );
-    presenter.configureNextPage(new Long(0), new Long(10));
+      .getV2WikiHistory(any(), any(), any(), any());
+    presenter.configureNextPage(0L, 10L);
     verify(mockSynAlert).handleException(ex);
   }
 
@@ -161,13 +151,8 @@ public class WikiHistoryWidgetTest {
         )
       )
       .when(mockSynapseClient)
-      .getV2WikiHistory(
-        any(WikiPageKey.class),
-        any(Long.class),
-        any(Long.class),
-        any(AsyncCallback.class)
-      );
-    presenter.configureNextPage(new Long(0), new Long(10));
+      .getV2WikiHistory(any(), any(), any(), any());
+    presenter.configureNextPage(0L, 10L);
     verify(mockView).hideLoadMoreButton();
   }
 
@@ -181,13 +166,8 @@ public class WikiHistoryWidgetTest {
     AsyncMockStubber
       .callSuccessWith(paginatedHistory)
       .when(mockSynapseClient)
-      .getV2WikiHistory(
-        any(WikiPageKey.class),
-        any(Long.class),
-        any(Long.class),
-        any(AsyncCallback.class)
-      );
-    presenter.configureNextPage(new Long(10), new Long(10));
+      .getV2WikiHistory(any(), any(), any(), any());
+    presenter.configureNextPage(10L, 10L);
     verify(mockView).hideLoadMoreButton();
   }
 
@@ -198,13 +178,13 @@ public class WikiHistoryWidgetTest {
       .callFailureWith(ex)
       .when(mockSynapseJavascriptClient)
       .getUserGroupHeadersById(any(ArrayList.class), any(AsyncCallback.class));
-    presenter.configureNextPage(new Long(0), new Long(10));
+    presenter.configureNextPage(0L, 10L);
     verify(mockSynAlert).handleException(ex);
   }
 
   @Test
   public void testConfigureNextPage() {
-    presenter.configureNextPage(new Long(0), new Long(10));
+    presenter.configureNextPage(0L, 10L);
     verify(mockView).updateHistoryList(any(List.class));
     verify(mockView).buildHistoryWidget();
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiMarkdownEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiMarkdownEditorTest.java
@@ -147,7 +147,7 @@ public class WikiMarkdownEditorTest {
   public void testConfigure() {
     // configured in before, verify that view is reset
     verify(mockView).setPresenter(presenter);
-    verify(mockView).setMarkdownEditorWidget(any(Widget.class));
+    verify(mockView).setMarkdownEditorWidget(any());
     verify(mockView).clear();
     verify(mockMarkdownEditorWidget).configure(anyString());
     verify(mockView).setTitleEditorVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageDeleteConfirmationDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageDeleteConfirmationDialogTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.SynapseClientAsync;
@@ -37,7 +37,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class WikiPageDeleteConfirmationDialogTest {
 
   private static final String WIKI_TREE_PAGE_A2_TITLE = "title(A2)";
@@ -78,7 +78,7 @@ public class WikiPageDeleteConfirmationDialogTest {
     AsyncMockStubber
       .callSuccessWith(getWikiHeaderTree())
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     when(mockWikiPageKey.getWikiPageId()).thenReturn(WIKI_TREE_PAGE_A2_ID);
     dialog =
       new WikiPageDeleteConfirmationDialog(
@@ -175,10 +175,8 @@ public class WikiPageDeleteConfirmationDialogTest {
     // the call under tests
     dialog.show(mockWikiPageKey, mockAfterDeleteCallback);
 
-    verify(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
-    verify(mockView)
-      .showModal(eq(WIKI_TREE_ROOT_ID), any(Map.class), any(Map.class));
+    verify(mockJsClient).getV2WikiHeaderTree(any(), any(), any());
+    verify(mockView).showModal(eq(WIKI_TREE_ROOT_ID), any(), any());
 
     // should not make it to the delete wiki page call
     verify(mockSynapseClient, never())
@@ -210,18 +208,16 @@ public class WikiPageDeleteConfirmationDialogTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .deleteV2WikiPage(any(WikiPageKey.class), any(AsyncCallback.class));
+      .deleteV2WikiPage(any(), any());
 
     dialog.show(mockWikiPageKey, mockAfterDeleteCallback);
 
     // did not make it to the delete wiki page call
-    verify(mockSynapseClient, never())
-      .deleteV2WikiPage(any(WikiPageKey.class), any(AsyncCallback.class));
+    verify(mockSynapseClient, never()).deleteV2WikiPage(any(), any());
 
     dialog.onDeleteWiki();
 
-    verify(mockView)
-      .showModal(eq(WIKI_TREE_PAGE_A2_ID), any(Map.class), any(Map.class));
+    verify(mockView).showModal(eq(WIKI_TREE_PAGE_A2_ID), any(), any());
     verify(mockSynapseClient)
       .deleteV2WikiPage(any(WikiPageKey.class), any(AsyncCallback.class));
     verify(mockView).showInfo(THE + WIKI + WAS_SUCCESSFULLY_DELETED);
@@ -237,11 +233,11 @@ public class WikiPageDeleteConfirmationDialogTest {
     AsyncMockStubber
       .callSuccessWith(headers)
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .deleteV2WikiPage(any(WikiPageKey.class), any(AsyncCallback.class));
+      .deleteV2WikiPage(any(), any());
 
     dialog.show(mockWikiPageKey, mockAfterDeleteCallback);
 
@@ -270,7 +266,7 @@ public class WikiPageDeleteConfirmationDialogTest {
     AsyncMockStubber
       .callFailureWith(new NotFoundException())
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
 
     dialog.show(mockWikiPageKey, mockAfterDeleteCallback);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/WikiPageWidgetTest.java
@@ -160,18 +160,13 @@ public class WikiPageWidgetTest {
     AsyncMockStubber
       .callSuccessWith(testPage)
       .when(mockSynapseJavascriptClient)
-      .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
+      .getV2WikiPageAsV1(any(), any());
     WikiPage fakeWiki = new WikiPage();
     fakeWiki.setMarkdown("Fake wiki");
     AsyncMockStubber
       .callSuccessWith(fakeWiki)
       .when(mockSynapseClient)
-      .createV2WikiPageWithV1(
-        anyString(),
-        anyString(),
-        any(WikiPage.class),
-        any(AsyncCallback.class)
-      );
+      .createV2WikiPageWithV1(any(), any(), any(), any());
     when(mockFeatureFlagConfig.isFeatureEnabled(FeatureFlagKey.WIKI_DIFF_TOOL))
       .thenReturn(true);
   }
@@ -187,8 +182,7 @@ public class WikiPageWidgetTest {
     boolean canEdit = true;
     String suffix = "-test-suffix";
     String formattedDate = "today";
-    when(mockDateTimeUtils.getDateTimeString(any(Date.class)))
-      .thenReturn(formattedDate);
+    when(mockDateTimeUtils.getDateTimeString(any())).thenReturn(formattedDate);
     WikiPageKey key = new WikiPageKey(
       "ownerId",
       ObjectType.ENTITY.toString(),
@@ -199,8 +193,7 @@ public class WikiPageWidgetTest {
     verify(mockView).setLoadingVisible(true);
     verify(mockSynapseJavascriptClient)
       .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
-    verify(mockMarkdownWidget)
-      .configure(anyString(), any(WikiPageKey.class), any(Long.class));
+    verify(mockMarkdownWidget).configure(any(), any(), any());
     verify(mockView).setNoWikiCanEditMessageVisible(false);
     verify(mockView).setNoWikiCannotEditMessageVisible(false);
     verify(mockView).setWikiHistoryWidget(any(IsWidget.class));
@@ -402,8 +395,8 @@ public class WikiPageWidgetTest {
     verify(mockView, times(2)).scrollWikiHeadingIntoView();
     verify(mockCallbackP).invoke(anyString());
     // also verify that the created by and modified by are updated when wiki page is reloaded
-    verify(mockView, times(2)).setModifiedOn(anyString());
-    verify(mockView, times(2)).setCreatedOn(anyString());
+    verify(mockView, times(2)).setModifiedOn(any());
+    verify(mockView, times(2)).setCreatedOn(any());
 
     // verify response for a different wiki is ignored (if it does not match the current wiki page id,
     // then the markdown widget is not updated).
@@ -471,7 +464,7 @@ public class WikiPageWidgetTest {
     presenter.configure(wikiPageKey, false, null);
     verify(mockSynapseJavascriptClient, never())
       .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
-    verify(mockMarkdownWidget).configure(eq(md), eq(wikiPageKey), anyLong());
+    verify(mockMarkdownWidget).configure(eq(md), eq(wikiPageKey), any());
   }
 
   @Test
@@ -502,13 +495,13 @@ public class WikiPageWidgetTest {
     AsyncMockStubber
       .callSuccessWith(currentV2WikiPage)
       .when(mockSynapseJavascriptClient)
-      .getV2WikiPage(eq(wikiPageKey), any(AsyncCallback.class));
+      .getV2WikiPage(eq(wikiPageKey), any());
 
     presenter.configure(wikiPageKey, false, null);
     verify(mockSynapseJavascriptClient)
       .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
     verify(mockMarkdownWidget)
-      .configure(eq(testPage.getMarkdown()), eq(wikiPageKey), anyLong());
+      .configure(eq(testPage.getMarkdown()), eq(wikiPageKey), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/ACTRevokeUserAccessModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/ACTRevokeUserAccessModalTest.java
@@ -75,8 +75,8 @@ public class ACTRevokeUserAccessModalTest {
   @Test
   public void testConfigure() {
     verify(mockView).setPresenter(dialog);
-    verify(mockView).setUserPickerWidget(any(Widget.class));
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setUserPickerWidget(any());
+    verify(mockView).setSynAlert(any());
     verify(mockSynAlert).clear();
     verify(mockPeopleSuggestWidget).setTypeFilter(TypeFilter.USERS_ONLY);
     verify(mockView).show();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/ApproveUserAccessModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/ApproveUserAccessModalTest.java
@@ -450,13 +450,7 @@ public class ApproveUserAccessModalTest {
       .createAccessApproval(any(AccessApproval.class), aaCaptor.capture());
     aaCaptor.getValue().onSuccess(mockAccessApproval);
     verify(mockSynapseClient)
-      .sendMessage(
-        anySetOf(String.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        sCaptor.capture()
-      );
+      .sendMessage(any(), any(), any(), any(), sCaptor.capture());
   }
 
   @Test
@@ -485,13 +479,7 @@ public class ApproveUserAccessModalTest {
     aaCaptor.getValue().onSuccess(mockAccessApproval);
 
     verify(mockSynapseClient)
-      .sendMessage(
-        anySetOf(String.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        sCaptor.capture()
-      );
+      .sendMessage(any(), any(), any(), any(), sCaptor.capture());
     sCaptor.getValue().onFailure(ex);
 
     verify(mockView).setApproveProcessing(false);
@@ -523,13 +511,7 @@ public class ApproveUserAccessModalTest {
     aaCaptor.getValue().onSuccess(mockAccessApproval);
 
     verify(mockSynapseClient)
-      .sendMessage(
-        anySetOf(String.class),
-        anyString(),
-        anyString(),
-        anyString(),
-        sCaptor.capture()
-      );
+      .sendMessage(any(), any(), any(), any(), sCaptor.capture());
     sCaptor.getValue().onSuccess(anyString());
 
     verify(mockView).setApproveProcessing(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/UserBadgeListTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/act/UserBadgeListTest.java
@@ -82,13 +82,13 @@ public class UserBadgeListTest {
     list.configure();
     list.addAccessorChange(mockChange1);
     verify(mockGinInjector).getUserBadgeItem();
-    verify(mockView).addUserBadge(any(Widget.class));
+    verify(mockView).addUserBadge(any());
 
     // verify attempting to add the same user, it should ignore.
     list.addAccessorChange(mockChange1b);
     // not called again (still a single call, from the first addAccessorChange)
     verify(mockGinInjector).getUserBadgeItem();
-    verify(mockView).addUserBadge(any(Widget.class));
+    verify(mockView).addUserBadge(any());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class UserBadgeListTest {
     list.addAccessorChange(mockChange1);
     list.refreshListUI();
     verify(mockView).clearUserBadges();
-    verify(mockView, times(2)).addUserBadge(any(Widget.class));
+    verify(mockView, times(2)).addUserBadge(any());
   }
 
   @Test
@@ -128,11 +128,11 @@ public class UserBadgeListTest {
     when(mockUserBadgeItem.isSelected()).thenReturn(true);
     list.deleteSelected();
     verify(mockView).clearUserBadges();
-    verify(mockView, times(1)).addUserBadge(any(Widget.class)); // only called when user added initially
+    verify(mockView, times(1)).addUserBadge(any()); // only called when user added initially
 
     // if we add it again, it should add a new user badge
     list.addAccessorChange(mockChange1);
-    verify(mockView, times(2)).addUserBadge(any(Widget.class)); // only called when user added initially
+    verify(mockView, times(2)).addUserBadge(any()); // only called when user added initially
   }
 
   @Test
@@ -144,11 +144,11 @@ public class UserBadgeListTest {
       .thenReturn(mockUserBadgeItem, mockUserBadgeItem2);
     list.addAccessorChange(mockChange1);
     list.addAccessorChange(mockChange2);
-    verify(mockView, times(2)).addUserBadge(any(Widget.class));
+    verify(mockView, times(2)).addUserBadge(any());
     reset(mockView);
     list.deleteSelected();
     verify(mockView).clearUserBadges();
-    verify(mockView, times(1)).addUserBadge(any(Widget.class));
+    verify(mockView, times(1)).addUserBadge(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/AnnotationsRendererWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/AnnotationsRendererWidgetTest.java
@@ -148,7 +148,7 @@ public class AnnotationsRendererWidgetTest {
       EntityBundle.class
     );
 
-    verify(mockView).addEditorToPage(any(Widget.class));
+    verify(mockView).addEditorToPage(any());
     verify(mockEditAnnotationsDialog).configure(bundleCaptor.capture());
 
     assertEquals(bundleCaptor.getValue(), mockBundle);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/EditAnnotationsDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/annotation/EditAnnotationsDialogTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.annotation.v2.Annotations;
 import org.sagebionetworks.repo.model.annotation.v2.AnnotationsValue;
@@ -39,7 +39,7 @@ import org.sagebionetworks.web.client.widget.entity.annotation.EditAnnotationsDi
 import org.sagebionetworks.web.client.widget.entity.annotation.EditAnnotationsDialogView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EditAnnotationsDialogTest {
 
   private static final String ENTITY_ID = "88888888";
@@ -121,7 +121,7 @@ public class EditAnnotationsDialogTest {
 
     // verify a single annotation editor is still added by default
     verify(mockPortalGinInjector).getAnnotationEditor();
-    verify(mockView).addAnnotationEditor(any(Widget.class));
+    verify(mockView).addAnnotationEditor(any());
     verify(mockView).showEditor();
 
     assertEquals(1, dialog.getAnnotationEditors().size());
@@ -134,7 +134,7 @@ public class EditAnnotationsDialogTest {
     // verify the 3 annotation editors are created and added to the view
     verify(mockPortalGinInjector, times(3)).getAnnotationEditor();
     verify(mockView).showEditor();
-    verify(mockView, times(3)).addAnnotationEditor(any(Widget.class));
+    verify(mockView, times(3)).addAnnotationEditor(any());
 
     assertEquals(dialog.getAnnotationsCopy(), annotations);
     assertEquals(3, dialog.getAnnotationEditors().size());
@@ -168,7 +168,7 @@ public class EditAnnotationsDialogTest {
     // before delete, 2 editors
     assertEquals(2, dialog.getAnnotationEditors().size());
     deletedCallback.invoke();
-    verify(mockView).removeAnnotationEditor(any(Widget.class));
+    verify(mockView).removeAnnotationEditor(any());
 
     assertEquals(1, dialog.getAnnotationEditors().size());
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/EntityFinderWidgetImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/EntityFinderWidgetImplTest.java
@@ -19,7 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.Reference;
@@ -40,7 +40,7 @@ import org.sagebionetworks.web.client.widget.entity.browse.EntityFinderWidgetImp
 import org.sagebionetworks.web.client.widget.entity.browse.EntityFinderWidgetView;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityFinderWidgetImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/EntityTreeBrowserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/EntityTreeBrowserTest.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityChildrenRequest;
 import org.sagebionetworks.repo.model.EntityChildrenResponse;
 import org.sagebionetworks.repo.model.EntityHeader;
@@ -51,7 +51,7 @@ import org.sagebionetworks.web.client.widget.entity.browse.EntityTreeBrowserView
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityTreeBrowserTest {
 
   public static final String TEST_RESULT_ID = "testResultId";

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/FilesBrowserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/FilesBrowserTest.java
@@ -6,12 +6,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.widget.entity.browse.FilesBrowser;
 import org.sagebionetworks.web.client.widget.entity.browse.FilesBrowserView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FilesBrowserTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/MyEntitiesBrowserTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/browse/MyEntitiesBrowserTest.java
@@ -102,14 +102,7 @@ public class MyEntitiesBrowserTest {
     AsyncMockStubber
       .callSuccessWith(mockProjectHeaderList)
       .when(mockSynapseJavascriptClient)
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
   }
 
   @Test
@@ -117,28 +110,14 @@ public class MyEntitiesBrowserTest {
     when(mockProjectHeaderList.getNextPageToken()).thenReturn("abc", null);
     widget.loadMoreUserUpdateable();
     verify(mockSynapseJavascriptClient)
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
-    verify(mockView).addUpdatableEntities(anyList());
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
+    verify(mockView).addUpdatableEntities(any());
     verify(mockView).setIsMoreUpdatableEntities(true);
 
     entities.clear();
     widget.loadMoreUserUpdateable();
     verify(mockSynapseJavascriptClient, times(2))
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
     verify(mockView).setIsMoreUpdatableEntities(false);
   }
 
@@ -155,14 +134,7 @@ public class MyEntitiesBrowserTest {
     AsyncMockStubber
       .callFailureWith(new Exception(errorMessage))
       .when(mockSynapseJavascriptClient)
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
     widget.loadMoreUserUpdateable();
     verify(mockView, never()).addUpdatableEntities(anyList());
     verify(mockView).showErrorMessage(errorMessage);
@@ -214,14 +186,7 @@ public class MyEntitiesBrowserTest {
     verify(mockEntityTreeBrowser).clear();
     verify(mockView, times(2)).setIsMoreUpdatableEntities(true);
     verify(mockSynapseJavascriptClient)
-      .getMyProjects(
-        any(ProjectListType.class),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getMyProjects(any(), anyInt(), any(), any(), any(), any());
 
     // test clearState() when context has changed
     when(mockGlobalApplicationState.getCurrentPlace())

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.xpath.Arg;
 import org.gwtbootstrap3.extras.bootbox.client.callback.PromptCallback;
 import org.junit.Before;
 import org.junit.Test;
@@ -458,7 +459,7 @@ public class EntityActionControllerImplTest {
       .thenReturn(currentUserId);
     when(mockGlobalApplicationState.getPlaceChanger())
       .thenReturn(mockPlaceChanger);
-    when(mockKeyFactoryProvider.getKeyFactory(anyString()))
+    when(mockKeyFactoryProvider.getKeyFactory(any()))
       .thenReturn(mockKeyFactory);
 
     when(mockPortalGinInjector.getSynapseProperties())
@@ -585,7 +586,7 @@ public class EntityActionControllerImplTest {
 
     mockEntityView.setId(entityId);
     mockEntityView.setParentId(parentId);
-    mockEntityView.setViewTypeMask(new Long(WebConstants.FILE));
+    mockEntityView.setViewTypeMask(Long.valueOf(WebConstants.FILE));
 
     // Setup the mock entity selector to select an entity.
     Mockito
@@ -608,11 +609,11 @@ public class EntityActionControllerImplTest {
     CallbackMockStubber
       .invokeCallback()
       .when(mockGWT)
-      .scheduleExecution(any(Callback.class), anyInt());
+      .scheduleExecution(any(), anyInt());
 
     when(mockPromptModalConfigurationBuilder.buildConfiguration())
       .thenReturn(mockPromptModalConfiguration);
-    when(mockSynapseJavascriptClient.getChallengeForProject(anyString()))
+    when(mockSynapseJavascriptClient.getChallengeForProject(any()))
       .thenReturn(getDoneFuture(new Challenge()));
   }
 
@@ -1647,7 +1648,7 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callSuccessWith(headers)
       .when(mockSynapseJavascriptClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     entityBundle.setEntity(new Project());
     currentEntityArea = EntityArea.WIKI;
     boolean canEdit = true;
@@ -1668,7 +1669,7 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callSuccessWith(new ArrayList<V2WikiHeader>())
       .when(mockSynapseJavascriptClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     entityBundle.setEntity(new Project());
     currentEntityArea = EntityArea.WIKI;
     boolean canEdit = true;
@@ -2703,16 +2704,16 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callWithInvoke()
       .when(mockView)
-      .showConfirmDeleteDialog(anyString(), any(Callback.class));
+      .showConfirmDeleteDialog(any(), any());
     // confirm pre-flight
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkDeleteEntity(any(EntityBundle.class), any(Callback.class));
+      .checkDeleteEntity(any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseJavascriptClient)
-      .deleteEntityById(anyString(), any(AsyncCallback.class));
+      .deleteEntityById(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -2739,7 +2740,7 @@ public class EntityActionControllerImplTest {
       .goTo(new Synapse(parentId, null, EntityArea.TABLES, null));
     QueryKey mockQueryKey = mock(QueryKey.class);
     when(mockKeyFactory.getTrashCanItemsQueryKey()).thenReturn(mockQueryKey);
-    verify(mockKeyFactoryProvider).getKeyFactory(anyString());
+    verify(mockKeyFactoryProvider).getKeyFactory(any());
     verify(mockKeyFactory).getTrashCanItemsQueryKey();
     verify(mockQueryClient)
       .invalidateQueries(any(InvalidateQueryFilters.class));
@@ -3088,12 +3089,7 @@ public class EntityActionControllerImplTest {
     );
     // method under test
     controller.onAction(Action.EDIT_FILE_METADATA, null);
-    verify(mockEditFileMetadataModalWidget)
-      .configure(
-        any(FileEntity.class),
-        any(FileHandle.class),
-        any(Callback.class)
-      );
+    verify(mockEditFileMetadataModalWidget).configure(any(), any(), any());
     verify(mockEventBus, never()).fireEvent(any(EntityUpdatedEvent.class));
   }
 
@@ -3277,7 +3273,7 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockSynapseJavascriptClient)
-      .getV2WikiPageAsV1(any(WikiPageKey.class), any(AsyncCallback.class));
+      .getV2WikiPageAsV1(any(), any());
     entityBundle.setRootWikiId("111");
     controller.configure(
       mockActionMenu,
@@ -3288,7 +3284,7 @@ public class EntityActionControllerImplTest {
       mockAddToDownloadListWidget
     );
     controller.onAction(Action.VIEW_WIKI_SOURCE, null);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -3690,11 +3686,11 @@ public class EntityActionControllerImplTest {
   }
 
   @Test
-  public void testOnSubmitWithUdate() {
+  public void testOnSubmitWithUpdate() {
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
+      .checkUpdateEntity(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -3704,8 +3700,7 @@ public class EntityActionControllerImplTest {
       mockAddToDownloadListWidget
     );
     controller.onAction(Action.SUBMIT_TO_CHALLENGE, null);
-    verify(mockSubmitter)
-      .configure(any(Entity.class), any(Set.class), any(FormParams.class));
+    verify(mockSubmitter).configure(any(Entity.class), any(), any());
   }
 
   @Test
@@ -4211,7 +4206,7 @@ public class EntityActionControllerImplTest {
     // note that the currentArea is null (project settings)
     currentEntityArea = null;
     entityBundle.setEntity(new Project());
-    when(mockSynapseJavascriptClient.getChallengeForProject(anyString()))
+    when(mockSynapseJavascriptClient.getChallengeForProject(any()))
       .thenReturn(getFailedFuture(new NotFoundException()));
     controller.configure(
       mockActionMenu,
@@ -4240,7 +4235,7 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callSuccessWith(new Challenge())
       .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
+      .getChallengeForProject(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4258,7 +4253,7 @@ public class EntityActionControllerImplTest {
     // currentArea is on the challenge tab
     currentEntityArea = EntityArea.CHALLENGE;
     entityBundle.setEntity(new Project());
-    when(mockSynapseJavascriptClient.getChallengeForProject(anyString()))
+    when(mockSynapseJavascriptClient.getChallengeForProject(any()))
       .thenReturn(getDoneFuture(new Challenge()));
     controller.configure(
       mockActionMenu,
@@ -4324,7 +4319,7 @@ public class EntityActionControllerImplTest {
   public void testGetChallengeError() throws Exception {
     entityBundle.setEntity(new Project());
     String error = "an error";
-    when(mockSynapseJavascriptClient.getChallengeForProject(anyString()))
+    when(mockSynapseJavascriptClient.getChallengeForProject(any()))
       .thenReturn(getFailedFuture(new Exception(error)));
     controller.configure(
       mockActionMenu,
@@ -4667,15 +4662,15 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockChallengeClient)
-      .deleteChallenge(anyString(), any(AsyncCallback.class));
+      .deleteChallenge(any(), any());
     AsyncMockStubber
       .callWithInvoke()
       .when(mockView)
-      .showConfirmDeleteDialog(anyString(), any(Callback.class));
+      .showConfirmDeleteDialog(any(), any());
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkDeleteEntity(any(EntityBundle.class), any(Callback.class));
+      .checkDeleteEntity(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4690,8 +4685,7 @@ public class EntityActionControllerImplTest {
     verify(mockView).showConfirmDeleteDialog(anyString(), any(Callback.class));
     verify(mockPreflightController)
       .checkDeleteEntity(any(EntityBundle.class), any(Callback.class));
-    verify(mockChallengeClient)
-      .deleteChallenge(anyString(), any(AsyncCallback.class));
+    verify(mockChallengeClient).deleteChallenge(any(), any());
     verify(mockEventBus).fireEvent(any(EntityUpdatedEvent.class));
   }
 
@@ -4701,15 +4695,15 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callFailureWith(new Exception(error))
       .when(mockChallengeClient)
-      .deleteChallenge(anyString(), any(AsyncCallback.class));
+      .deleteChallenge(any(), any());
     AsyncMockStubber
       .callWithInvoke()
       .when(mockView)
-      .showConfirmDeleteDialog(anyString(), any(Callback.class));
+      .showConfirmDeleteDialog(any(), any());
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkDeleteEntity(any(EntityBundle.class), any(Callback.class));
+      .checkDeleteEntity(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4721,8 +4715,7 @@ public class EntityActionControllerImplTest {
 
     controller.onAction(Action.DELETE_CHALLENGE, null);
 
-    verify(mockChallengeClient)
-      .deleteChallenge(anyString(), any(AsyncCallback.class));
+    verify(mockChallengeClient).deleteChallenge(any(), any());
     verify(mockView).showErrorMessage(error);
     verify(mockEventBus, never()).fireEvent(any(EntityUpdatedEvent.class));
   }
@@ -4741,22 +4734,17 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
+      .checkUpdateEntity(any(), any());
     AsyncMockStubber
       .callSuccessWith(tableEntity)
       .when(mockSynapseJavascriptClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
     assertFalse(tableEntity.getIsSearchEnabled());
 
     controller.onAction(Action.TOGGLE_FULL_TEXT_SEARCH, null);
 
     assertTrue(tableEntity.getIsSearchEnabled());
-    verify(mockView).showSuccess(anyString());
+    verify(mockView).showSuccess(any());
   }
 
   @Test
@@ -4774,16 +4762,11 @@ public class EntityActionControllerImplTest {
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
-      .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
+      .checkUpdateEntity(any(), any());
     AsyncMockStubber
       .callFailureWith(new Exception(errorMessage))
       .when(mockSynapseJavascriptClient)
-      .updateEntity(
-        any(Entity.class),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .updateEntity(any(), any(), any(), any());
     assertFalse(tableEntity.getIsSearchEnabled());
 
     controller.onAction(Action.TOGGLE_FULL_TEXT_SEARCH, null);
@@ -4943,11 +4926,7 @@ public class EntityActionControllerImplTest {
       )
     );
 
-    when(
-      mockSynapseJavascriptClient.getActionsRequiredForEntityDownload(
-        anyString()
-      )
-    )
+    when(mockSynapseJavascriptClient.getActionsRequiredForEntityDownload(any()))
       .thenReturn(getDoneFuture(actionsRequiredForDownload));
 
     entityBundle.setEntity(new FileEntity());
@@ -4964,7 +4943,9 @@ public class EntityActionControllerImplTest {
     );
 
     verify(mockActionMenu).setDownloadMenuEnabled(false);
-    ArgumentCaptor<String> tooltipCaptor = new ArgumentCaptor<>();
+    ArgumentCaptor<String> tooltipCaptor = ArgumentCaptor.forClass(
+      String.class
+    );
     verify(mockActionMenu, times(2))
       .setDownloadMenuTooltipText(tooltipCaptor.capture());
     String tooltip = tooltipCaptor.getAllValues().get(1);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceEditorWidgetTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
@@ -44,7 +44,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.URLProvEntryView;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ProvenanceEditorWidgetTest {
 
   @Mock
@@ -146,11 +146,7 @@ public class ProvenanceEditorWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockActivity)
       .when(mockJsClient)
-      .getActivityForEntityVersion(
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getActivityForEntityVersion(any(), any(), any());
     when(mockProvenanceList.getEntries())
       .thenReturn(new LinkedList<ProvenanceEntry>());
     presenter.configure(mockEntityBundle);
@@ -187,11 +183,7 @@ public class ProvenanceEditorWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockActivity)
       .when(mockJsClient)
-      .getActivityForEntityVersion(
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getActivityForEntityVersion(any(), any(), any());
     presenter.configure(mockEntityBundle);
     verify(mockView).setName(mockActivity.getName());
     verify(mockView).setDescription(mockActivity.getDescription());
@@ -214,11 +206,7 @@ public class ProvenanceEditorWidgetTest {
     AsyncMockStubber
       .callFailureWith(caught)
       .when(mockJsClient)
-      .getActivityForEntityVersion(
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getActivityForEntityVersion(any(), any(), any());
     presenter.configure(mockEntityBundle);
     verify(mockSynAlert).handleException(caught);
   }
@@ -263,20 +251,12 @@ public class ProvenanceEditorWidgetTest {
     AsyncMockStubber
       .callFailureWith(new NotFoundException())
       .when(mockJsClient)
-      .getActivityForEntityVersion(
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getActivityForEntityVersion(any(), any(), any());
     presenter.configure(mockEntityBundle);
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockJsClient)
-      .createActivityAndLinkToEntity(
-        any(Activity.class),
-        eq(mockEntity),
-        any(AsyncCallback.class)
-      );
+      .createActivityAndLinkToEntity(any(), eq(mockEntity), any());
     presenter.onSave();
     verify(mockJsClient)
       .createActivityAndLinkToEntity(

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/ProvenanceListWidgetTest.java
@@ -18,7 +18,7 @@ import org.mockito.AdditionalMatchers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -32,7 +32,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.ProvenanceURLDial
 import org.sagebionetworks.web.client.widget.entity.controller.URLProvEntryView;
 import org.sagebionetworks.web.test.helper.SelfReturningAnswer;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ProvenanceListWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StorageLocationWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/StorageLocationWidgetTest.java
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination;
@@ -46,7 +46,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class StorageLocationWidgetTest {
 
   @Mock
@@ -353,19 +353,10 @@ public class StorageLocationWidgetTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .createStorageLocationSetting(
-        anyString(),
-        any(StorageLocationSetting.class),
-        any(AsyncCallback.class)
-      );
+      .createStorageLocationSetting(any(), any(), any());
     widget.onSave();
 
-    verify(mockSynapseClient)
-      .createStorageLocationSetting(
-        anyString(),
-        any(StorageLocationSetting.class),
-        any(AsyncCallback.class)
-      );
+    verify(mockSynapseClient).createStorageLocationSetting(any(), any(), any());
     verify(mockEventBus).fireEvent(any(EntityUpdatedEvent.class));
     verify(mockView).hide();
   }
@@ -415,19 +406,10 @@ public class StorageLocationWidgetTest {
     AsyncMockStubber
       .callFailureWith(e)
       .when(mockSynapseClient)
-      .createStorageLocationSetting(
-        anyString(),
-        any(StorageLocationSetting.class),
-        any(AsyncCallback.class)
-      );
+      .createStorageLocationSetting(any(), any(), any());
     widget.onSave();
 
-    verify(mockSynapseClient)
-      .createStorageLocationSetting(
-        anyString(),
-        any(StorageLocationSetting.class),
-        any(AsyncCallback.class)
-      );
+    verify(mockSynapseClient).createStorageLocationSetting(any(), any(), any());
     verify(mockSynAlert).handleException(e);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/AddFolderDialogWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/AddFolderDialogWidgetTest.java
@@ -79,7 +79,7 @@ public class AddFolderDialogWidgetTest {
   @Test
   public void testConstructor() {
     verify(mockView).setSynAlert(mockSynAlert);
-    verify(mockView).setSharingAndDataUseWidget(any(IsWidget.class));
+    verify(mockView).setSharingAndDataUseWidget(any());
     verify(mockView).setPresenter(w);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/QuizInfoDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/QuizInfoDialogTest.java
@@ -60,10 +60,10 @@ public class QuizInfoDialogTest {
     verify(mockQuizInfo).configure();
     verify(mockModal)
       .configure(
-        anyString(),
-        any(Widget.class),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
+        any(),
         callbackCaptor.capture(),
         anyBoolean()
       );

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploadDialogTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploadDialogTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.web.client.events.CancelHandler;
 import org.sagebionetworks.web.client.events.UploadSuccessHandler;
@@ -19,7 +19,7 @@ import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidget;
 import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidgetView;
 import org.sagebionetworks.web.client.widget.entity.download.Uploader;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UploadDialogTest {
 
   @Mock
@@ -52,7 +52,7 @@ public class UploadDialogTest {
 
     verify(mockUploader)
       .configure(entity, parentEntityId, fileHandleIdCallback, isEntity);
-    verify(view).configureDialog(eq(title), any(Widget.class));
+    verify(view).configureDialog(eq(title), any());
 
     verify(mockUploader).setSuccessHandler(any(UploadSuccessHandler.class));
     verify(mockUploader).setCancelHandler(any(CancelHandler.class));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/download/UploaderTest.java
@@ -30,11 +30,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.FileEntity;
@@ -76,7 +77,7 @@ import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 import org.sagebionetworks.web.unitclient.widget.upload.MultipartUploaderStub;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UploaderTest {
 
   @Mock
@@ -194,17 +195,12 @@ public class UploaderTest {
     AsyncMockStubber
       .callSuccessWith(destinations)
       .when(mockSynapseJavascriptClient)
-      .getUploadDestinations(anyString(), any(AsyncCallback.class));
+      .getUploadDestinations(any(), any());
 
     AsyncMockStubber
       .callSuccessWith("entityID")
       .when(mockSynapseClient)
-      .setFileEntityFileHandle(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .setFileEntityFileHandle(any(), any(), any(), any());
 
     String[] fileNames = { "newFile.txt" };
     when(
@@ -217,37 +213,33 @@ public class UploaderTest {
       .callSuccessWith(testEntity)
       .when(mockSynapseClient)
       .updateExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        anyLong(),
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any()
       );
     AsyncMockStubber
       .callSuccessWith(testEntity)
       .when(mockSynapseClient)
       .createExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        anyLong(),
-        anyString(),
-        anyLong(),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        any()
       );
     // by default, there is no name conflict
     AsyncMockStubber
       .callFailureWith(new NotFoundException())
       .when(mockSynapseClient)
-      .getFileEntityIdWithSameName(
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .getFileEntityIdWithSameName(any(), any(), any());
     uploader =
       new Uploader(
         mockView,
@@ -306,14 +298,14 @@ public class UploaderTest {
     );
     verify(mockSynapseClient)
       .createExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        eq((Long) null),
-        eq((String) null),
+        any(),
+        any(),
+        any(),
+        any(),
+        eq(null),
+        eq(null),
         eq(storageLocationId),
-        any(AsyncCallback.class)
+        any()
       );
     verify(mockView).showInfo(anyString());
     verify(mockUploadSuccessHandler).onSuccessfulUpload();
@@ -325,14 +317,14 @@ public class UploaderTest {
       .callFailureWith(new Exception("failed to create"))
       .when(mockSynapseClient)
       .createExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        eq((Long) null),
-        eq((String) null),
-        anyLong(),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any(),
+        eq(null),
+        eq(null),
+        any(),
+        any()
       );
     uploader.setExternalFilePath(
       "http://fakepath.url/blah.xml",
@@ -348,21 +340,21 @@ public class UploaderTest {
       .callFailureWith(new Exception("failed to update path"))
       .when(mockSynapseClient)
       .createExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        eq((Long) null),
-        eq((String) null),
-        anyLong(),
-        any(AsyncCallback.class)
+        any(),
+        any(),
+        any(),
+        any(),
+        eq(null),
+        eq(null),
+        any(),
+        any()
       );
     uploader.setExternalFilePath(
       "http://fakepath.url/blah.xml",
       "",
       storageLocationId
     );
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -373,14 +365,14 @@ public class UploaderTest {
     uploader.setExternalFilePath(url, "", storageLocationId);
     verify(mockSynapseClient)
       .createExternalFile(
-        anyString(),
+        any(),
         eq(encodedUrl),
-        anyString(),
-        anyString(),
-        eq((Long) null),
-        eq((String) null),
+        any(),
+        any(),
+        eq(null),
+        eq(null),
         eq(storageLocationId),
-        any(AsyncCallback.class)
+        any()
       );
     verify(mockView).showInfo(anyString());
   }
@@ -395,14 +387,14 @@ public class UploaderTest {
     );
     verify(mockSynapseClient)
       .updateExternalFile(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        eq((Long) null),
-        eq((String) null),
+        any(),
+        any(),
+        any(),
+        any(),
+        eq(null),
+        eq(null),
         eq(storageLocationId),
-        any(AsyncCallback.class)
+        any()
       );
     verify(mockView).showInfo(anyString());
   }
@@ -423,12 +415,7 @@ public class UploaderTest {
     verify(mockGlobalApplicationState).clearDropZoneHandler(); // SWC-5161 (cleared on handleUploads)
     verify(mockView).disableSelectionDuringUpload();
     verify(mockSynapseClient)
-      .setFileEntityFileHandle(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .setFileEntityFileHandle(any(), any(), any(), any());
     verify(mockView).hideLoading();
     assertEquals(UploadType.S3, uploader.getCurrentUploadType());
     // verify upload success
@@ -561,7 +548,7 @@ public class UploaderTest {
   }
 
   private void verifyUploadError() {
-    verify(mockView).showErrorMessage(anyString(), anyString());
+    verify(mockView).showErrorMessage(any(), any());
     verify(mockCancelHandler).onCancel();
   }
 
@@ -887,9 +874,9 @@ public class UploaderTest {
       .configure(accessKey, secretKey, bucket, endpoint);
     verify(mockS3DirectUploader)
       .uploadFile(
-        anyString(),
-        anyString(),
-        any(JavaScriptObject.class),
+        any(),
+        any(),
+        any(),
         eq(uploader),
         eq(keyPrefixUUID),
         eq(storageLocationId),
@@ -921,12 +908,7 @@ public class UploaderTest {
     dragAndDropHandlerCaptor.getValue().invoke(mockDroppedFileList);
 
     verify(mockSynapseClient)
-      .setFileEntityFileHandle(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .setFileEntityFileHandle(any(), any(), any(), any());
   }
 
   @Test
@@ -984,12 +966,7 @@ public class UploaderTest {
     r.setMessage(fileHandleId);
     uploader.handleSubmitResult(r);
     verify(mockSynapseClient)
-      .setFileEntityFileHandle(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .setFileEntityFileHandle(any(), any(), any(), any());
   }
 
   @Test
@@ -1053,11 +1030,7 @@ public class UploaderTest {
   @Test
   public void testGetSelectedFilesText() {
     String fileName = "single file.txt";
-    when(
-      mockSynapseJsniUtils.getMultipleUploadFileNames(
-        any(JavaScriptObject.class)
-      )
-    )
+    when(mockSynapseJsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { fileName });
     assertEquals(fileName, uploader.getSelectedFilesText());
   }
@@ -1075,11 +1048,7 @@ public class UploaderTest {
 
   @Test
   public void testGetSelectedFilesTextMultipleFiles() {
-    when(
-      mockSynapseJsniUtils.getMultipleUploadFileNames(
-        any(JavaScriptObject.class)
-      )
-    )
+    when(mockSynapseJsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "file1", "file2" });
     assertEquals("2 files", uploader.getSelectedFilesText());
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/APITableColumnManagerTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/APITableColumnManagerTest.java
@@ -81,7 +81,7 @@ public class APITableColumnManagerTest {
     manager.configure(configs);
 
     verify(mockView).clearColumns();
-    verify(mockView, times(2)).addColumn(any(Widget.class));
+    verify(mockView, times(2)).addColumn(any());
     verify(mockView).setButtonToolbarVisible(true);
     verify(mockView).setHeaderColumnsVisible(true);
     verify(mockView).setNoColumnsUIVisible(false);
@@ -109,7 +109,7 @@ public class APITableColumnManagerTest {
       .setSelectionChangedCallback(any(Callback.class));
     verify(mockColumnConfigEditor).configure(any(APITableColumnConfig.class));
 
-    verify(mockView).addColumn(any(Widget.class));
+    verify(mockView).addColumn(any());
     verify(mockView).setButtonToolbarVisible(true);
     verify(mockView).setHeaderColumnsVisible(true);
     verify(mockView).setNoColumnsUIVisible(false);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/AttachmentConfigEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/AttachmentConfigEditorTest.java
@@ -81,8 +81,8 @@ public class AttachmentConfigEditorTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(editor);
-    verify(mockView).setFileInputWidget(any(Widget.class));
-    verify(mockView).setWikiAttachmentsWidget(any(Widget.class));
+    verify(mockView).setFileInputWidget(any());
+    verify(mockView).setWikiAttachmentsWidget(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/EntityListConfigEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/EntityListConfigEditorTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityGroupRecord;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.security.AuthenticationController;
@@ -32,7 +32,7 @@ import org.sagebionetworks.web.client.widget.entity.renderer.EntityListWidget;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.test.helper.SelfReturningAnswer;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityListConfigEditorTest {
 
   EntityListConfigEditor editor;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/EvaluationSubmissionConfigEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/EvaluationSubmissionConfigEditorTest.java
@@ -17,13 +17,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.widget.entity.dialog.DialogCallback;
 import org.sagebionetworks.web.client.widget.entity.editor.EvaluationSubmissionConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.EvaluationSubmissionConfigView;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EvaluationSubmissionConfigEditorTest {
 
   EvaluationSubmissionConfigEditor editor;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/ImageConfigEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/ImageConfigEditorTest.java
@@ -89,8 +89,8 @@ public class ImageConfigEditorTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(editor);
-    verify(mockView).setFileInputWidget(any(Widget.class));
-    verify(mockView).setWikiAttachmentsWidget(any(Widget.class));
+    verify(mockView).setFileInputWidget(any());
+    verify(mockView).setWikiAttachmentsWidget(any());
     verify(mockFileInputWidget).configure(any(CallbackP.class));
     verify(mockAttachments).configure(any(WikiPageKey.class));
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/TeamSelectEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/TeamSelectEditorTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.principal.TypeFilter;
 import org.sagebionetworks.web.client.widget.entity.editor.TeamSelectEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.TeamSelectEditorView;
@@ -19,7 +19,7 @@ import org.sagebionetworks.web.client.widget.search.UserGroupSuggestionProvider;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TeamSelectEditorTest {
 
   TeamSelectEditor widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/UserSelectorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/editor/UserSelectorTest.java
@@ -81,7 +81,7 @@ public class UserSelectorTest {
     verify(mockSuggestBox)
       .setSuggestionProvider(mockUserGroupSuggestionProvider);
     verify(mockSuggestBox).setTypeFilter(TypeFilter.ALL);
-    verify(mockView).setSelectBox(any(Widget.class));
+    verify(mockView).setSelectBox(any());
     verify(mockSuggestBox).addItemSelectedHandler(any(CallbackP.class));
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/ProjectTitleBarTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/ProjectTitleBarTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.Folder;
@@ -20,7 +20,7 @@ import org.sagebionetworks.web.client.widget.entity.FavoriteWidget;
 import org.sagebionetworks.web.client.widget.entity.file.ProjectTitleBar;
 import org.sagebionetworks.web.client.widget.entity.file.ProjectTitleBarView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ProjectTitleBarTest {
 
   ProjectTitleBar titleBar;
@@ -49,7 +49,7 @@ public class ProjectTitleBarTest {
     entity.setId(entityId);
     entity.setName(testEntityName);
     when(mockBundle.getEntity()).thenReturn(entity);
-    verify(mockView).setFavoritesWidget(any(Widget.class));
+    verify(mockView).setFavoritesWidget(any());
     verify(mockFavoriteWidget).asWidget();
     when(mockAuthController.isLoggedIn()).thenReturn(true);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/downloadlist/PackageSizeSummaryTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/downloadlist/PackageSizeSummaryTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.DateTimeUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -25,7 +25,7 @@ import org.sagebionetworks.web.client.widget.DownloadSpeedTester;
 import org.sagebionetworks.web.client.widget.entity.file.downloadlist.PackageSizeSummary;
 import org.sagebionetworks.web.client.widget.entity.file.downloadlist.PackageSizeSummaryView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class PackageSizeSummaryTest {
 
   PackageSizeSummary widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/menu/v3/EntityActionMenuImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/menu/v3/EntityActionMenuImplTest.java
@@ -18,7 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.jsinterop.ReactMouseEvent;
 import org.sagebionetworks.web.client.jsinterop.entity.actionmenu.ActionConfiguration;
 import org.sagebionetworks.web.client.jsinterop.entity.actionmenu.EntityActionMenuDropdownMap;
@@ -29,7 +29,7 @@ import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenuImpl
 import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenuProps;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenuView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EntityActionMenuImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ButtonLinkWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ButtonLinkWidgetTest.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -29,7 +29,7 @@ import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ButtonLinkWidgetTest {
 
   ButtonLinkWidget widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/CancelControlWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/CancelControlWidgetTest.java
@@ -81,7 +81,7 @@ public class CancelControlWidgetTest {
     verify(mockView).setButtonText(DisplayConstants.BUTTON_CANCEL);
     verify(mockView).setButtonType(ButtonType.DANGER);
     verify(mockView).setPresenter(widget);
-    verify(mockView).addWidget(any(Widget.class));
+    verify(mockView).addWidget(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ChallengeParticipantsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ChallengeParticipantsWidgetTest.java
@@ -18,7 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
@@ -35,7 +35,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ChallengeParticipantsWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ChallengeTeamsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ChallengeTeamsWidgetTest.java
@@ -75,13 +75,7 @@ public class ChallengeTeamsWidgetTest {
     AsyncMockStubber
       .callSuccessWith(getTestChallengeTeamPagedResults())
       .when(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
   }
 
   public ChallengeTeamPagedResults getTestChallengeTeamPagedResults() {
@@ -119,13 +113,7 @@ public class ChallengeTeamsWidgetTest {
     verify(mockView).showLoading();
     verify(mockView).clearTeams();
     verify(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
     verify(mockView).hideLoading();
     verify(mockPaginationWidget)
       .configure(anyLong(), anyLong(), anyLong(), eq(widget));
@@ -139,8 +127,7 @@ public class ChallengeTeamsWidgetTest {
 
     // now edit test team
     widget.onEdit(TEST_TEAM_ID);
-    verify(mockEditRegisterTeamDialog)
-      .configure(eq(testChallengeTeam), any(Callback.class));
+    verify(mockEditRegisterTeamDialog).configure(eq(testChallengeTeam), any());
   }
 
   @Test
@@ -148,13 +135,7 @@ public class ChallengeTeamsWidgetTest {
     AsyncMockStubber
       .callSuccessWith(getEmptyTestChallengeTeamPagedResults())
       .when(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
     widget.configure(
       new WikiPageKey(entityId, ObjectType.ENTITY.toString(), null),
       descriptor,
@@ -166,13 +147,7 @@ public class ChallengeTeamsWidgetTest {
     verify(mockView).showLoading();
     verify(mockView).clearTeams();
     verify(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
     verify(mockView).hideLoading();
     verify(mockView).showNoTeams();
   }
@@ -182,13 +157,7 @@ public class ChallengeTeamsWidgetTest {
     AsyncMockStubber
       .callFailureWith(new Exception("unhandled"))
       .when(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
     widget.configure(
       new WikiPageKey(entityId, ObjectType.ENTITY.toString(), null),
       descriptor,
@@ -200,13 +169,7 @@ public class ChallengeTeamsWidgetTest {
     verify(mockView).showLoading();
     verify(mockView).clearTeams();
     verify(mockChallengeClient)
-      .getChallengeTeams(
-        anyString(),
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getChallengeTeams(any(), any(), any(), any(), any());
     verify(mockView).hideLoading();
     verify(mockView).showErrorMessage(anyString());
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/CytoscapeWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/CytoscapeWidgetTest.java
@@ -76,7 +76,7 @@ public class CytoscapeWidgetTest {
     RequestBuilderMockStubber
       .callOnResponseReceived(null, mockResponse)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
   }
 
   @Test
@@ -113,7 +113,7 @@ public class CytoscapeWidgetTest {
     widget.configure(wikiKey, descriptor, null, null);
 
     verify(mockRequestBuilder, times(2))
-      .configure(eq(RequestBuilder.GET), anyString());
+      .configure(eq(RequestBuilder.GET), any());
     verify(mockView)
       .configure(CYTOSCAPE_JS_JSON_TEST, CYTOSCAPE_JS_JSON_TEST, height);
     verify(mockView).setGraphVisible(true);
@@ -125,7 +125,7 @@ public class CytoscapeWidgetTest {
     RequestBuilderMockStubber
       .callOnError(null, e)
       .when(mockRequestBuilder)
-      .sendRequest(anyString(), any(RequestCallback.class));
+      .sendRequest(any(), any());
     Map<String, String> descriptor = new HashMap<String, String>();
     descriptor.put(WidgetConstants.SYNAPSE_ID_KEY, CYTOSCAPE_JS_ENTITY_ID);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/EntityListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/EntityListWidgetTest.java
@@ -97,7 +97,7 @@ public class EntityListWidgetTest {
     verify(mockEntityListRowBadge).setIsSelectable(false);
     verify(mockEntityListRowBadge)
       .setSelectionChangedCallback(any(Callback.class));
-    verify(mockView).addRow(any(Widget.class));
+    verify(mockView).addRow(any());
 
     assertEquals(mockEntityListRowBadge, widget.getRowWidgets().get(0));
   }
@@ -136,7 +136,7 @@ public class EntityListWidgetTest {
 
     reset(mockView);
     widget.addRecord(new EntityGroupRecord());
-    verify(mockView).addRow(any(Widget.class));
+    verify(mockView).addRow(any());
     verify(mockView).setTableVisible(true);
     verify(mockView).setEmptyUiVisible(false);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ImageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/ImageWidgetTest.java
@@ -134,7 +134,7 @@ public class ImageWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockFileEntity)
       .when(mockSynapseJavascriptClient)
-      .getEntityForVersion(anyString(), anyLong(), any(AsyncCallback.class));
+      .getEntityForVersion(any(), any(), any());
     String synId = "syn239";
     descriptor.put(IMAGE_WIDGET_SYNAPSE_ID_KEY, synId);
     String dataFileHandleId = "8765";
@@ -160,8 +160,8 @@ public class ImageWidgetTest {
       .configure(
         eq(PRESIGNED_URL),
         eq(FILE_NAME),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         eq(ALT_TEXT),
         eq(synId),
         eq(isLoggedIn)
@@ -201,8 +201,8 @@ public class ImageWidgetTest {
       .configure(
         eq(PRESIGNED_URL),
         eq(FILE_NAME),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         eq(ALT_TEXT),
         eq(synId),
         eq(isLoggedIn)
@@ -215,7 +215,7 @@ public class ImageWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseJavascriptClient)
-      .getEntityForVersion(anyString(), anyLong(), any(AsyncCallback.class));
+      .getEntityForVersion(any(), any(), any());
     String synId = "syn239";
     descriptor.put(IMAGE_WIDGET_SYNAPSE_ID_KEY, synId);
 
@@ -269,10 +269,10 @@ public class ImageWidgetTest {
       .configure(
         eq(PRESIGNED_URL),
         eq(FILE_NAME),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         eq(ALT_TEXT),
-        eq((String) null),
+        eq(null),
         eq(isLoggedIn)
       );
   }
@@ -283,11 +283,7 @@ public class ImageWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseJavascriptClient)
-      .getWikiAttachmentFileHandles(
-        any(WikiPageKey.class),
-        anyLong(),
-        any(AsyncCallback.class)
-      );
+      .getWikiAttachmentFileHandles(any(), any(), any());
 
     widget.configure(wikiKey, descriptor, null, null);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/PlotlyWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/PlotlyWidgetTest.java
@@ -452,11 +452,11 @@ public class PlotlyWidgetTest {
 
     verify(mockView)
       .showChart(
-        anyString(),
+        any(),
         eq(yAxisTitle),
         eq(xAxisTitle),
         plotlyTraceArrayCaptor.capture(),
-        anyString(),
+        any(),
         any(),
         any(),
         anyBoolean()

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/RegisterChallengeTeamWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/RegisterChallengeTeamWidgetTest.java
@@ -84,8 +84,7 @@ public class RegisterChallengeTeamWidgetTest {
     // add dialog to view
     verify(mockView).clearWidgets();
     // and configure dialog
-    verify(mockRegisterTeamDialog)
-      .configure(eq(CHALLENGE_ID), any(Callback.class));
+    verify(mockRegisterTeamDialog).configure(eq(CHALLENGE_ID), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SubmitToEvaluationWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SubmitToEvaluationWidgetTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.ObjectType;
@@ -47,7 +47,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SubmitToEvaluationWidgetTest {
 
   private static final String EVALUATION_2_SUBMISSION_RECEIPT_MESSAGE =
@@ -162,7 +162,7 @@ public class SubmitToEvaluationWidgetTest {
         anyInt(),
         any(AsyncCallback.class)
       );
-    verify(mockView).configure(anyString());
+    verify(mockView).configure(any());
   }
 
   @Test
@@ -197,7 +197,7 @@ public class SubmitToEvaluationWidgetTest {
     verify(mockChallengeClient)
       .getChallengeEvaluationIds(anyString(), any(AsyncCallback.class));
     verify(mockCallback, never()).invoke(anySet());
-    verify(mockView).showUnavailable(anyString());
+    verify(mockView).showUnavailable(any());
   }
 
   @Test
@@ -248,7 +248,7 @@ public class SubmitToEvaluationWidgetTest {
     verify(mockChallengeClient)
       .getProjectEvaluationIds(anyString(), any(AsyncCallback.class));
     verify(mockCallback, never()).invoke(anySet());
-    verify(mockView).showUnavailable(anyString());
+    verify(mockView).showUnavailable(any());
   }
 
   @Test
@@ -322,8 +322,7 @@ public class SubmitToEvaluationWidgetTest {
     when(mockAuthenticationController.isLoggedIn()).thenReturn(true);
     widget.submitToChallengeClicked();
     verify(mockView, times(0)).showAnonymousRegistrationMessage();
-    verify(mockEvaluationSubmitter)
-      .configure(any(Entity.class), anySet(), eq(null));
+    verify(mockEvaluationSubmitter).configure(any(), any(), eq(null));
   }
 
   @Test
@@ -345,7 +344,7 @@ public class SubmitToEvaluationWidgetTest {
     widget.submitToChallengeClicked();
 
     verify(mockEvaluationSubmitter)
-      .configure(any(Entity.class), anySet(), formParamsCaptor.capture());
+      .configure(any(), anySet(), formParamsCaptor.capture());
     FormParams formParams = formParamsCaptor.getValue();
     assertEquals(formContainerId, formParams.getContainerSynId());
     assertEquals(schemaId, formParams.getJsonSchemaSynId());

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SynapseTableFormWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/SynapseTableFormWidgetTest.java
@@ -116,9 +116,9 @@ public class SynapseTableFormWidgetTest {
   @Test
   public void testAsWidget() {
     // test construction
-    verify(mockView).setRowFormWidget(any(Widget.class));
-    verify(mockView).setSynAlertWidget(any(Widget.class));
-    verify(mockView).setUserBadge(any(Widget.class));
+    verify(mockView).setRowFormWidget(any());
+    verify(mockView).setSynAlertWidget(any());
+    verify(mockView).setUserBadge(any());
     verify(mockView).setPresenter(widget);
 
     // and asWidget

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/VideoWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/VideoWidgetTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundleRequest;
@@ -28,7 +28,7 @@ import org.sagebionetworks.web.client.widget.entity.renderer.VideoWidgetView;
 import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class VideoWidgetTest {
 
   VideoWidget widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiFilesPreviewWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiFilesPreviewWidgetTest.java
@@ -54,7 +54,7 @@ public class WikiFilesPreviewWidgetTest {
   public void testConfigure() {
     Map<String, String> descriptor = new HashMap<String, String>();
     widget.configure(wikiKey, descriptor, null, null);
-    verify(mockView).configure(any(WikiPageKey.class), any(List.class));
+    verify(mockView).configure(any(), any());
   }
 
   @Test
@@ -62,12 +62,9 @@ public class WikiFilesPreviewWidgetTest {
     AsyncMockStubber
       .callFailureWith(new Exception())
       .when(mockSynapseClient)
-      .getWikiAttachmentHandles(
-        any(WikiPageKey.class),
-        any(AsyncCallback.class)
-      );
+      .getWikiAttachmentHandles(any(), any());
     Map<String, String> descriptor = new HashMap<String, String>();
     widget.configure(wikiKey, descriptor, null, null);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesOrderEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesOrderEditorTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiHeader;
 import org.sagebionetworks.repo.model.v2.wiki.V2WikiOrderHint;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -25,7 +25,7 @@ import org.sagebionetworks.web.client.widget.entity.renderer.WikiSubpagesOrderEd
 import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class WikiSubpagesOrderEditorTest {
 
   WikiSubpagesOrderEditor editor;
@@ -65,11 +65,11 @@ public class WikiSubpagesOrderEditorTest {
     AsyncMockStubber
       .callSuccessWith(mockWikiHeaders)
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(mockHint)
       .when(mockJsClient)
-      .getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
+      .getV2WikiOrderHint(any(), any());
   }
 
   @Test
@@ -78,9 +78,8 @@ public class WikiSubpagesOrderEditorTest {
     verify(mockSynAlert).clear();
     verify(mockView).setLoadingVisible(true);
     verify(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
-    verify(mockJsClient)
-      .getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any(AsyncCallback.class));
+    verify(mockJsClient).getV2WikiOrderHint(any(), any());
     verify(mockEditorTree)
       .configure(
         eq((String) null),
@@ -99,10 +98,9 @@ public class WikiSubpagesOrderEditorTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any());
     editor.configure(mockPageKey, OWNER_OBJECT_NAME);
-    verify(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
+    verify(mockJsClient).getV2WikiHeaderTree(any(), any(), any());
     verify(mockSynAlert).handleException(ex);
     verify(mockJsClient, never())
       .getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
@@ -118,9 +116,8 @@ public class WikiSubpagesOrderEditorTest {
       .getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
     editor.configure(mockPageKey, OWNER_OBJECT_NAME);
     verify(mockJsClient)
-      .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
-    verify(mockJsClient)
-      .getV2WikiOrderHint(any(WikiPageKey.class), any(AsyncCallback.class));
+      .getV2WikiHeaderTree(any(), any(), any(AsyncCallback.class));
+    verify(mockJsClient).getV2WikiOrderHint(any(), any());
     verify(mockSynAlert).handleException(ex);
     verify(mockView).setLoadingVisible(false);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/renderer/WikiSubpagesWidgetTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
@@ -49,7 +49,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class WikiSubpagesWidgetTest {
 
   @Mock
@@ -157,7 +157,7 @@ public class WikiSubpagesWidgetTest {
         any(EntityBundleRequest.class),
         any(AsyncCallback.class)
       );
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class WikiSubpagesWidgetTest {
     );
     verify(mockSynapseJavascriptClient)
       .getV2WikiHeaderTree(anyString(), anyString(), any(AsyncCallback.class));
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test
@@ -368,7 +368,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
     // hidden initially in configure, and called again because only a single WikiPage is in the header
@@ -393,7 +393,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
   }
@@ -421,7 +421,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
 
@@ -449,7 +449,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
   }
@@ -478,7 +478,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
 
@@ -510,7 +510,7 @@ public class WikiSubpagesWidgetTest {
         any(Place.class),
         any(),
         anyBoolean(),
-        any(CallbackP.class),
+        any(),
         any(EntityActionMenu.class)
       );
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/restriction/v2/RestrictionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/restriction/v2/RestrictionWidgetTest.java
@@ -22,7 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.RestrictableObjectType;
 import org.sagebionetworks.repo.model.RestrictionInformationResponse;
@@ -47,7 +47,7 @@ import org.sagebionetworks.web.client.widget.entity.restriction.v2.RestrictionWi
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class RestrictionWidgetTest {
 
   RestrictionWidget widget;
@@ -157,7 +157,7 @@ public class RestrictionWidgetTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setSynAlert(any(IsWidget.class));
+    verify(mockView).setSynAlert(any());
     verify(mockView).setPresenter(widget);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/ChallengeTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/ChallengeTabTest.java
@@ -109,8 +109,8 @@ public class ChallengeTabTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setEvaluationList(any(Widget.class));
-    verify(mockView).setChallengeWidget(any(Widget.class));
+    verify(mockView).setEvaluationList(any());
+    verify(mockView).setChallengeWidget(any());
   }
 
   @Test
@@ -145,8 +145,8 @@ public class ChallengeTabTest {
     verify(mockEvaluationEditorReactComponentPage)
       .configure(
         eq(evaluationId),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         anyBoolean(),
         callbackCaptor.capture()
       );

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DatasetsTabTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.EntityType;
@@ -72,7 +72,7 @@ import org.sagebionetworks.web.client.widget.table.explore.TableEntityWidgetV2;
 import org.sagebionetworks.web.client.widget.table.v2.QueryTokenProvider;
 import org.sagebionetworks.web.shared.WidgetConstants;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DatasetsTabTest {
 
   @Mock
@@ -287,8 +287,7 @@ public class DatasetsTabTest {
   }
 
   private void verifyTableConfiguration(Long version) {
-    verify(mockBreadcrumb)
-      .configure(any(EntityPath.class), eq(EntityArea.DATASETS));
+    verify(mockBreadcrumb).configure(any(), eq(EntityArea.DATASETS));
     verify(mockTitleBar).configure(mockDatasetBundle, mockActionMenuWidget);
     verify(mockEntityMetadata)
       .configure(mockDatasetBundle, version, mockActionMenuWidget);
@@ -301,7 +300,7 @@ public class DatasetsTabTest {
         tab,
         mockActionMenuWidget
       );
-    verify(mockView).setTableEntityWidget(any(Widget.class));
+    verify(mockView).setTableEntityWidget(any());
     verify(mockModifiedCreatedBy).configure(datasetId, version);
     verify(mockProvenanceWidget).configure(mapCaptor.capture());
     // verify configuration
@@ -321,7 +320,7 @@ public class DatasetsTabTest {
     verify(mockView).setTitlebarVisible(true);
     verify(mockView).clearTableEntityWidget();
     verify(mockModifiedCreatedBy).setVisible(false);
-    verify(mockView).setWikiPage(any(Widget.class));
+    verify(mockView).setWikiPage(any());
     verify(mockView).setWikiPageVisible(true);
 
     ArgumentCaptor<Synapse> captor = ArgumentCaptor.forClass(Synapse.class);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DiscussionTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DiscussionTabTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
@@ -37,7 +37,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.DiscussionTabView;
 import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
 import org.sagebionetworks.web.shared.WebConstants;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DiscussionTabTest {
 
   @Mock
@@ -97,7 +97,7 @@ public class DiscussionTabTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(tab);
-    verify(mockView).setForum(any(Widget.class));
+    verify(mockView).setForum(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DockerTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/DockerTabTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.Project;
@@ -42,7 +42,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.DockerTab;
 import org.sagebionetworks.web.client.widget.entity.tabs.DockerTabView;
 import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DockerTabTest {
 
   @Mock
@@ -159,10 +159,10 @@ public class DockerTabTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(tab);
-    verify(mockView).setBreadcrumb(any(Widget.class));
-    verify(mockView).setDockerRepoList(any(Widget.class));
-    verify(mockView).setSynapseAlert(any(Widget.class));
-    verify(mockView).setActionMenu(any(Widget.class));
+    verify(mockView).setBreadcrumb(any());
+    verify(mockView).setDockerRepoList(any());
+    verify(mockView).setSynapseAlert(any());
+    verify(mockView).setActionMenu(any());
     verify(mockTab)
       .configure(
         anyString(),
@@ -172,7 +172,7 @@ public class DockerTabTest {
         any(EntityArea.class)
       );
     verify(mockBreadcrumb).setLinkClickedHandler(callbackPCaptor.capture());
-    verify(mockTab).setContent(any(Widget.class));
+    verify(mockTab).setContent(any());
 
     // test click on breadcrumb
     String newEntityId = "syn9898989822";
@@ -260,7 +260,7 @@ public class DockerTabTest {
       )
     );
     verify(mockGinInjector).createNewDockerRepoWidget();
-    verify(mockView).setDockerRepoWidget(any(Widget.class));
+    verify(mockView).setDockerRepoWidget(any());
     verify(mockDockerRepoListWidget, never()).configure(projectEntityId);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/FilesTabTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.Folder;
@@ -60,7 +60,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
 import org.sagebionetworks.web.client.widget.provenance.v2.ProvenanceWidget;
 import org.sagebionetworks.web.client.widget.refresh.EntityRefreshAlert;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FilesTabTest {
 
   @Mock
@@ -250,15 +250,15 @@ public class FilesTabTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setTitlebar(any(Widget.class));
-    verify(mockView).setFolderTitlebar(any(Widget.class));
-    verify(mockView).setBreadcrumb(any(Widget.class));
-    verify(mockView).setPreview(any(Widget.class));
-    verify(mockView).setMetadata(any(Widget.class));
-    verify(mockView).setWikiPage(any(Widget.class));
-    verify(mockView).setSynapseAlert(any(Widget.class));
+    verify(mockView).setTitlebar(any());
+    verify(mockView).setFolderTitlebar(any());
+    verify(mockView).setBreadcrumb(any());
+    verify(mockView).setPreview(any());
+    verify(mockView).setMetadata(any());
+    verify(mockView).setWikiPage(any());
+    verify(mockView).setSynapseAlert(any());
     verify(mockBreadcrumb).setLinkClickedHandler(any(CallbackP.class));
-    verify(mockView).setDiscussionThreadListWidget(any(Widget.class));
+    verify(mockView).setDiscussionThreadListWidget(any());
     ArgumentCaptor<CallbackP> captor = ArgumentCaptor.forClass(CallbackP.class);
     verify(mockDiscussionThreadListWidget)
       .setThreadIdClickedCallback(captor.capture());
@@ -364,8 +364,7 @@ public class FilesTabTest {
     verify(mockEntityMetadata)
       .configure(mockEntityBundle, version, mockActionMenuWidget);
 
-    verify(mockBreadcrumb)
-      .configure(any(EntityPath.class), eq(EntityArea.FILES));
+    verify(mockBreadcrumb).configure(any(), eq(EntityArea.FILES));
 
     verify(mockView).setProvenanceVisible(true);
     verify(mockModifiedCreatedBy).configure(fileEntityId, version);
@@ -374,7 +373,7 @@ public class FilesTabTest {
     verify(mockView, times(2)).setFileBrowserVisible(false);
     verify(mockPortalGinInjector).getProvenanceRenderer();
 
-    verify(mockView).setRefreshAlert(any(Widget.class));
+    verify(mockView).setRefreshAlert(any());
     verify(mockView).setDiscussionText(fileName);
     verify(mockEntityRefreshAlert).configure(fileEntityId);
 
@@ -413,7 +412,7 @@ public class FilesTabTest {
     verify(mockView).setWikiPageWidgetVisible(false);
     verify(mockView).setWikiPageWidgetVisible(true);
 
-    verify(mockView).setRefreshAlert(any(Widget.class));
+    verify(mockView).setRefreshAlert(any());
     verify(mockEntityRefreshAlert).configure(folderEntityId);
 
     verify(mockProjectTitleBar, never()).configure(mockEntityBundle);
@@ -421,8 +420,7 @@ public class FilesTabTest {
     verify(mockEntityMetadata)
       .configure(mockEntityBundle, version, mockActionMenuWidget);
 
-    verify(mockBreadcrumb)
-      .configure(any(EntityPath.class), eq(EntityArea.FILES));
+    verify(mockBreadcrumb).configure(any(), eq(EntityArea.FILES));
 
     verify(mockView, times(2)).setProvenanceVisible(false);
     verify(mockModifiedCreatedBy).configure(folderEntityId, null);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -31,7 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.EntityType;
@@ -74,7 +74,7 @@ import org.sagebionetworks.web.client.widget.table.explore.TableEntityWidgetV2;
 import org.sagebionetworks.web.client.widget.table.v2.QueryTokenProvider;
 import org.sagebionetworks.web.shared.WidgetConstants;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TablesTabTest {
 
   @Mock
@@ -308,8 +308,7 @@ public class TablesTabTest {
   }
 
   private void verifyTableConfiguration(Long version) {
-    verify(mockBreadcrumb)
-      .configure(any(EntityPath.class), eq(EntityArea.TABLES));
+    verify(mockBreadcrumb).configure(any(), eq(EntityArea.TABLES));
     verify(mockTitleBar).configure(mockTableEntityBundle, mockActionMenuWidget);
     verify(mockEntityMetadata)
       .configure(mockTableEntityBundle, version, mockActionMenuWidget);
@@ -322,7 +321,7 @@ public class TablesTabTest {
         tab,
         mockActionMenuWidget
       );
-    verify(mockView).setTableEntityWidget(any(Widget.class));
+    verify(mockView).setTableEntityWidget(any());
     verify(mockModifiedCreatedBy).configure(tableEntityId, version);
     verify(mockProvenanceWidget).configure(mapCaptor.capture());
     // verify configuration
@@ -342,7 +341,7 @@ public class TablesTabTest {
     verify(mockView).setTitlebarVisible(true);
     verify(mockView).clearTableEntityWidget();
     verify(mockModifiedCreatedBy).setVisible(false);
-    verify(mockView).setWikiPage(any(Widget.class));
+    verify(mockView).setWikiPage(any());
     verify(mockView).setWikiPageVisible(true);
     verify(mockView).setVersionAlertVisible(false);
     verify(mockView, never()).setVersionAlertVisible(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/WikiTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/WikiTabTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
@@ -29,7 +29,7 @@ import org.sagebionetworks.web.client.widget.entity.tabs.Tab;
 import org.sagebionetworks.web.client.widget.entity.tabs.WikiTab;
 import org.sagebionetworks.web.shared.WikiPageKey;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class WikiTabTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/BigTeamBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/BigTeamBadgeTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Team;
 import org.sagebionetworks.repo.model.TeamMembershipStatus;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
@@ -21,7 +21,7 @@ import org.sagebionetworks.web.client.widget.team.BigTeamBadge;
 import org.sagebionetworks.web.client.widget.team.BigTeamBadgeView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class BigTeamBadgeTest {
 
   @Mock
@@ -66,11 +66,11 @@ public class BigTeamBadgeTest {
     AsyncMockStubber
       .callSuccessWith(TEAM_ICON_URL)
       .when(mockJsClient)
-      .getTeamPicturePreviewURL(anyString(), any(AsyncCallback.class));
+      .getTeamPicturePreviewURL(any(), any());
     AsyncMockStubber
       .callSuccessWith(mockTeam)
       .when(mockJsClient)
-      .getTeam(anyString(), any(AsyncCallback.class));
+      .getTeam(any(), any());
   }
 
   @Test
@@ -85,7 +85,7 @@ public class BigTeamBadgeTest {
     AsyncMockStubber
       .callFailureWith(new Exception("failed"))
       .when(mockJsClient)
-      .getTeamPicturePreviewURL(anyString(), any(AsyncCallback.class));
+      .getTeamPicturePreviewURL(any(), any());
 
     presenter.configure("123");
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/InviteWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/InviteWidgetTest.java
@@ -21,7 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.Team;
@@ -47,7 +47,7 @@ import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 import org.sagebionetworks.web.unitclient.widget.entity.EvaluationSubmitterTest;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class InviteWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/JoinTeamWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/JoinTeamWidgetTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -101,20 +102,15 @@ public class JoinTeamWidgetTest {
     AsyncMockStubber
       .callSuccessWith(new HashMap())
       .when(mockSynapseClient)
-      .getPageNameToWikiKeyMap(any(AsyncCallback.class));
+      .getPageNameToWikiKeyMap(any());
     AsyncMockStubber
       .callSuccessWith(true)
       .when(mockSynapseClient)
-      .hasAccess(
-        anyString(),
-        anyString(),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .hasAccess(any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(ars)
       .when(mockSynapseClient)
-      .getTeamAccessRequirements(anyString(), any(AsyncCallback.class));
+      .getTeamAccessRequirements(any(), any());
 
     joinWidget =
       new JoinTeamWidget(
@@ -150,22 +146,12 @@ public class JoinTeamWidgetTest {
     AsyncMockStubber
       .callSuccessWith(status)
       .when(mockSynapseClient)
-      .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        any(Date.class),
-        any(AsyncCallback.class)
-      );
+      .requestMembership(any(), any(), any(), any(), any(), any());
 
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .createAccessApproval(
-        any(AccessApproval.class),
-        any(AsyncCallback.class)
-      );
+      .createAccessApproval(any(), any());
     when(mockGwt.getHostPageBaseURL())
       .thenReturn(EvaluationSubmitterTest.HOST_PAGE_URL);
   }
@@ -371,12 +357,12 @@ public class JoinTeamWidgetTest {
       .configure(Mockito.anyInt(), Mockito.anyInt());
     verify(mockSynapseClient)
       .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
         eq(EvaluationSubmitterTest.HOST_PAGE_URL),
-        eq((Date) null),
-        any(AsyncCallback.class)
+        eq(null),
+        any()
       );
   }
 
@@ -475,12 +461,12 @@ public class JoinTeamWidgetTest {
     joinWidget.sendJoinRequestStep3();
     verify(mockSynapseClient)
       .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
         eq(EvaluationSubmitterTest.HOST_PAGE_URL),
-        eq((Date) null),
-        any(AsyncCallback.class)
+        eq(null),
+        any()
       );
     verify(mockView).showInfo(anyString());
     // verify that team updated callback is invoked
@@ -494,24 +480,17 @@ public class JoinTeamWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyString(),
-        any(Date.class),
-        any(AsyncCallback.class)
-      );
+      .requestMembership(any(), any(), any(), any(), any(), any());
     joinWidget.sendJoinRequest("");
     verify(mockSynAlert).handleException(ex);
     verify(mockSynapseClient)
       .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
         eq(EvaluationSubmitterTest.HOST_PAGE_URL),
-        eq((Date) null),
-        any(AsyncCallback.class)
+        eq(null),
+        any()
       );
   }
 
@@ -537,12 +516,12 @@ public class JoinTeamWidgetTest {
     ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
     verify(mockSynapseClient)
       .requestMembership(
-        anyString(),
-        anyString(),
-        anyString(),
+        any(),
+        any(),
+        any(),
         eq(EvaluationSubmitterTest.HOST_PAGE_URL),
         dateCaptor.capture(),
-        any(AsyncCallback.class)
+        any()
       );
     verify(mockView).showInfo(anyString());
     // verify that wiki page refresh is invoked

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/MemberListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/MemberListWidgetTest.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.TeamMemberTypeFilterOptions;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
@@ -33,7 +33,7 @@ import org.sagebionetworks.web.shared.TeamMemberPagedResults;
 import org.sagebionetworks.web.shared.exceptions.BadRequestException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class MemberListWidgetTest {
 
   @Mock
@@ -78,28 +78,15 @@ public class MemberListWidgetTest {
     AsyncMockStubber
       .callSuccessWith(getTestTeamMembers())
       .when(mockJsClient)
-      .getTeamMembers(
-        anyString(),
-        anyString(),
-        any(TeamMemberTypeFilterOptions.class),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getTeamMembers(any(), any(), any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockJsClient)
-      .deleteTeamMember(anyString(), anyString(), any(AsyncCallback.class));
+      .deleteTeamMember(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .setIsTeamAdmin(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .setIsTeamAdmin(any(), any(), any(), anyBoolean(), any());
   }
 
   private TeamMemberPagedResults getTestTeamMembers() {
@@ -129,14 +116,7 @@ public class MemberListWidgetTest {
     TeamMemberTypeFilterOptions memberType = TeamMemberTypeFilterOptions.ALL;
     widget.configure(teamId, isAdmin, memberType, mockTeamUpdatedCallback);
     verify(mockJsClient)
-      .getTeamMembers(
-        anyString(),
-        anyString(),
-        eq(memberType),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getTeamMembers(any(), any(), eq(memberType), any(), any(), any());
     verify(mockView).addMembers(anyList(), anyBoolean());
     verify(mockMembersContainer).configure(any(Callback.class));
   }
@@ -149,24 +129,10 @@ public class MemberListWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockJsClient)
-      .getTeamMembers(
-        anyString(),
-        anyString(),
-        any(TeamMemberTypeFilterOptions.class),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getTeamMembers(any(), any(), any(), any(), any(), any());
     widget.configure(teamId, isAdmin, memberType, mockTeamUpdatedCallback);
     verify(mockJsClient)
-      .getTeamMembers(
-        anyString(),
-        anyString(),
-        eq(memberType),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getTeamMembers(any(), any(), eq(memberType), any(), any(), any());
     verify(mockView).showErrorMessage(error);
   }
 
@@ -236,13 +202,7 @@ public class MemberListWidgetTest {
     );
     widget.setIsAdmin("a user id", true);
     verify(mockSynapseClient)
-      .setIsTeamAdmin(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .setIsTeamAdmin(any(), any(), any(), anyBoolean(), any());
     verify(mockView).showInfo(anyString());
     verify(mockTeamUpdatedCallback).invoke();
   }
@@ -260,33 +220,14 @@ public class MemberListWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .setIsTeamAdmin(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .setIsTeamAdmin(any(), any(), any(), anyBoolean(), any());
     widget.setIsAdmin("a user id", true);
     verify(mockSynapseClient)
-      .setIsTeamAdmin(
-        anyString(),
-        anyString(),
-        anyString(),
-        anyBoolean(),
-        any(AsyncCallback.class)
-      );
+      .setIsTeamAdmin(any(), any(), any(), anyBoolean(), any());
     verify(mockView).showErrorMessage(message);
     // called twice. once during configuration, and once to refresh members to get correct admin state
     verify(mockJsClient, times(2))
-      .getTeamMembers(
-        anyString(),
-        anyString(),
-        any(TeamMemberTypeFilterOptions.class),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getTeamMembers(any(), any(), any(), any(), any(), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/OpenTeamInvitationsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/OpenTeamInvitationsWidgetTest.java
@@ -107,8 +107,7 @@ public class OpenTeamInvitationsWidgetTest {
     testInvite.setMessage("This is a test invite");
     testInvite.setCreatedOn(new Date());
 
-    when(mockDateTimeUtils.getRelativeTime(any(Date.class)))
-      .thenReturn(FORMATTED_DATE);
+    when(mockDateTimeUtils.getRelativeTime(any())).thenReturn(FORMATTED_DATE);
     testReturn = new ArrayList<OpenUserInvitationBundle>();
     OpenUserInvitationBundle mib = new OpenUserInvitationBundle();
     mib.setTeam(testTeam);
@@ -118,7 +117,7 @@ public class OpenTeamInvitationsWidgetTest {
     AsyncMockStubber
       .callSuccessWith(testReturn)
       .when(mockSynapseClient)
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+      .getOpenInvitations(any(), any());
 
     mockOpenTeamInvitationsCallback = mock(CallbackP.class);
     mockTeamUpdatedCallback = mock(Callback.class);
@@ -127,23 +126,16 @@ public class OpenTeamInvitationsWidgetTest {
     when(mockPortalGinInjector.getJoinTeamWidget())
       .thenReturn(mockJoinTeamWidget);
 
-    when(mockJsClient.deleteMembershipInvitation(anyString()))
+    when(mockJsClient.deleteMembershipInvitation(any()))
       .thenReturn(getDoneFuture(null));
   }
 
   @Test
   public void testConfigure() throws Exception {
     widget.configure(mockTeamUpdatedCallback, mockOpenTeamInvitationsCallback);
-    verify(mockSynapseClient)
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+    verify(mockSynapseClient).getOpenInvitations(any(), any());
     verify(mockView)
-      .addTeamInvite(
-        any(Team.class),
-        any(String.class),
-        eq(RECEIVED + FORMATTED_DATE),
-        anyString(),
-        any(Widget.class)
-      );
+      .addTeamInvite(any(), any(), eq(RECEIVED + FORMATTED_DATE), any(), any());
     verify(mockPortalGinInjector).getJoinTeamWidget();
     ArgumentCaptor<Callback> refreshCallbackCaptor = ArgumentCaptor.forClass(
       Callback.class
@@ -159,16 +151,9 @@ public class OpenTeamInvitationsWidgetTest {
     Callback refreshCallback = refreshCallbackCaptor.getValue();
     refreshCallback.invoke();
     verify(mockTeamUpdatedCallback).invoke();
-    verify(mockSynapseClient, times(2))
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+    verify(mockSynapseClient, times(2)).getOpenInvitations(any(), any());
     verify(mockView, times(2))
-      .addTeamInvite(
-        any(Team.class),
-        anyString(),
-        eq(RECEIVED + FORMATTED_DATE),
-        anyString(),
-        any(Widget.class)
-      );
+      .addTeamInvite(any(), any(), eq(RECEIVED + FORMATTED_DATE), any(), any());
     verify(mockPortalGinInjector, times(2)).getJoinTeamWidget();
     verify(mockJoinTeamWidget, times(2))
       .configure(eq(teamId), any(Callback.class));
@@ -180,10 +165,9 @@ public class OpenTeamInvitationsWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+      .getOpenInvitations(any(), any());
     widget.configure(mockTeamUpdatedCallback, mockOpenTeamInvitationsCallback);
-    verify(mockSynapseClient)
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+    verify(mockSynapseClient).getOpenInvitations(any(), any());
     verify(mockSynapseAlert).handleException(ex);
   }
 
@@ -198,8 +182,7 @@ public class OpenTeamInvitationsWidgetTest {
     verify(mockPopupUtils)
       .showInfo(OpenTeamInvitationsWidget.DELETED_INVITATION_MESSAGE);
     verify(mockTeamUpdatedCallback).invoke();
-    verify(mockSynapseClient, times(2))
-      .getOpenInvitations(anyString(), any(AsyncCallback.class));
+    verify(mockSynapseClient, times(2)).getOpenInvitations(any(), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/OpenUserInvitationsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/OpenUserInvitationsWidgetTest.java
@@ -119,20 +119,15 @@ public class OpenUserInvitationsWidgetTest {
     AsyncMockStubber
       .callSuccessWith(testReturn)
       .when(mockSynapseClient)
-      .getOpenTeamInvitations(
-        anyString(),
-        anyInt(),
-        anyInt(),
-        any(AsyncCallback.class)
-      );
+      .getOpenTeamInvitations(any(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockJsClient)
-      .deleteMembershipInvitation(anyString(), any(AsyncCallback.class));
+      .deleteMembershipInvitation(any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockSynapseClient)
-      .resendTeamInvitation(anyString(), anyString(), any(AsyncCallback.class));
+      .resendTeamInvitation(any(), any(), any());
 
     when(mockGinInjector.getUserBadgeWidget()).thenReturn(mockUserBadge);
     when(mockGinInjector.getEmailInvitationBadgeWidget())
@@ -187,7 +182,7 @@ public class OpenUserInvitationsWidgetTest {
         eq(null),
         eq(testInvite.getId()),
         eq(testInvite.getMessage()),
-        anyString()
+        any()
       );
     verify(mockGWT).restoreWindowPosition();
     verify(mockView).setVisible(true);
@@ -226,7 +221,7 @@ public class OpenUserInvitationsWidgetTest {
         eq(null),
         eq(testInvite.getId()),
         eq(testInvite.getMessage()),
-        anyString()
+        any()
       );
     verify(mockGWT).restoreWindowPosition();
   }
@@ -249,7 +244,7 @@ public class OpenUserInvitationsWidgetTest {
         eq(null),
         eq(testEmailInvite.getId()),
         eq(testEmailInvite.getMessage()),
-        anyString()
+        any()
       );
     verify(mockGWT).restoreWindowPosition();
   }
@@ -273,7 +268,7 @@ public class OpenUserInvitationsWidgetTest {
         eq(testInvite.getInviteeEmail()),
         eq(testInvite.getId()),
         eq(testInvite.getMessage()),
-        anyString()
+        any()
       );
     verify(mockView, times(emailInvitationCount))
       .addInvitation(
@@ -281,7 +276,7 @@ public class OpenUserInvitationsWidgetTest {
         eq(null),
         eq(testEmailInvite.getId()),
         eq(testEmailInvite.getMessage()),
-        anyString()
+        any()
       );
     verify(mockGWT).restoreWindowPosition();
   }
@@ -459,11 +454,7 @@ public class OpenUserInvitationsWidgetTest {
 
     verify(mockGWT).saveWindowPosition();
     verify(mockSynapseClient)
-      .resendTeamInvitation(
-        eq(invitationId),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .resendTeamInvitation(eq(invitationId), any(), any(AsyncCallback.class));
     verify(mockPopupUtils)
       .showInfo(OpenUserInvitationsWidget.RESENT_INVITATION);
     verify(mockView, times(2)).clear();
@@ -483,17 +474,13 @@ public class OpenUserInvitationsWidgetTest {
     AsyncMockStubber
       .callFailureWith(ex)
       .when(mockSynapseClient)
-      .resendTeamInvitation(anyString(), anyString(), any(AsyncCallback.class));
+      .resendTeamInvitation(any(), any(), any());
     widget.configure(teamId, mockTeamUpdatedCallback);
 
     widget.resendInvitation(invitationId);
 
     verify(mockSynapseClient)
-      .resendTeamInvitation(
-        eq(invitationId),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .resendTeamInvitation(eq(invitationId), any(), any(AsyncCallback.class));
     verify(mockSynapseAlert).handleException(ex);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/SelectTeamModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/SelectTeamModalTest.java
@@ -54,7 +54,7 @@ public class SelectTeamModalTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSuggestWidget(any(Widget.class));
+    verify(mockView).setSuggestWidget(any());
     verify(mockTeamSuggestBox).setSuggestionProvider(mockProvider);
     verify(mockTeamSuggestBox).setTypeFilter(TypeFilter.TEAMS_ONLY);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamEditModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamEditModalWidgetTest.java
@@ -270,7 +270,7 @@ public class TeamEditModalWidgetTest {
     when(mockFileUpload.getFileHandleId()).thenReturn(null);
     finishedUploadingCallback.invoke(mockFileUpload);
     verify(mockView, times(2)).hideLoading();
-    verify(mockView, times(2)).setImageURL(anyString());
+    verify(mockView, times(2)).setImageURL(any());
     verify(mockFileUpload).getFileHandleId();
 
     presenter.onConfirm();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamLeaveModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamLeaveModalWidgetTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Team;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.security.AuthenticationController;
@@ -20,7 +20,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.team.controller.TeamLeaveModalWidget;
 import org.sagebionetworks.web.client.widget.team.controller.TeamLeaveModalWidgetView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TeamLeaveModalWidgetTest {
 
   TeamLeaveModalWidget presenter;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamProjectsModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/team/controller/TeamProjectsModalWidgetTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ProjectHeader;
 import org.sagebionetworks.repo.model.ProjectHeaderList;
 import org.sagebionetworks.repo.model.ProjectListSortColumn;
@@ -31,7 +31,7 @@ import org.sagebionetworks.web.client.widget.team.controller.TeamProjectsModalWi
 import org.sagebionetworks.web.client.widget.team.controller.TeamProjectsModalWidgetView;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TeamProjectsModalWidgetTest {
 
   TeamProjectsModalWidget presenter;
@@ -93,14 +93,7 @@ public class TeamProjectsModalWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockProjectHeaderList)
       .when(mockJsClient)
-      .getProjectsForTeam(
-        anyString(),
-        anyInt(),
-        anyString(),
-        any(ProjectListSortColumn.class),
-        any(SortDirection.class),
-        any(AsyncCallback.class)
-      );
+      .getProjectsForTeam(any(), anyInt(), any(), any(), any(), any());
   }
 
   @Test
@@ -128,7 +121,7 @@ public class TeamProjectsModalWidgetTest {
       );
     // added the 2 project badges
     verify(mockGinInjector, times(2)).getProjectBadgeWidget();
-    verify(mockLoadMoreWidgetContainer, times(2)).add(any(Widget.class));
+    verify(mockLoadMoreWidgetContainer, times(2)).add(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/AdministerEvaluationsListTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/AdministerEvaluationsListTest.java
@@ -157,13 +157,13 @@ public class AdministerEvaluationsListTest {
     verify(mockEvalEditor).show();
     callbackCaptor.getValue().invoke();
     verify(mockChallengeClient)
-      .getSharableEvaluations(anyString(), any(AsyncCallback.class));
+      .getSharableEvaluations(any(), any(AsyncCallback.class));
   }
 
   @Test
   public void testOnShareClicked() {
     evalList.onShareClicked(e1);
-    verify(mockAclEditor).configure(eq(e1), any(Callback.class));
+    verify(mockAclEditor).configure(eq(e1), any());
     verify(mockAclEditor).show();
   }
 
@@ -178,7 +178,7 @@ public class AdministerEvaluationsListTest {
       .deleteEvaluation(eq(e1.getId()), any(AsyncCallback.class));
     // refresh
     verify(mockChallengeClient)
-      .getSharableEvaluations(anyString(), any(AsyncCallback.class));
+      .getSharableEvaluations(any(), any(AsyncCallback.class));
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/ChallengeWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/ChallengeWidgetTest.java
@@ -19,7 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Challenge;
 import org.sagebionetworks.web.client.ChallengeClientAsync;
 import org.sagebionetworks.web.client.utils.CallbackP;
@@ -33,7 +33,7 @@ import org.sagebionetworks.web.shared.WidgetConstants;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ChallengeWidgetTest {
 
   ChallengeWidget widget;
@@ -88,9 +88,9 @@ public class ChallengeWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).add(any(Widget.class));
-    verify(mockView).setChallengeTeamWidget(any(Widget.class));
-    verify(mockView).setSelectTeamModal(any(Widget.class));
+    verify(mockView).add(any());
+    verify(mockView).setChallengeTeamWidget(any());
+    verify(mockView).setSelectTeamModal(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/DurationHelperTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/DurationHelperTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.widget.evaluation.DurationHelper;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class DurationHelperTest {
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/EvaluationEditorModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/EvaluationEditorModalTest.java
@@ -94,11 +94,11 @@ public class EvaluationEditorModalTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockChallengeClient)
-      .updateEvaluation(any(Evaluation.class), any(AsyncCallback.class));
+      .updateEvaluation(any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockChallengeClient)
-      .createEvaluation(any(Evaluation.class), any(AsyncCallback.class));
+      .createEvaluation(any(), any());
 
     when(mockView.getSubmissionLimit()).thenReturn(null);
     when(mockView.getNumberOfRounds()).thenReturn(null);
@@ -114,7 +114,7 @@ public class EvaluationEditorModalTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setSynAlert(any(IsWidget.class));
+    verify(mockView).setSynAlert(any());
     verify(mockView).setPresenter(modal);
   }
 
@@ -143,7 +143,7 @@ public class EvaluationEditorModalTest {
     verify(mockView).setSubmissionInstructionsMessage(submissionInstruction);
     verify(mockView).setSubmissionReceiptMessage(submissionReceiptMessage);
     verify(mockView).setDescription(description);
-    verify(mockView).setCreatedOn(anyString());
+    verify(mockView).setCreatedOn(any());
     // verify no quota
     verify(mockView, never()).setRoundStart(any(Date.class));
     verify(mockView, never()).setNumberOfRounds(anyLong());
@@ -169,7 +169,7 @@ public class EvaluationEditorModalTest {
     verify(mockView).setSubmissionInstructionsMessage(submissionInstruction);
     verify(mockView).setSubmissionReceiptMessage(submissionReceiptMessage);
     verify(mockView).setDescription(description);
-    verify(mockView).setCreatedOn(anyString());
+    verify(mockView).setCreatedOn(any());
     // verify quota
     verify(mockView).setRoundStart(quotaRoundStart);
     verify(mockView).setNumberOfRounds(numberOfRounds);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/SubmissionViewScopeEditorModalWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/evaluation/SubmissionViewScopeEditorModalWidgetTest.java
@@ -10,14 +10,14 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.jsinterop.SubmissionViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.widget.evaluation.SubmissionViewScopeEditorModalWidget;
 import org.sagebionetworks.web.client.widget.evaluation.SubmissionViewScopeEditorModalWidgetView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SubmissionViewScopeEditorModalWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/footer/FooterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/footer/FooterTest.java
@@ -12,7 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.widget.footer.FooterView;
 import org.sagebionetworks.web.client.widget.footer.VersionState;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class FooterTest {
 
   Footer footer;
@@ -68,7 +68,7 @@ public class FooterTest {
     AsyncMockStubber
       .callSuccessWith(versionState)
       .when(mockGlobalAppState)
-      .checkVersionCompatibility(any(AsyncCallback.class));
+      .checkVersionCompatibility(any());
     verify(mockView).setPresenter(footer);
     when(mockUserProfile.getEmails())
       .thenReturn(Collections.singletonList(EMAIL));
@@ -92,7 +92,7 @@ public class FooterTest {
     AsyncMockStubber
       .callSuccessWith(versionState)
       .when(mockGlobalAppState)
-      .checkVersionCompatibility(any(AsyncCallback.class));
+      .checkVersionCompatibility(any());
     footer =
       new Footer(
         mockView,
@@ -101,8 +101,7 @@ public class FooterTest {
         mockGwt,
         mockJsniUtils
       );
-    verify(mockView)
-      .setVersion(eq(Footer.UNKNOWN), eq(Footer.UNKNOWN), anyString());
+    verify(mockView).setVersion(eq(Footer.UNKNOWN), eq(Footer.UNKNOWN), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/googlemap/GoogleMapTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/googlemap/GoogleMapTest.java
@@ -63,7 +63,7 @@ public class GoogleMapTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setSynAlert(any());
     verify(mockView).setPresenter(map);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/lazyload/LazyLoadWikiWidgetWrapperTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/lazyload/LazyLoadWikiWidgetWrapperTest.java
@@ -103,6 +103,6 @@ public class LazyLoadWikiWidgetWrapperTest {
         wikiVersionInView
       );
     String className = mockWikiWidget.getClass().getSimpleName();
-    verify(mockView).showWidget(any(Widget.class), eq(className));
+    verify(mockView).showWidget(any(), eq(className));
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/profile/ProfileCertifiedValidatedWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/profile/ProfileCertifiedValidatedWidgetTest.java
@@ -67,7 +67,7 @@ public class ProfileCertifiedValidatedWidgetTest {
     AsyncMockStubber
       .callFailureWith(new Exception(errorMessage))
       .when(mockSynapseJavascriptClient)
-      .getUserBundle(anyLong(), anyInt(), any(AsyncCallback.class));
+      .getUserBundle(any(), anyInt(), any());
     widget.loadData();
     verify(mockView).setError(errorMessage);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/search/SearchUtilTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/search/SearchUtilTest.java
@@ -8,14 +8,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.place.Search;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.presenter.SearchUtil;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SearchUtilTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/AccessControlListEditorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/AccessControlListEditorTest.java
@@ -27,7 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ErrorResponseCode;
 import org.sagebionetworks.repo.model.Project;
@@ -56,7 +56,7 @@ import org.sagebionetworks.web.shared.users.AclUtils;
 import org.sagebionetworks.web.shared.users.PermissionLevel;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class AccessControlListEditorTest {
 
   private static final String HOST_PAGE_BASE_URL = "http://www.wwu.edu/";
@@ -675,19 +675,15 @@ public class AccessControlListEditorTest {
     AsyncMockStubber
       .callSuccessWith(entityBundleTransport_localACL)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundle(
-        anyString(),
-        any(EntityBundleRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getEntityBundle(any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(inheritedACL)
       .when(mockSynapseClient)
-      .deleteAcl(eq(ENTITY_ID), any(AsyncCallback.class));
+      .deleteAcl(eq(ENTITY_ID), any());
     AsyncMockStubber
       .callSuccessWith(inheritedACL)
       .when(mockSynapseClient)
-      .getEntityBenefactorAcl(anyString(), any(AsyncCallback.class));
+      .getEntityBenefactorAcl(any(), any());
 
     // update
     acle.refresh();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/OpenDataTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/OpenDataTest.java
@@ -7,11 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.widget.sharing.OpenData;
 import org.sagebionetworks.web.client.widget.sharing.OpenDataView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OpenDataTest {
 
   OpenData openData;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/PublicPrivateBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/sharing/PublicPrivateBadgeTest.java
@@ -100,13 +100,9 @@ public class PublicPrivateBadgeTest {
     AsyncMockStubber
       .callFailureWith(new IllegalArgumentException())
       .when(mockSynapseJavascriptClient)
-      .getEntityBundle(
-        anyString(),
-        any(EntityBundleRequest.class),
-        any(AsyncCallback.class)
-      );
+      .getEntityBundle(any(), any(), any());
     publicPrivateBadge.configure(testEntity);
-    verify(mockView).showErrorMessage(anyString());
+    verify(mockView).showErrorMessage(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/subscription/SubscribeButtonWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/subscription/SubscribeButtonWidgetTest.java
@@ -123,7 +123,7 @@ public class SubscribeButtonWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setSynAlert(any());
     assertFalse(widget.isIconOnly());
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/api/APITableWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/api/APITableWidgetTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.ServiceConstants;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -63,7 +63,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.TableUnavilableException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class APITableWidgetTest {
 
   public static final String COL_1_RESULT_VALUE_1 = "result1 value 1";
@@ -281,7 +281,7 @@ public class APITableWidgetTest {
     descriptor.remove(WidgetConstants.API_TABLE_WIDGET_PATH_KEY);
     widget.configure(testWikiKey, descriptor, null, null);
     verify(mockSynAlert).showError(DisplayConstants.API_TABLE_MISSING_URI);
-    verify(mockView).showError(any(Widget.class));
+    verify(mockView).showError(any());
   }
 
   // test uri call failure causes view to render error
@@ -295,7 +295,7 @@ public class APITableWidgetTest {
       .getJSON(anyString(), any(AsyncCallback.class));
     widget.configure(testWikiKey, descriptor, null, null);
     verify(mockSynAlert).handleException(ex);
-    verify(mockView).showError(any(Widget.class));
+    verify(mockView).showError(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/explore/TableEntityWidgetV2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/explore/TableEntityWidgetV2Test.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityRef;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
@@ -83,7 +83,7 @@ import org.sagebionetworks.web.unitclient.widget.table.v2.TableModelTestUtils;
  * Business logic tests for the TableEntityPlotsWidget
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TableEntityWidgetV2Test {
 
   AdapterFactory adapterFactory;
@@ -719,8 +719,7 @@ public class TableEntityWidgetV2Test {
     );
     widget.onEditResults();
     // proceed to edit
-    verify(mockQueryResultEditorWidget)
-      .showEditor(any(QueryResultBundle.class), any(TableType.class));
+    verify(mockQueryResultEditorWidget).showEditor(any(), any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/ScopeWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/fileview/ScopeWidgetTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.table.EntityView;
@@ -32,7 +32,7 @@ import org.sagebionetworks.web.client.widget.table.modal.fileview.TableType;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ScopeWidgetTest {
 
   @Mock
@@ -132,8 +132,8 @@ public class ScopeWidgetTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setEditableEntityViewModalWidget(any(Widget.class));
-    verify(mockView).setEntityListWidget(any(Widget.class));
+    verify(mockView).setEditableEntityViewModalWidget(any());
+    verify(mockView).setEntityListWidget(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/upload/CSVOptionsWidgetImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/upload/CSVOptionsWidgetImplTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.UploadToTablePreviewRequest;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -18,7 +18,7 @@ import org.sagebionetworks.web.client.widget.table.modal.upload.CSVOptionsWidget
 import org.sagebionetworks.web.client.widget.table.modal.upload.Delimiter;
 import org.sagebionetworks.web.client.widget.table.modal.upload.EscapeCharacter;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CSVOptionsWidgetImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/upload/UploadCSVFinalPageImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/upload/UploadCSVFinalPageImplTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.repo.model.asynch.AsynchronousResponseBody;
 import org.sagebionetworks.repo.model.table.ColumnModel;
@@ -38,7 +38,7 @@ import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 import org.sagebionetworks.web.unitclient.widget.asynch.JobTrackingWidgetStub;
 import org.sagebionetworks.web.unitclient.widget.table.v2.schema.ColumnModelTableRowEditorStub;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UploadCSVFinalPageImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/wizard/ModalWizardWidgetImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/modal/wizard/ModalWizardWidgetImplTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.table.modal.upload.UploadCSVFilePage;
 import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalPage;
@@ -21,7 +21,7 @@ import org.sagebionetworks.web.client.widget.table.modal.wizard.ModalWizardWidge
  * @author jhill
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ModalWizardWidgetImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TotalVisibleResultsWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/TotalVisibleResultsWidgetTest.java
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityRef;
 import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.EntityView;
@@ -30,7 +30,7 @@ import org.sagebionetworks.web.client.widget.table.v2.TotalVisibleResultsWidget;
 import org.sagebionetworks.web.client.widget.table.v2.TotalVisibleResultsWidgetView;
 import org.sagebionetworks.web.shared.asynch.AsynchType;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TotalVisibleResultsWidgetTest {
 
   TotalVisibleResultsWidget widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/QueryResultEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/QueryResultEditorWidgetTest.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.file.BulkFileDownloadResponse;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.EntityUpdateFailureCode;
@@ -56,7 +56,7 @@ import org.sagebionetworks.web.unitclient.widget.table.v2.TableModelTestUtils;
  * @author John
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class QueryResultEditorWidgetTest {
 
   @Mock
@@ -379,7 +379,7 @@ public class QueryResultEditorWidgetTest {
     verify(mockEventBus).fireEvent(any(EntityUpdatedEvent.class));
 
     verify(mockClientCache)
-      .put(eq(ENTITY_ID + VIEW_RECENTLY_CHANGED_KEY), anyString(), anyLong());
+      .put(eq(ENTITY_ID + VIEW_RECENTLY_CHANGED_KEY), any(), anyLong());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TablePageWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TablePageWidgetTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -53,7 +53,7 @@ import org.sagebionetworks.web.unitclient.widget.table.v2.TableModelTestUtils;
  * Business logic unit tests for the TablePageWidget.
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TablePageWidgetTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWikiWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/TableQueryResultWikiWidgetTest.java
@@ -28,7 +28,7 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.table.Query;
@@ -53,7 +53,7 @@ import org.sagebionetworks.web.shared.WikiPageKey;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TableQueryResultWikiWidgetTest {
 
   TableQueryResultWikiWidget widget;
@@ -122,7 +122,7 @@ public class TableQueryResultWikiWidgetTest {
     AsyncMockStubber
       .callSuccessWith(mockEntityBundle)
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleFromCache(anyString(), any(AsyncCallback.class));
+      .getEntityBundleFromCache(any(), any());
     when(mockGinInjector.createNewTableEntityWidgetV2())
       .thenReturn(mockTableEntityWidget);
   }
@@ -131,8 +131,8 @@ public class TableQueryResultWikiWidgetTest {
   public void testConstruction() {
     // lazily loaded table query result widget
     verify(mockView, never()).setTableQueryResultWidget(any(Widget.class));
-    verify(mockView).setSynAlert(any(Widget.class));
-    verify(mockActionMenu).addControllerWidget(any(Widget.class));
+    verify(mockView).setSynAlert(any());
+    verify(mockActionMenu).addControllerWidget(any());
   }
 
   @Test
@@ -152,7 +152,7 @@ public class TableQueryResultWikiWidgetTest {
     widget.configure(wikiKey, descriptor, null, null);
 
     verifyZeroInteractions(mockGWT);
-    verify(mockView).setTableQueryResultWidget(any(Widget.class));
+    verify(mockView).setTableQueryResultWidget(any());
     verify(mockSynapseJavascriptClient)
       .getEntityBundleFromCache(eq(tableId), any(AsyncCallback.class));
     verify(mockSynAlert).clear();
@@ -199,7 +199,7 @@ public class TableQueryResultWikiWidgetTest {
     AsyncMockStubber
       .callFailureWith(new NotFoundException())
       .when(mockSynapseJavascriptClient)
-      .getEntityBundleFromCache(anyString(), any(AsyncCallback.class));
+      .getEntityBundleFromCache(any(), any());
     Map<String, String> descriptor = new HashMap<String, String>();
     String sql = "my query string";
     descriptor.put(WidgetConstants.TABLE_QUERY_KEY, sql);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EnumFormCellEditorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EnumFormCellEditorImplTest.java
@@ -13,14 +13,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.view.DivView;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.EnumFormCellEditor;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.ListCellEditorView;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.RadioCellEditorView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class EnumFormCellEditorImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/JSONListCellEditorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/JSONListCellEditorImplTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.schema.adapter.JSONArrayAdapter;
@@ -30,7 +30,7 @@ import org.sagebionetworks.web.client.widget.table.v2.results.cell.CellEditorVie
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.JSONListCellEditor;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.JSONListCellEditorView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class JSONListCellEditorImplTest {
 
   @Mock

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/UserIdCellEditorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/UserIdCellEditorImplTest.java
@@ -17,7 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.search.SynapseSuggestBox;
 import org.sagebionetworks.web.client.widget.search.UserGroupSuggestion;
@@ -26,7 +26,7 @@ import org.sagebionetworks.web.client.widget.table.v2.results.cell.UserIdCellEdi
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.UserIdCellEditorView;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.UserIdCellRenderer;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class UserIdCellEditorImplTest {
 
   @Mock
@@ -70,8 +70,8 @@ public class UserIdCellEditorImplTest {
 
   @Test
   public void testConstruction() {
-    verify(mockView).setSynapseSuggestBoxWidget(any(Widget.class));
-    verify(mockView).setUserIdCellRenderer(any(Widget.class));
+    verify(mockView).setSynapseSuggestBoxWidget(any());
+    verify(mockView).setUserIdCellRenderer(any());
     verify(mockSynapseSuggestBox)
       .setSuggestionProvider(mockUserGroupSuggestionProvider);
     verify(mockSynapseSuggestBox).addItemSelectedHandler(any(CallbackP.class));

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsEditorWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/schema/ColumnModelsEditorWidgetTest.java
@@ -9,13 +9,13 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.jsinterop.TableColumnSchemaEditorProps;
 import org.sagebionetworks.web.client.widget.table.v2.schema.ColumnModelsEditorWidget;
 import org.sagebionetworks.web.client.widget.table.v2.schema.ColumnModelsEditorWidgetView;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ColumnModelsEditorWidgetTest {
 
   ColumnModelsEditorWidget widget;

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/FileHandleListTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/FileHandleListTest.java
@@ -68,7 +68,7 @@ public class FileHandleListTest {
   @Test
   public void testConstruction() {
     verify(mockView).setPresenter(widget);
-    verify(mockView).setUploadWidget(any(Widget.class));
+    verify(mockView).setUploadWidget(any());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class FileHandleListTest {
     widget.refreshLinkUI();
 
     verify(mockView).clearFileLinks();
-    verify(mockView).addFileLink(any(Widget.class));
+    verify(mockView).addFileLink(any());
     // show toolbar since we can delete and we're showing a file.
     verify(mockView).setToolbarVisible(true);
     // show that we can delete, since the single file is telling us that it's selected

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/FileHandleUploadWidgetImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/FileHandleUploadWidgetImplTest.java
@@ -68,10 +68,9 @@ public class FileHandleUploadWidgetImplTest {
 
     // The metadata returned should correspond to testFileName
     when(mockView.getInputId()).thenReturn(inputId);
-    when(jsniUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(jsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName" });
-    when(jsniUtils.getContentType(any(JavaScriptObject.class), anyInt()))
-      .thenReturn(null);
+    when(jsniUtils.getContentType(any(), anyInt())).thenReturn(null);
   }
 
   @Test
@@ -99,11 +98,11 @@ public class FileHandleUploadWidgetImplTest {
 
     verify(mockMultipartUploader)
       .uploadFile(
-        anyString(),
-        anyString(),
-        any(JavaScriptObject.class),
+        any(),
+        any(),
+        any(),
         handleCaptor.capture(),
-        any(Long.class),
+        any(),
         eq(mockView)
       );
     handleCaptor.getValue().updateProgress(0.1, "10%", "100 KB/s");
@@ -127,7 +126,7 @@ public class FileHandleUploadWidgetImplTest {
     FileValidator mockFileValidator = mock(FileValidator.class);
     when(mockFileValidator.getInvalidFileCallback())
       .thenReturn(mockFailedValidationCallback);
-    when(jsniUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(jsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName#($*#.jpg" });
     widget.configure("button text", mockCallback);
     widget.setValidation(mockFileValidator);
@@ -140,7 +139,7 @@ public class FileHandleUploadWidgetImplTest {
 
   @Test
   public void testSelectInvalidFileNameNoValidator() {
-    when(jsniUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(jsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName#($*#.jpg" });
     widget.configure("button text", mockCallback);
 
@@ -152,7 +151,7 @@ public class FileHandleUploadWidgetImplTest {
   @Test
   public void testMultiFileSelected() {
     final String successFileHandle = "123";
-    when(jsniUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(jsniUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName", "testName2" });
 
     // Configure before the test
@@ -168,11 +167,11 @@ public class FileHandleUploadWidgetImplTest {
     // The progress should be updated with scaled values based on the presence of two files to upload
     verify(mockMultipartUploader)
       .uploadFile(
-        anyString(),
-        anyString(),
-        any(JavaScriptObject.class),
+        any(),
+        any(),
+        any(),
         handleCaptor.capture(),
-        any(Long.class),
+        any(),
         eq(mockView)
       );
     verify(mockView).showProgress(true);

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/ImageUploadWidgetImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/ImageUploadWidgetImplTest.java
@@ -78,10 +78,9 @@ public class ImageUploadWidgetImplTest {
 
     // The metadata returned should correspond to testFileName
     when(mockView.getInputId()).thenReturn(inputId);
-    when(mockJSNIUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(mockJSNIUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName.png" });
-    when(mockJSNIUtils.getContentType(any(JavaScriptObject.class), anyInt()))
-      .thenReturn("image/png");
+    when(mockJSNIUtils.getContentType(any(), anyInt())).thenReturn("image/png");
     when(mockPortalGinInjector.getImageUploadView()).thenReturn(mockView);
   }
 
@@ -110,11 +109,11 @@ public class ImageUploadWidgetImplTest {
 
     verify(mockMultipartUploader)
       .uploadFile(
-        anyString(),
+        any(),
         eq("image/png"),
-        any(JavaScriptObject.class),
+        any(),
         handleCaptor.capture(),
-        any(Long.class),
+        any(),
         eq(mockView)
       );
     handleCaptor.getValue().updateProgress(0.1, "10%", "100 KB/s");
@@ -139,11 +138,11 @@ public class ImageUploadWidgetImplTest {
     widget.onFileProcessed(mockBlob, "image/jpeg");
     verify(mockMultipartUploader)
       .uploadFile(
-        anyString(),
+        any(),
         eq("image/jpeg"),
-        any(JavaScriptObject.class),
+        any(),
         handleCaptor.capture(),
-        any(Long.class),
+        any(),
         eq(mockView)
       );
   }
@@ -160,9 +159,9 @@ public class ImageUploadWidgetImplTest {
 
   @Test
   public void testFileSelectedFailed() {
-    when(mockJSNIUtils.getMultipleUploadFileNames(any(JavaScriptObject.class)))
+    when(mockJSNIUtils.getMultipleUploadFileNames(any()))
       .thenReturn(new String[] { "testName.raw" });
-    when(mockJSNIUtils.getContentType(any(JavaScriptObject.class), anyInt()))
+    when(mockJSNIUtils.getContentType(any(), anyInt()))
       .thenReturn("notanimage/raw");
 
     // Configure before the test
@@ -178,6 +177,6 @@ public class ImageUploadWidgetImplTest {
     verify(mockView, never()).updateProgress(90, "90%");
 
     // Failure should trigger the following:
-    verify(mockSynAlert).showError(anyString());
+    verify(mockSynAlert).showError(any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/MultipartUploaderImplV2Test.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/upload/MultipartUploaderImplV2Test.java
@@ -96,19 +96,18 @@ public class MultipartUploaderImplV2Test {
 
     when(
       mockSRCUploadFileWrapper.uploadFile(
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         any(),
         anyInt(),
-        anyString(),
+        any(),
         any(),
         any()
       )
     )
       .thenReturn(mockPromise);
 
-    when(synapseJsniUtils.getFileSize(any(JavaScriptObject.class)))
-      .thenReturn(FILE_SIZE);
+    when(synapseJsniUtils.getFileSize(any())).thenReturn(FILE_SIZE);
 
     when(
       mockSynapseProperties.getSynapseProperty(
@@ -184,11 +183,11 @@ public class MultipartUploaderImplV2Test {
 
     verify(mockSRCUploadFileWrapper)
       .uploadFile(
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         any(),
         eq((int) defaultStorageLocationId),
-        anyString(),
+        any(),
         any(),
         any()
       );
@@ -209,11 +208,11 @@ public class MultipartUploaderImplV2Test {
 
     verify(mockSRCUploadFileWrapper)
       .uploadFile(
-        anyString(),
-        anyString(),
+        any(),
+        any(),
         any(),
         anyInt(),
-        anyString(),
+        any(),
         any(),
         isCancelledCaptor.capture()
       );

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/verification/VerificationSubmissionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/verification/VerificationSubmissionWidgetTest.java
@@ -164,20 +164,11 @@ public class VerificationSubmissionWidgetTest {
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockUserProfileClient)
-      .updateVerificationState(
-        anyLong(),
-        any(VerificationState.class),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .updateVerificationState(anyLong(), any(), any(), any());
     AsyncMockStubber
       .callSuccessWith(null)
       .when(mockUserProfileClient)
-      .createVerificationSubmission(
-        any(VerificationSubmission.class),
-        anyString(),
-        any(AsyncCallback.class)
-      );
+      .createVerificationSubmission(any(), any(), any());
     fileHandleIds = new ArrayList<String>();
     when(mockFileHandleList.getFileHandleIds()).thenReturn(fileHandleIds);
 
@@ -213,8 +204,8 @@ public class VerificationSubmissionWidgetTest {
 
     assertFalse(widget.isNewSubmission());
     verify(mockGinInjector).getVerificationSubmissionModalViewImpl();
-    verify(mockView).setFileHandleList(any(Widget.class));
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setFileHandleList(any());
+    verify(mockView).setSynAlert(any());
     verify(mockView).setPresenter(widget);
 
     widget.asWidget();
@@ -229,8 +220,8 @@ public class VerificationSubmissionWidgetTest {
 
     assertTrue(widget.isNewSubmission());
     verify(mockGinInjector).getVerificationSubmissionModalViewImpl();
-    verify(mockView).setFileHandleList(any(Widget.class));
-    verify(mockView).setSynAlert(any(Widget.class));
+    verify(mockView).setFileHandleList(any());
+    verify(mockView).setSynAlert(any());
     verify(mockView).setPresenter(widget);
   }
 
@@ -240,8 +231,8 @@ public class VerificationSubmissionWidgetTest {
     boolean isModal = false;
     widget.configure(mockSubmission, isACTMember, isModal);
     verify(mockGinInjector).getVerificationSubmissionRowViewImpl();
-    verify(mockRowView).setFileHandleList(any(Widget.class));
-    verify(mockRowView).setSynAlert(any(Widget.class));
+    verify(mockRowView).setFileHandleList(any());
+    verify(mockRowView).setSynAlert(any());
     verify(mockRowView).setPresenter(widget);
 
     widget.asWidget();

--- a/src/test/java/org/sagebionetworks/web/unitserver/ChallengeClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/ChallengeClientImplTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
@@ -66,8 +65,9 @@ import org.sagebionetworks.web.shared.ChallengeTeamPagedResults;
 import org.sagebionetworks.web.shared.UserProfilePagedResults;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
+import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class ChallengeClientImplTest {
 
   public static final String TEST_CHALLENGE_PROJECT_NAME =
@@ -174,7 +174,7 @@ public class ChallengeClientImplTest {
     setupChallengeteamPagedResults();
     when(mockSynapse.getChallenge(anyString())).thenReturn(testChallenge);
 
-    Whitebox.setInternalState(
+    ReflectionTestUtils.setField(
       synapseClient,
       "perThreadRequest",
       mockThreadLocal

--- a/src/test/java/org/sagebionetworks/web/unitserver/DataAccessClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/DataAccessClientImplTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.unitserver;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -53,13 +54,12 @@ public class DataAccessClientImplTest {
     dataAccessClient = new DataAccessClientImpl();
     dataAccessClient.setSynapseProvider(mockSynapseProvider);
     dataAccessClient.setTokenProvider(mockTokenProvider);
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
     when(mockSubject.getId()).thenReturn(TARGET_SUBJECT_ID);
     when(mockSubject.getType()).thenReturn(TARGET_SUBJECT_TYPE);
     when(mockRestrictableObjectDescriptorResponse.getSubjects())
       .thenReturn(java.util.Collections.singletonList(mockSubject));
-    when(mockSynapse.getSubjects(anyString(), anyString()))
+    when(mockSynapse.getSubjects(any(), any()))
       .thenReturn(mockRestrictableObjectDescriptorResponse);
   }
 

--- a/src/test/java/org/sagebionetworks/web/unitserver/StackConfigServiceTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/StackConfigServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.UserProfile;
@@ -23,6 +22,7 @@ import org.sagebionetworks.web.server.servlet.SynapseClientImpl;
 import org.sagebionetworks.web.server.servlet.SynapseProvider;
 import org.sagebionetworks.web.server.servlet.TokenProvider;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class StackConfigServiceTest {
 
@@ -76,7 +76,7 @@ public class StackConfigServiceTest {
     when(mockUserSessionData.getSession()).thenReturn(testSession);
     when(mockSynapse.getMyProfile()).thenReturn(testProfile);
 
-    Whitebox.setInternalState(
+    ReflectionTestUtils.setField(
       stackConfigService,
       "perThreadRequest",
       mockThreadLocal

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientBaseTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientBaseTest.java
@@ -11,14 +11,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.internal.util.reflection.Whitebox;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.web.server.StackEndpoints;
 import org.sagebionetworks.web.server.servlet.SynapseClientBase;
 import org.sagebionetworks.web.server.servlet.SynapseProvider;
+import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class SynapseClientBaseTest {
 
   @Mock
@@ -56,12 +56,12 @@ public class SynapseClientBaseTest {
     synapseClientBase = new SynapseClientBase();
     when(mockSynapseProvider.createNewClient(anyString()))
       .thenReturn(mockSynapseClient);
-    Whitebox.setInternalState(
+    ReflectionTestUtils.setField(
       synapseClientBase,
       "synapseProvider",
       mockSynapseProvider
     );
-    Whitebox.setInternalState(
+    ReflectionTestUtils.setField(
       synapseClientBase,
       "perThreadRequest",
       mockThreadLocal

--- a/src/test/java/org/sagebionetworks/web/unitserver/UserAccountServiceImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/UserAccountServiceImplTest.java
@@ -40,8 +40,7 @@ public class UserAccountServiceImplTest {
   public void before() throws SynapseException, JSONObjectAdapterException {
     mockSynapse = Mockito.mock(SynapseClient.class);
     mockSynapseProvider = Mockito.mock(SynapseProvider.class);
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
     mockTokenProvider = Mockito.mock(TokenProvider.class);
 
     testProfile = new UserProfile();

--- a/src/test/java/org/sagebionetworks/web/unitserver/UserProfileClientImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/UserProfileClientImplTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.internal.util.reflection.Whitebox;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.UserProfile;
@@ -21,6 +20,7 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.server.servlet.SynapseProvider;
 import org.sagebionetworks.web.server.servlet.TokenProvider;
 import org.sagebionetworks.web.server.servlet.UserProfileClientImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Test for the UserAccountServiceImpl
@@ -70,7 +70,7 @@ public class UserProfileClientImplTest {
     userProfileClient.setTokenProvider(mockTokenProvider);
     when(mockSynapse.getMyProfile()).thenReturn(testProfile);
 
-    Whitebox.setInternalState(
+    ReflectionTestUtils.setField(
       userProfileClient,
       "perThreadRequest",
       mockThreadLocal

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/CORSFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/CORSFilterTest.java
@@ -22,10 +22,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.server.servlet.filter.CORSFilter;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CORSFilterTest {
 
   CORSFilter filter;

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/CrawlFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/CrawlFilterTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.Entity;
@@ -36,7 +36,7 @@ import org.sagebionetworks.web.server.servlet.filter.BotHtml;
 import org.sagebionetworks.web.server.servlet.filter.CrawlFilter;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CrawlFilterTest {
 
   @Captor

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/HtmlInjectionFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/HtmlInjectionFilterTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
@@ -56,7 +56,7 @@ import org.sagebionetworks.web.server.servlet.filter.CrawlFilter;
 import org.sagebionetworks.web.server.servlet.filter.HtmlInjectionFilter;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class HtmlInjectionFilterTest {
 
   HtmlInjectionFilter filter;

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/XFrameOptionsFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/XFrameOptionsFilterTest.java
@@ -17,10 +17,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.web.server.servlet.filter.XFrameOptionsFilter;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class XFrameOptionsFilterTest {
 
   XFrameOptionsFilter filter;

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/AliasRedirectorServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/AliasRedirectorServletTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.web.unitserver.servlet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -63,8 +64,7 @@ public class AliasRedirectorServletTest {
     throws IOException, SynapseException, JSONObjectAdapterException {
     MockitoAnnotations.initMocks(this);
     servlet = new AliasRedirectorServlet();
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
 
     servlet.setSynapseProvider(mockSynapseProvider);
 
@@ -148,8 +148,9 @@ public class AliasRedirectorServletTest {
   @Test
   public void testDoGetError() throws Exception {
     String errorMessage = "An error from the service call";
-    when(mockSynapse.getUserGroupHeadersByAliases(anyList()))
+    when(mockSynapse.getUserGroupHeadersByAliases(any()))
       .thenThrow(new SynapseForbiddenException(errorMessage));
+
     servlet.doGet(mockRequest, mockResponse);
 
     // redirects to an error place

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/DiscussionMessageServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/DiscussionMessageServletTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.unitserver.servlet;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -60,10 +61,9 @@ public class DiscussionMessageServletTest {
     ReflectionTestUtils.setField(servlet, "tokenProvider", mockTokenProvider);
 
     URL resolvedUrl = new URL("http://localhost/file.png");
-    when(mockSynapse.getThreadUrl(anyString())).thenReturn(resolvedUrl);
-    when(mockSynapse.getReplyUrl(anyString())).thenReturn(resolvedUrl);
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapse.getThreadUrl(any())).thenReturn(resolvedUrl);
+    when(mockSynapse.getReplyUrl(any())).thenReturn(resolvedUrl);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
     when(mockResponse.getOutputStream()).thenReturn(responseOutputStream);
     when(mockRequest.getRequestURL())
       .thenReturn(new StringBuffer("https://www.synapse.org/"));
@@ -157,6 +157,6 @@ public class DiscussionMessageServletTest {
     servlet.doGet(mockRequest, mockResponse);
 
     verify(mockResponse)
-      .sendError(eq(HttpServletResponse.SC_BAD_REQUEST), anyString());
+      .sendError(eq(HttpServletResponse.SC_BAD_REQUEST), any());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileEntityResolverServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileEntityResolverServletTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.unitserver.servlet;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -63,8 +64,7 @@ public class FileEntityResolverServletTest {
     MockitoAnnotations.initMocks(this);
     servlet = new FileEntityResolverServlet();
 
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
 
     URL resolvedUrl = new URL(resolvedUrlString);
     when(

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
@@ -65,8 +65,7 @@ public class FileHandleAssociationServletTest {
     MockitoAnnotations.initMocks(this);
     servlet = new FileHandleAssociationServlet();
 
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
 
     resolvedUrl = new URL("http://localhost/file.png");
     when(mockSynapse.getFileURL(any(FileHandleAssociation.class)))

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleServletTest.java
@@ -63,8 +63,7 @@ public class FileHandleServletTest {
   public void setup() throws IOException, SynapseException {
     MockitoAnnotations.initMocks(this);
     servlet = new FileHandleServlet();
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
 
     WikiPage testPage = new WikiPage();
     testPage.setAttachmentFileHandleIds(new ArrayList<String>());

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/ProjectAliasServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/ProjectAliasServletTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.unitserver.servlet;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -47,8 +48,7 @@ public class ProjectAliasServletTest {
     // unintentionally testing those classes
     mockSynapse = mock(SynapseClient.class);
     mockSynapseProvider = mock(SynapseProvider.class);
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
 
     mockTokenProvider = mock(TokenProvider.class);
 
@@ -80,7 +80,7 @@ public class ProjectAliasServletTest {
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(mockResponse).encodeRedirectURL(captor.capture());
     assertTrue(captor.getValue().endsWith("/Synapse:" + testAliasSynapseId));
-    verify(mockResponse).sendRedirect(anyString());
+    verify(mockResponse).sendRedirect(any());
   }
 
   @Test
@@ -99,7 +99,7 @@ public class ProjectAliasServletTest {
         .getValue()
         .endsWith("/Synapse:" + testAliasSynapseId + testFilesPath)
     );
-    verify(mockResponse).sendRedirect(anyString());
+    verify(mockResponse).sendRedirect(any());
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/SlackServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/SlackServletTest.java
@@ -114,8 +114,7 @@ public class SlackServletTest {
     when(mockEntityPath.getPath()).thenReturn(entityPath);
     when(mockEntityBundle.getPath()).thenReturn(mockEntityPath);
     when(mockParentProject.getName()).thenReturn(ENTITY_PROJECT);
-    when(mockSynapseProvider.createNewClient(anyString()))
-      .thenReturn(mockSynapse);
+    when(mockSynapseProvider.createNewClient(any())).thenReturn(mockSynapse);
     when(mockResponse.getOutputStream()).thenReturn(mockOutputStream);
     when(mockEntityBundle.getThreadCount()).thenReturn(THREAD_COUNT);
     when(mockEntityBundle.getAnnotations()).thenReturn(mockAnnotations);
@@ -140,10 +139,10 @@ public class SlackServletTest {
     String requestSynId = "syn1234";
     when(mockRequest.getParameter("text")).thenReturn(requestSynId);
     when(mockRequest.getParameter("command")).thenReturn("/synapse");
+
     servlet.doGet(mockRequest, mockResponse);
 
-    verify(mockSynapse)
-      .getEntityBundleV2(anyString(), any(EntityBundleRequest.class));
+    verify(mockSynapse).getEntityBundleV2(any(), any());
 
     verify(mockOutputStream)
       .write(byteArrayCaptor.capture(), anyInt(), anyInt());
@@ -163,8 +162,7 @@ public class SlackServletTest {
     when(mockRequest.getParameter("command")).thenReturn("/synapsestaging");
     servlet.doGet(mockRequest, mockResponse);
 
-    verify(mockSynapse)
-      .getEntityBundleV2(anyString(), any(EntityBundleRequest.class));
+    verify(mockSynapse).getEntityBundleV2(any(), any());
 
     verify(mockOutputStream)
       .write(byteArrayCaptor.capture(), anyInt(), anyInt());

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/oaut/OAuth2SessionServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/oaut/OAuth2SessionServletTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
 import org.sagebionetworks.client.exceptions.SynapseException;
@@ -36,7 +36,7 @@ import org.sagebionetworks.web.server.servlet.SynapseProvider;
 import org.sagebionetworks.web.server.servlet.oauth2.OAuth2SessionServlet;
 import org.sagebionetworks.web.shared.WebConstants;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OAuth2SessionServletTest {
 
   @Mock

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.21.0":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.4.tgz#6ef37d678428306e7d75f054d5b1bdb8cf8aa8ee"
+  integrity sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.25.0":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.0.tgz#e733dc3134b4fede528c15bc95e89cb98c52592a"
@@ -293,6 +300,18 @@
   dependencies:
     fast-deep-equal "^3.1.3"
     supercluster "^8.0.1"
+
+"@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
+  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/topo@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -829,6 +848,23 @@
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@sage-bionetworks/synapse-types/-/synapse-types-0.0.2.tgz#4190a908a10f10d0cc51e304d6d1d23da41ad64e"
   integrity sha512-31MxrIOnJiAUYeXsDsf2J+q9A6nVZt9pWGfG+pYoKC2vZIgUo7L3ToelYEqoufvdgHht+aWq83bnk/+Y4UNoUA==
+
+"@sideway/address@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
+  integrity sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@tanstack/query-core@5.22.2":
   version "5.22.2"
@@ -1488,12 +1524,26 @@ ascii2mathml@^0.6.2:
   dependencies:
     minimist "^1.2.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.7.4:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.5.tgz#21eed340eb5daf47d29b6e002424b3e88c8c54b1"
+  integrity sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -1631,7 +1681,7 @@ chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1711,6 +1761,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
 
 clone@^2.1.2:
   version "2.1.2"
@@ -1842,6 +1901,13 @@ colorette@^2.0.20:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@2, commander@^2.15.1, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1895,6 +1961,21 @@ concat-stream@^1.5.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concurrently@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-8.2.2.tgz#353141985c198cfa5e4a3ef90082c336b5851784"
+  integrity sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==
+  dependencies:
+    chalk "^4.1.2"
+    date-fns "^2.30.0"
+    lodash "^4.17.21"
+    rxjs "^7.8.1"
+    shell-quote "^1.8.1"
+    spawn-command "0.0.2"
+    supports-color "^8.1.1"
+    tree-kill "^1.2.2"
+    yargs "^17.7.2"
 
 convert-source-map@^1.5.0:
   version "1.9.0"
@@ -2220,6 +2301,13 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+
 dayjs@^1.11.10:
   version "1.11.12"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.12.tgz#5245226cc7f40a15bf52e0b99fd2a04669ccac1d"
@@ -2278,6 +2366,11 @@ defined@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.1.tgz#c0b9db27bfaffd95d6f61399419b893df0f91ebf"
   integrity sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
@@ -2566,6 +2659,11 @@ es6-weak-map@^2.0.3:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+escalade@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
+  integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2846,6 +2944,11 @@ flatten-vertex-data@^1.0.2:
   dependencies:
     dtype "^2.0.0"
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 font-atlas@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/font-atlas/-/font-atlas-2.1.0.tgz#aa2d6dcf656a6c871d66abbd3dfbea2f77178348"
@@ -2871,6 +2974,15 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 from2@^2.3.0:
   version "2.3.0"
@@ -2920,7 +3032,7 @@ geojson-vt@^3.2.1:
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
   integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3648,6 +3760,17 @@ java-parser@2.2.0:
     chevrotain "6.5.0"
     lodash "4.17.21"
 
+joi@^17.13.3:
+  version "17.13.3"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
+  integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
+  dependencies:
+    "@hapi/hoek" "^9.3.0"
+    "@hapi/topo" "^5.1.0"
+    "@sideway/address" "^4.1.5"
+    "@sideway/formula" "^3.0.1"
+    "@sideway/pinpoint" "^2.0.0"
+
 jotai@^2.7.0:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.9.1.tgz#f32dd16fc16b7b32d940a3a8d452eddfcb16218c"
@@ -4048,6 +4171,18 @@ micromatch@^4.0.4, micromatch@~4.0.7:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
@@ -4072,7 +4207,7 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -4729,6 +4864,11 @@ protocol-buffers-schema@^3.3.1:
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
   integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 punycode.js@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
@@ -5318,6 +5458,13 @@ rw@^1.3.3:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.2.tgz#81d77ee0c4e8b863635227c721278dd524c20edb"
@@ -5459,7 +5606,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1:
+shell-quote@^1.6.1, shell-quote@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
@@ -5532,6 +5679,11 @@ spark-md5@^3.0.2:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
+spawn-command@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2.tgz#9544e1a43ca045f8531aac1a48cb29bdae62338e"
+  integrity sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==
+
 spdx-correct@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
@@ -5594,7 +5746,7 @@ string-split-by@^1.0.0:
   dependencies:
     parenthesis "^3.1.5"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5731,6 +5883,13 @@ supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -5951,10 +6110,20 @@ topojson-client@^3.1.0:
   dependencies:
     commander "2"
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 ts-api-utils@^1.0.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
   integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
+
+tslib@^2.1.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslib@^2.3.0, tslib@^2.6.2:
   version "2.6.3"
@@ -6175,6 +6344,17 @@ vt-pbf@^3.1.1:
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.2.1"
 
+wait-on@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.0.tgz#82e3f334db01cf37beef0d11639d66333b027f03"
+  integrity sha512-fNE5SXinLr2Bt7cJvjvLg2PcXfqznlqRvtE3f8AqYdRZ9BhE+XpsCp1mwQbRoO7s1q7uhAuCw0Ro3mG/KdZjEw==
+  dependencies:
+    axios "^1.7.4"
+    joi "^17.13.3"
+    lodash "^4.17.21"
+    minimist "^1.2.8"
+    rxjs "^7.8.1"
+
 warning@^4.0.0, warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
@@ -6266,6 +6446,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
@@ -6316,6 +6505,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
@@ -6334,6 +6528,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
@@ -6350,6 +6549,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Also bump Guice to 6, Mockito to 2, and lock guice-assistedinject to 6 to override Gin.

Migrate many tests to be compatible with Mockito 2. The main reason tests had to change was because `anyString()` and `any(Foo.class)` matchers do not allow `null` as a valid match in v2, but they do in v1. In these cases, just use `any()`

Also fix the dev scripts so now `yarn dev` should launch the GWT Codeserver and a Tomcat 9 container that will re-compile on refresh if there's a source code change.

We should be able to upgrade to Java 17 at a later date just by upgrading the JDK and compile target.