### PR TITLE
PORTALS-3204: Use SynapseChat from SRC (when available)

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -17,6 +17,7 @@ import org.sagebionetworks.web.client.presenter.AccountPresenter;
 import org.sagebionetworks.web.client.presenter.BulkPresenterProxy;
 import org.sagebionetworks.web.client.presenter.ChallengeOverviewPresenter;
 import org.sagebionetworks.web.client.presenter.ChangeUsernamePresenter;
+import org.sagebionetworks.web.client.presenter.ChatPresenter;
 import org.sagebionetworks.web.client.presenter.ComingSoonPresenter;
 import org.sagebionetworks.web.client.presenter.DataAccessApprovalTokenPresenter;
 import org.sagebionetworks.web.client.presenter.DataAccessManagementPresenter;
@@ -896,4 +897,5 @@ public interface PortalGinInjector extends Ginjector {
   FeatureFlagConfig getFeatureFlagConfig();
 
   TrustCenterPresenter getTrustCenterPresenter();
+  ChatPresenter getChatPresenter();
 }

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -967,7 +967,7 @@ public class PortalGinModule extends AbstractGinModule {
       .in(Singleton.class);
     bind(IntendedDataUseReportWidgetView.class)
       .to(IntendedDataUseReportWidgetViewImpl.class);
-    bind(DialogView.class).to(Dialog.class);
+    bind(ChatView.class).to(ChatViewImpl.class);
 
     bind(FollowingPageView.class)
       .to(FollowingPageViewImpl.class)

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -967,6 +967,7 @@ public class PortalGinModule extends AbstractGinModule {
       .in(Singleton.class);
     bind(IntendedDataUseReportWidgetView.class)
       .to(IntendedDataUseReportWidgetViewImpl.class);
+    bind(DialogView.class).to(Dialog.class);
     bind(ChatView.class).to(ChatViewImpl.class);
 
     bind(FollowingPageView.class)

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -121,6 +121,7 @@ public class SRC {
     public static ReactComponentType<
       EntityAclEditorModalProps
     > EntityAclEditorModal;
+    public static ReactComponentType<SynapseChatProps> SynapseChat;
 
     /**
      * Pushes a global toast message. In SWC, you should use {@link DisplayUtils#notify}, rather than calling this method directly.

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseChatProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SynapseChatProps.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class SynapseChatProps extends ReactComponentProps {
+
+  @JsNullable
+  public String initialMessage;
+
+  @JsNullable
+  public String agentId;
+
+  @JsNullable
+  public String chatbotName;
+
+  @JsOverlay
+  public static SynapseChatProps create(
+    String initialMessage,
+    String agentId,
+    String chatbotName
+  ) {
+    SynapseChatProps props = new SynapseChatProps();
+    if (initialMessage != null) {
+      props.initialMessage = initialMessage;
+    }
+    if (agentId != null) {
+      props.agentId = agentId;
+    }
+    if (chatbotName != null) {
+      props.chatbotName = chatbotName;
+    }
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/mvp/AppPlaceHistoryMapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/mvp/AppPlaceHistoryMapper.java
@@ -11,6 +11,7 @@ import org.sagebionetworks.web.client.place.AccessRequirementsPlace;
 import org.sagebionetworks.web.client.place.Account;
 import org.sagebionetworks.web.client.place.Challenges;
 import org.sagebionetworks.web.client.place.ChangeUsername;
+import org.sagebionetworks.web.client.place.ChatPlace;
 import org.sagebionetworks.web.client.place.ComingSoon;
 import org.sagebionetworks.web.client.place.DataAccessApprovalTokenPlace;
 import org.sagebionetworks.web.client.place.DataAccessManagementPlace;
@@ -98,6 +99,7 @@ import org.sagebionetworks.web.client.place.users.RegisterAccount;
     TwoFactorAuthPlace.Tokenizer.class,
     FollowingPlace.Tokenizer.class,
     TrustCenterPlace.Tokenizer.class,
+    ChatPlace.Tokenizer.class,
   }
 )
 public interface AppPlaceHistoryMapper extends PlaceHistoryMapper {}

--- a/src/main/java/org/sagebionetworks/web/client/place/ChatPlace.java
+++ b/src/main/java/org/sagebionetworks/web/client/place/ChatPlace.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.web.client.place;
+
+import com.google.gwt.place.shared.PlaceTokenizer;
+import com.google.gwt.place.shared.Prefix;
+
+public class ChatPlace extends ParameterizedPlace {
+
+  public static final String INITIAL_MESSAGE = "initalMessage";
+  public static final String AGENT_ID = "agentId";
+  public static final String CHATBOT_NAME = "chatbotName";
+
+  public ChatPlace(String token) {
+    super(token);
+  }
+
+  @Prefix("Chat")
+  public static class Tokenizer implements PlaceTokenizer<ChatPlace> {
+
+    @Override
+    public String getToken(ChatPlace place) {
+      return place.toToken();
+    }
+
+    @Override
+    public ChatPlace getPlace(String token) {
+      return new ChatPlace(token);
+    }
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/place/ChatPlace.java
+++ b/src/main/java/org/sagebionetworks/web/client/place/ChatPlace.java
@@ -5,7 +5,7 @@ import com.google.gwt.place.shared.Prefix;
 
 public class ChatPlace extends ParameterizedPlace {
 
-  public static final String INITIAL_MESSAGE = "initalMessage";
+  public static final String INITIAL_MESSAGE = "initialMessage";
   public static final String AGENT_ID = "agentId";
   public static final String CHATBOT_NAME = "chatbotName";
 

--- a/src/main/java/org/sagebionetworks/web/client/presenter/BulkPresenterProxy.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/BulkPresenterProxy.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.web.client.place.AccessRequirementsPlace;
 import org.sagebionetworks.web.client.place.Account;
 import org.sagebionetworks.web.client.place.Challenges;
 import org.sagebionetworks.web.client.place.ChangeUsername;
+import org.sagebionetworks.web.client.place.ChatPlace;
 import org.sagebionetworks.web.client.place.ComingSoon;
 import org.sagebionetworks.web.client.place.DataAccessApprovalTokenPlace;
 import org.sagebionetworks.web.client.place.DataAccessManagementPlace;
@@ -880,6 +881,23 @@ public class BulkPresenterProxy extends AbstractActivity {
             TrustCenterPresenter presenter =
               ginjector.getTrustCenterPresenter();
             presenter.setPlace((TrustCenterPlace) place);
+            presenter.start(panel, eventBus);
+          }
+
+          @Override
+          public void onFailure(Throwable caught) {
+            loadError(caught);
+          }
+        }
+      );
+    } else if (place instanceof ChatPlace) {
+      GWT.runAsync(
+        ChatPlace.class,
+        new RunAsyncCallback() {
+          @Override
+          public void onSuccess() {
+            ChatPresenter presenter = ginjector.getChatPresenter();
+            presenter.setPlace((ChatPlace) place);
             presenter.start(panel, eventBus);
           }
 

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ChatPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ChatPresenter.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.web.client.presenter;
+
+import com.google.gwt.activity.shared.AbstractActivity;
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import com.google.inject.Inject;
+import org.sagebionetworks.web.client.place.ChatPlace;
+import org.sagebionetworks.web.client.view.ChatView;
+
+public class ChatPresenter
+  extends AbstractActivity
+  implements Presenter<ChatPlace> {
+
+  private ChatPlace place;
+  private ChatView view;
+
+  @Inject
+  public ChatPresenter(ChatView view) {
+    this.view = view;
+    view.scrollToTop();
+  }
+
+  @Override
+  public void start(AcceptsOneWidget panel, EventBus eventBus) {
+    // Install the view
+    panel.setWidget(view);
+  }
+
+  @Override
+  public void setPlace(ChatPlace place) {
+    this.place = place;
+    String initialMessage = place.getParam(ChatPlace.INITIAL_MESSAGE);
+    String agentId = place.getParam(ChatPlace.AGENT_ID);
+    String chatbotName = place.getParam(ChatPlace.CHATBOT_NAME);
+
+    view.render(initialMessage, agentId, chatbotName);
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/view/ChatView.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ChatView.java
@@ -1,0 +1,8 @@
+package org.sagebionetworks.web.client.view;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface ChatView extends IsWidget {
+  void render(String initMessage, String agentId, String chatbotName);
+  void scrollToTop();
+}

--- a/src/main/java/org/sagebionetworks/web/client/view/ChatViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ChatViewImpl.java
@@ -1,0 +1,61 @@
+package org.sagebionetworks.web.client.view;
+
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.inject.Inject;
+import org.sagebionetworks.web.client.GlobalApplicationState;
+import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.jsinterop.SynapseChatProps;
+import org.sagebionetworks.web.client.jsinterop.SynapseHomepageV2Props;
+import org.sagebionetworks.web.client.widget.ReactComponent;
+import org.sagebionetworks.web.client.widget.header.Header;
+
+public class ChatViewImpl extends Composite implements ChatView {
+
+  ReactComponent container;
+
+  private Header headerWidget;
+  private SynapseReactClientFullContextPropsProvider propsProvider;
+  private GlobalApplicationState globalAppState;
+
+  @Inject
+  public ChatViewImpl(
+    Header headerWidget,
+    final SynapseReactClientFullContextPropsProvider propsProvider,
+    GlobalApplicationState globalAppState
+  ) {
+    this.headerWidget = headerWidget;
+    this.propsProvider = propsProvider;
+    this.globalAppState = globalAppState;
+    headerWidget.configure();
+    container = new ReactComponent();
+    initWidget(container);
+  }
+
+  @Override
+  public void render(String initMessage, String agentId, String chatbotName) {
+    headerWidget.configure();
+    headerWidget.refresh();
+    scrollToTop();
+    SynapseChatProps props = SynapseChatProps.create(
+      initMessage,
+      agentId,
+      chatbotName
+    );
+    ReactElement component = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.SynapseChat,
+      props,
+      propsProvider.getJsInteropContextProps()
+    );
+
+    container.render(component);
+  }
+
+  @Override
+  public void scrollToTop() {
+    Window.scrollTo(0, 0);
+  }
+}


### PR DESCRIPTION
Notes: Chat place is not in the open places set, so will prompt for login.
Chat place uses a parameterized token, so we can extend to support other agent IDs later if we want (and chatbot names).
Since these services are not currently available, this component will never load properly (we only get it to load by using mock service responses).  With this code, hopefully we will not need to update SWC for this again (other than updating the SRC version!)