### PR TITLE
SWC-6882 - Rename ReactNode to ReactElement

### DIFF
--- a/devdocs/ReactIntegration.md
+++ b/devdocs/ReactIntegration.md
@@ -49,6 +49,7 @@ How you manage updating your widget's view will vary based on the scenario, but 
 ```java
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 
 class MyView {
 
@@ -57,12 +58,12 @@ class MyView {
 
   void renderComponent() {
     MyProps props = props.create(/**/);
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.MyComponent,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 }
 

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
@@ -27,7 +27,7 @@ import org.sagebionetworks.web.client.cache.SessionStorage;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.mvp.AppActivityMapper;
 import org.sagebionetworks.web.client.mvp.AppPlaceHistoryMapper;
@@ -467,7 +467,7 @@ public class GlobalApplicationStateImpl implements GlobalApplicationState {
       isToastContainerInitialized = true;
 
       Element toastContainer = RootPanel.get("toastContainer").getElement();
-      ReactNode component = React.createElementWithThemeContext(
+      ReactElement component = React.createElementWithThemeContext(
         SRC.SynapseComponents.SynapseToastContainer,
         null
       );

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
@@ -8,15 +8,16 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class React {
 
-  public static native <P extends ReactComponentProps> ReactNode createElement(
-    ReactComponentType<P> component,
-    P props
-  );
+  public static native <
+    P extends ReactComponentProps
+  > ReactElement createElement(ReactComponentType<P> component, P props);
 
-  public static native <P extends ReactComponentProps> ReactNode createElement(
+  public static native <
+    P extends ReactComponentProps
+  > ReactElement createElement(
     ReactComponentType<P> component,
     P props,
-    ReactNode... children
+    ReactElement... children
   );
 
   public static native <T> T createRef();
@@ -28,7 +29,7 @@ public class React {
   @JsOverlay
   public static <
     P extends ReactComponentProps
-  > ReactNode createElementWithThemeContext(
+  > ReactElement createElementWithThemeContext(
     ReactComponentType<P> component,
     P props
   ) {
@@ -54,12 +55,12 @@ public class React {
   @JsOverlay
   public static <
     P extends ReactComponentProps
-  > ReactNode createElementWithSynapseContext(
+  > ReactElement createElementWithSynapseContext(
     ReactComponentType<P> component,
     P props,
     SynapseReactClientFullContextProviderProps wrapperProps
   ) {
-    ReactNode componentElement = createElement(component, props);
+    ReactElement componentElement = createElement(component, props);
     return createElement(
       SRC.SynapseContext.FullContextProvider,
       wrapperProps,
@@ -67,16 +68,16 @@ public class React {
     );
   }
 
-  public static native ReactNode cloneElement(ReactNode element);
+  public static native ReactElement cloneElement(ReactElement element);
 
-  public static native ReactNode cloneElement(
-    ReactNode element,
+  public static native ReactElement cloneElement(
+    ReactElement element,
     ReactComponentProps props
   );
 
-  public static native ReactNode cloneElement(
-    ReactNode element,
+  public static native ReactElement cloneElement(
+    ReactElement element,
     ReactComponentProps props,
-    ReactNode... children
+    ReactElement... children
   );
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactComponentProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactComponentProps.java
@@ -18,13 +18,13 @@ public class ReactComponentProps {
     void run(Element element);
   }
 
-  public JsArray<ReactNode<?>> children;
+  public JsArray<ReactElement<?>> children;
 
   // Either a ComponentRef or CallbackRef may be passed. A CallbackRef will be invoked when the ref is set.
   public Object ref;
 
   @JsOverlay
-  public final void addChild(ReactNode<?> child) {
+  public final void addChild(ReactElement<?> child) {
     if (children == null) {
       children = new JsArray<>();
     }
@@ -37,7 +37,7 @@ public class ReactComponentProps {
   }
 
   @JsOverlay
-  public final JsArray<ReactNode<?>> getChildren() {
+  public final JsArray<ReactElement<?>> getChildren() {
     if (children == null) {
       children = new JsArray<>();
     }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOMRoot.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOMRoot.java
@@ -6,7 +6,7 @@ import jsinterop.annotations.JsType;
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class ReactDOMRoot {
 
-  public native void render(ReactNode element);
+  public native void render(ReactElement element);
 
   public native void unmount();
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactElement.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactElement.java
@@ -5,7 +5,7 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class ReactNode<T extends ReactComponentProps> {
+public class ReactElement<T extends ReactComponentProps> {
 
   @JsNullable
   public T props;

--- a/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -43,7 +43,7 @@ public class DataAccessManagementViewImpl implements DataAccessManagementView {
     headerWidget.refresh();
     Window.scrollTo(0, 0);
 
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ReviewerDashboard,
       null,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
@@ -5,11 +5,10 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -90,7 +89,7 @@ public class DownViewImpl implements DownView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadCartPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -43,7 +43,7 @@ public class DownloadCartPageViewImpl implements DownloadCartPageView {
     DownloadCartPageProps props = DownloadCartPageProps.create(entityId -> {
       presenter.onViewSharingSettingsClicked(entityId);
     });
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadCartPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -61,7 +61,7 @@ public class FollowingPageViewImpl
 
   private void configure() {
     headerWidget.configure();
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubscriptionPage,
       EmptyProps.create(),
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
@@ -6,14 +6,12 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.FeatureFlagConfig;
 import org.sagebionetworks.web.client.FeatureFlagKey;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
-import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseHomepageProps;
 import org.sagebionetworks.web.client.jsinterop.SynapseHomepageV2Props;
@@ -54,7 +52,7 @@ public class HomeViewImpl extends Composite implements HomeView {
   @Override
   public void render() {
     scrollToTop();
-    ReactNode component;
+    ReactElement component;
 
     if (featureFlagConfig.isFeatureEnabled(FeatureFlagKey.HOMEPAGE_V2)) {
       SynapseHomepageV2Props props = SynapseHomepageV2Props.create(href -> {

--- a/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
@@ -14,7 +14,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.TermsAndConditionsProps;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -168,7 +168,7 @@ public class LoginViewImpl extends Composite implements LoginView {
       TermsAndConditionsProps props = TermsAndConditionsProps.create(
         this::onFormChange
       );
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.TermsAndConditions,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
@@ -34,7 +34,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Search;
 import org.sagebionetworks.web.client.place.Synapse;
@@ -603,7 +603,7 @@ public class ProfileViewImpl extends Composite implements ProfileView {
         "https://help.synapse.org/docs/Navigating-Synapse.2048557182.html#NavigatingSynapse-Favorites"
       );
       EmptyProps props = EmptyProps.create();
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.FavoritesPage,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.dom.client.SpanElement;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.web.client.jsinterop.EntityTypeIconProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class EntityTypeIconImpl
@@ -23,7 +23,7 @@ public class EntityTypeIconImpl
   @Override
   public void configure(EntityType type) {
     EntityTypeIconProps props = EntityTypeIconProps.create(type);
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.EntityTypeIcon,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
@@ -8,7 +8,7 @@ import org.gwtbootstrap3.client.ui.constants.AlertType;
 import org.sagebionetworks.web.client.jsinterop.AlertButtonConfig;
 import org.sagebionetworks.web.client.jsinterop.FullWidthAlertProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class FullWidthAlert implements IsWidget {
@@ -60,7 +60,7 @@ public class FullWidthAlert implements IsWidget {
       isGlobal,
       alertType
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.FullWidthAlert,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
@@ -7,7 +7,7 @@ import org.gwtbootstrap3.client.ui.constants.Pull;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.jsinterop.HelpPopoverProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 /**
@@ -54,7 +54,7 @@ public class HelpWidget implements IsWidget {
       showCloseButton,
       className
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.HelpPopover,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.web.client.widget;
 import com.google.gwt.dom.client.SpanElement;
 import org.sagebionetworks.web.client.jsinterop.IconSvgProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class IconSvg extends ReactComponent {
@@ -24,7 +24,7 @@ public class IconSvg extends ReactComponent {
 
   private void renderComponent() {
     IconSvgProps props = IconSvgProps.create(icon, label);
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.IconSvg,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.sagebionetworks.web.client.jsinterop.AlertButtonConfig;
 import org.sagebionetworks.web.client.jsinterop.OrientationBannerProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class OrientationBanner implements IsWidget {
@@ -43,7 +43,7 @@ public class OrientationBanner implements IsWidget {
       primaryButtonConfig,
       secondaryButtonConfig
     );
-    ReactNode component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithThemeContext(
       SRC.SynapseComponents.OrientationBanner,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponent.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponent.java
@@ -18,14 +18,14 @@ import org.sagebionetworks.web.client.jsinterop.ReactComponentProps;
 import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
 import org.sagebionetworks.web.client.jsinterop.ReactDOMRoot;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 
 /**
- * Widget that manages the lifecycle of a React component. To use this widget, create a {@link ReactNode} using the
- * {@link React} API and call {@link #render(ReactNode)} to render the React component.
+ * Widget that manages the lifecycle of a React component. To use this widget, create a {@link ReactElement} using the
+ * {@link React} API and call {@link #render(ReactElement)} to render the React component.
  * <p>
  * This widget also manages appending child elements if the associated React component can contain children. If all
- * child widgets use this class, then the child {@link ReactNode}s will be cloned and passed as children to the React
+ * child widgets use this class, then the child {@link ReactElement}s will be cloned and passed as children to the React
  * component. If any child of this component is a non-ReactComponent widget, then the child widgets will be injected
  * into the node found using the component's `ref`.
  * <p>
@@ -41,7 +41,7 @@ public class ReactComponent<T extends ReactComponentProps>
   private ReactComponentType<T> reactComponentType;
   public T props;
 
-  private ReactNode<?> reactElement;
+  private ReactElement<?> reactElement;
 
   public ReactComponent() {
     this(DivElement.TAG);
@@ -107,14 +107,14 @@ public class ReactComponent<T extends ReactComponentProps>
    */
   private void injectChildWidgetsIntoComponent() {
     if (this.allChildrenAreReactComponents()) {
-      // If all widget children are ReactNodes, clone the React component and add them as children
+      // If all widget children are ReactElements, clone the React component and add them as children
       List<ReactComponent<?>> childWidgets = new ArrayList<>();
       getChildren().forEach(w -> childWidgets.add(((ReactComponent<?>) w)));
 
-      ReactNode<?>[] childReactElements = childWidgets
+      ReactElement<?>[] childReactElements = childWidgets
         .stream()
         .map(ReactComponent::getReactElement)
-        .toArray(ReactNode<?>[]::new);
+        .toArray(ReactElement<?>[]::new);
 
       this.reactElement =
         React.cloneElement(reactElement, this.props, childReactElements);
@@ -141,8 +141,8 @@ public class ReactComponent<T extends ReactComponentProps>
     }
   }
 
-  public void render(ReactNode<?> reactNode) {
-    this.reactElement = reactNode;
+  public void render(ReactElement<?> reactElement) {
+    this.reactElement = reactElement;
     maybeCreateRoot();
     injectChildWidgetsIntoComponent();
 
@@ -240,7 +240,7 @@ public class ReactComponent<T extends ReactComponentProps>
     return true;
   }
 
-  public ReactNode<?> getReactElement() {
+  public ReactElement<?> getReactElement() {
     return reactElement;
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementRelatedProjectsListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -32,7 +32,7 @@ public class AccessRequirementRelatedProjectsList implements IsWidget {
   public void configure(String accessRequirementId) {
     AccessRequirementRelatedProjectsListProps props =
       AccessRequirementRelatedProjectsListProps.create(accessRequirementId);
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AccessRequirementRelatedProjectsList,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
@@ -6,7 +6,7 @@ import org.sagebionetworks.repo.model.request.ReferenceList;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityHeaderTableProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -44,7 +44,7 @@ public class EntitySubjectsWidgetViewImpl implements EntitySubjectsWidgetView {
     ReferenceList entityReferences,
     boolean isEditable
   ) {
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityHeaderTable,
       EntityHeaderTableProps.create(
         entityReferences.getReferences(),

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorHandler;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.ReactRef;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -42,7 +42,7 @@ public class CreateManagedACTAccessRequirementStep3ViewImpl
   public void configure(String accessRequirementId) {
     componentRef = React.createRef();
     reactContainer.clear();
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AccessRequirementAclEditor,
       AccessRequirementAclEditorProps.create(
         accessRequirementId,

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -43,12 +43,12 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
         this.onCancel
       );
 
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateOrUpdateAccessRequirementWizard,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   public void configure(

--- a/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.BreadcrumbItem;
 import org.sagebionetworks.web.client.jsinterop.EntityPageBreadcrumbsProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -81,7 +81,7 @@ public class BreadcrumbViewImpl implements BreadcrumbView {
       items.toArray(new BreadcrumbItem[0])
     );
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageBreadcrumbs,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
@@ -4,7 +4,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps;
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps.OnSearchResultsVisibleHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -21,7 +21,7 @@ public class ForumSearchWrapper extends ReactComponent {
       projectId,
       onSearchResultsVisible
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ForumSearch,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
@@ -33,7 +33,7 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.jsinterop.EntityBadgeIconsProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseReactClientFullContextProviderProps;
 import org.sagebionetworks.web.client.place.Synapse;
@@ -285,13 +285,13 @@ public class EntityBadgeViewImpl extends Composite implements EntityBadgeView {
     EntityBadgeIconsProps props,
     SynapseReactClientFullContextProviderProps providerProps
   ) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityBadgeIcons,
       props,
       providerProps
     );
 
-    iconsContainer.render(reactNode);
+    iconsContainer.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
@@ -22,12 +22,12 @@ public class EntityModalWidgetViewImpl implements EntityModalWidgetView {
 
   @Override
   public void renderComponent(EntityModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -26,12 +26,12 @@ public class EntityViewScopeEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(EntityViewScopeEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityViewScopeEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -40,7 +40,7 @@ public class ModifiedCreatedByWidgetViewImpl
 
   @Override
   public void setProps(CreatedByModifiedByProps props) {
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreatedByModifiedBy,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SqlDefinedTableEditorModalProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -26,12 +26,12 @@ public class SqlDefinedEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(SqlDefinedTableEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SqlDefinedTableEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
@@ -21,7 +21,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.EntityFinderProps;
 import org.sagebionetworks.web.client.jsinterop.EntityFinderScope;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsni.ReferenceJSNIObject;
 import org.sagebionetworks.web.client.widget.HelpWidget;
@@ -158,7 +158,7 @@ public class EntityFinderWidgetViewImpl implements EntityFinderWidgetView {
       treeOnly
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityFinder,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.view.DownViewImpl.ErrorPageType;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -92,7 +92,7 @@ public class StuAlertViewImpl implements StuAlertView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadConfirmationProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -72,7 +72,7 @@ public class AddToDownloadListV2Impl implements AddToDownloadListV2 {
       folderId,
       onClose
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadConfirmation,
       editorProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
@@ -9,7 +9,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityPageTitleBarProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -22,12 +22,12 @@ public class BasicTitleBarViewImpl implements BasicTitleBarView {
 
   @Override
   public void setProps(EntityPageTitleBarProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageTitleBar,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponentContainer.render(reactNode);
+    reactComponentContainer.render(reactElement);
   }
 
   interface BasicTitleBarViewImplUiBinder

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
@@ -7,7 +7,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SkeletonButtonProps;
 import org.sagebionetworks.web.client.jsinterop.entity.actionmenu.EntityActionMenuPropsJsInterop;
@@ -52,7 +52,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   }
 
   private void renderMenuComponent(EntityActionMenuPropsJsInterop props) {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityActionMenu,
       props,
       propsProvider.getJsInteropContextProps()
@@ -61,7 +61,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   }
 
   private void renderLoaderComponent() {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SkeletonButton,
       SkeletonButtonProps.create("Tools Menu Placeholder"),
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
@@ -9,7 +9,7 @@ import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HtmlPreviewProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -47,7 +47,7 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   public void configure(String createdBy, String rawHtml) {
     HtmlPreviewProps props = HtmlPreviewProps.create(createdBy, rawHtml);
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HtmlPreview,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.IDUReportProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -28,7 +28,7 @@ public class IntendedDataUseReportWidgetViewImpl
   public void render(String accessRequirementId) {
     IDUReportProps props = IDUReportProps.create(accessRequirementId);
 
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.IDUReport,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/PlotlyWidgetViewImpl.java
@@ -165,7 +165,7 @@ public class PlotlyWidgetViewImpl implements PlotlyWidgetView {
 			};
 
 			var component = $wnd.React.createElement(plot, props)
-			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(component);
+			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(component);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
@@ -13,7 +13,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HasAccessProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -194,7 +194,7 @@ public class RestrictionWidgetViewImpl implements RestrictionWidgetView {
       null,
       null
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HasAccess,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
@@ -11,7 +11,7 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EvaluationCardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.evaluation.EvaluationRowWidget.EvaluationActionHandler;
@@ -81,7 +81,7 @@ public class AdministerEvaluationsListViewImpl
     container.addStyleName("margin-top-50");
     rows.add(container);
 
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationCard,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.EvaluationEditorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -66,7 +66,7 @@ public class EvaluationEditorReactComponentPage extends Composite {
       entityId,
       this.onPageBack
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationEditorPage,
       editorProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AvailableEvaluationQueueListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -28,7 +28,7 @@ public class EvaluationListViewImpl implements EvaluationListView {
 
   @Override
   public void configure(List<Evaluation> list, boolean isSelectable) {
-    ReactNode element = React.createElementWithSynapseContext(
+    ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AvailableEvaluationQueueList,
       AvailableEvaluationQueueListProps.create(
         list,

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationSubmitterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationSubmitterViewImpl.java
@@ -452,7 +452,7 @@ public class EvaluationSubmitterViewImpl implements EvaluationSubmitterView {
 
 			var component = $wnd.React.createElement($wnd.SRC.SynapseComponents.EntityForm, props, null);
 			var wrapper = $wnd.React.createElement($wnd.SRC.SynapseContext.FullContextProvider, wrapperProps, component);
-            reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(wrapper);
+            reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(wrapper);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SubmissionViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -26,12 +26,12 @@ public class SubmissionViewScopeEditorModalWidgetViewImpl
 
   @Override
   public void renderComponent(SubmissionViewScopeEditorModalProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubmissionViewScopeEditorModal,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
@@ -10,7 +10,7 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseFooterProps;
 import org.sagebionetworks.web.client.utils.Callback;
@@ -91,7 +91,7 @@ public class FooterViewImpl implements FooterView, IsWidget {
           globalAppState.refreshPage();
         }
       );
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.SynapseFooter,
         props,
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.CookieNotificationProps;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.SynapseNavDrawerProps;
 import org.sagebionetworks.web.client.place.Home;
@@ -110,7 +110,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
     CookieNotificationProps props = CookieNotificationProps.create(prefs -> {
       rerenderGoogleAnalytics();
     });
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CookiesNotification,
       props,
       propsProvider.getJsInteropContextProps()
@@ -125,7 +125,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
 
   private void rerenderGoogleAnalytics() {
     EmptyProps props = EmptyProps.create();
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.GoogleAnalytics,
       props,
       propsProvider.getJsInteropContextProps()
@@ -144,7 +144,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
         globalAppState.handleRelativePathClick(href);
       }
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapseNavDrawer,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.LoginPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.place.Profile;
 import org.sagebionetworks.web.client.place.Synapse.ProfileArea;
@@ -58,7 +58,7 @@ public class LoginWidgetViewImpl implements LoginWidgetView, IsWidget {
           null,
           () -> this.postLogin()
         );
-        ReactNode component = React.createElementWithSynapseContext(
+        ReactElement component = React.createElementWithSynapseContext(
           SRC.SynapseComponents.LoginPage,
           props,
           propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
@@ -10,7 +10,7 @@ import org.sagebionetworks.web.client.SynapseProperties;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.PageProgressProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -60,7 +60,7 @@ public class PageProgressWidgetViewImpl
       () -> forwardBtnCallback.invoke(),
       isForwardActive
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.PageProgress,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
@@ -28,7 +28,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.AccountLevelBadgesProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.UserProfileLinksProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -249,7 +249,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
 
   @Override
   public void setOwnerId(String userId) {
-    ReactNode accountLevelBadgesComponent =
+    ReactElement accountLevelBadgesComponent =
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.AccountLevelBadges,
         AccountLevelBadgesProps.create(userId),
@@ -259,7 +259,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
     setAccountTypeVisibility(Long.parseLong(userId));
 
     UserProfileLinksProps props = UserProfileLinksProps.create(userId);
-    ReactNode profileLinksComponent = React.createElementWithSynapseContext(
+    ReactElement profileLinksComponent = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserProfileLinks,
       props,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
@@ -8,7 +8,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps;
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps.OnUpdateJavaScriptObject;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -57,7 +57,7 @@ public class ProvenanceWidgetViewImpl
       nodesListener,
       edgesListener
     );
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ProvenanceGraph,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityAclEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class EntityAccessControlListModalWidgetImpl
@@ -54,7 +54,7 @@ public class EntityAccessControlListModalWidgetImpl
   }
 
   private void renderComponent() {
-    ReactNode node = React.createElementWithSynapseContext(
+    ReactElement node = React.createElementWithSynapseContext(
       EntityAclEditorModal,
       componentProps,
       propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/statistics/StatisticsPlotWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/statistics/StatisticsPlotWidgetViewImpl.java
@@ -96,7 +96,7 @@ public class StatisticsPlotWidgetViewImpl
 
 			var component = $wnd.React.createElement($wnd.SRC.SynapseComponents.StatisticsPlot, props, null)
 			var wrapper = $wnd.React.createElement($wnd.SRC.SynapseContext.FullContextProvider, wrapperProps, component)
-			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactNode;)(wrapper);
+			reactComponent.@org.sagebionetworks.web.client.widget.ReactComponent::render(Lorg/sagebionetworks/web/client/jsinterop/ReactElement;)(wrapper);
 		} catch (err) {
 			console.error(err);
 		}

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
@@ -6,7 +6,7 @@ import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQuery
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryResultBundleCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnViewSharingSettingsHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -30,7 +30,7 @@ public class QueryWrapperPlotNav extends ReactComponent {
       hideSqlEditorControl
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.QueryWrapperPlotNav,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.web.client.widget.table.explore;
 
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.StandaloneQueryWrapperProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -14,7 +14,7 @@ public class StandaloneQueryWrapper extends ReactComponent {
     String sql
   ) {
     StandaloneQueryWrapperProps props = StandaloneQueryWrapperProps.create(sql);
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.StandaloneQueryWrapper,
       props,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
@@ -6,7 +6,7 @@ import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateTableViewWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -29,12 +29,12 @@ public class CreateTableViewWizard implements IsWidget {
   }
 
   private void renderComponent(CreateTableViewWizardProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateTableViewWizard,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   public void configure(

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
@@ -19,7 +19,7 @@ import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQuery
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryResultBundleCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnViewSharingSettingsHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.FullWidthAlert;
@@ -188,7 +188,7 @@ public class TableEntityWidgetViewImpl
   public void setItemsEditorVisible(boolean visible) {
     itemsEditorContainer.setVisible(visible);
     if (visible) {
-      ReactNode component = React.createElementWithSynapseContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.DatasetItemsEditor,
         this.presenter.getItemsEditorProps(),
         propsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
@@ -4,7 +4,7 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.TableColumnSchemaEditorProps;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -27,12 +27,12 @@ public class ColumnModelsEditorWidgetViewImpl
 
   @Override
   public void renderComponent(TableColumnSchemaEditorProps props) {
-    ReactNode reactNode = React.createElementWithSynapseContext(
+    ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TableColumnSchemaEditor,
       props,
       propsProvider.getJsInteropContextProps()
     );
-    reactComponent.render(reactNode);
+    reactComponent.render(reactElement);
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.web.client.widget.trash;
 
 import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
@@ -11,7 +11,7 @@ public class TrashCanList extends ReactComponent {
   public TrashCanList(
     SynapseReactClientFullContextPropsProvider contextPropsProvider
   ) {
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TrashCanList,
       null,
       contextPropsProvider.getJsInteropContextProps()

--- a/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
@@ -23,7 +23,7 @@ import org.sagebionetworks.web.client.context.SynapseReactClientFullContextProps
 import org.sagebionetworks.web.client.jsinterop.JSON;
 import org.sagebionetworks.web.client.jsinterop.MenuAction;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactNode;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.jsinterop.UserCardProps;
 import org.sagebionetworks.web.client.place.Profile;
@@ -118,7 +118,7 @@ public class UserBadgeViewImpl extends Div implements UserBadgeView {
       extraCssClassStrings
     );
 
-    ReactNode component = React.createElementWithSynapseContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserCard,
       props,
       propsProvider.getJsInteropContextProps()


### PR DESCRIPTION
ReactElement describes the object explicitly returned by React.createElement, while ReactNode describes anything that React can render (including ReactElement). For our purposes, ReactElement is more appropriate to use.