### PR TITLE
Add job summary

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,10 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.PLATFORM_ARTIFACTORY_USER }}
           MAVEN_USERPWD: ${{ secrets.PLATFORM_ARTIFACTORY_PWD }}
 
+      - name: setup-job-summary
+        run: |
+          echo "| version | ${{ env.pomversion }} |" > $GITHUB_STEP_SUMMARY
+
   call-test:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This PR adds a job summary which should make the artifact version visible without having to dig in the job output.

See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary for more details about job summaries.
