### PR TITLE
SWC-7131 - workaround - do not render components that are not visible

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
@@ -199,6 +199,8 @@ public abstract class ReactComponentV2<
 
       return childWidgets
         .stream()
+        // SWC-7131: Visibility via style: {display: "none"} may not work in production
+        .filter(ReactComponentV2::isVisible)
         .map(ReactComponentV2::createReactElement)
         .toArray(ReactElement<?, ?>[]::new);
     } else {


### PR DESCRIPTION
The bug occurs when we hide the visibility of a ReactComponentV2 widget containing a GWT widget inside of another ReactComponentV2 widget, but only when using the React production build. In both the React production and the development build, the ReactElement does have the expected `style` prop with `display: "none"`, but the DOM node does not get the inline style in production mode.

I could not find a related bug in the React issue tracker.

As a workaround, we can simply omit rendering elements that are not visible. One risk of this approach is that any element state will be reset when the visibility is toggled.