### PR TITLE
SWC-7165 - Widen Show more results button on project mobile page

### DIFF
--- a/src/main/resources/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainerViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/LoadMoreWidgetContainerViewImpl.ui.xml
@@ -8,7 +8,11 @@
   <bh:Div marginBottom="5" width="100%">
     <bh:Div ui:field="container" />
     <bh:ClearFix />
-    <b:Button ui:field="loadMoreButton" text="Show more results" />
+    <b:Button
+      ui:field="loadMoreButton"
+      text="Show more results"
+      addStyleNames="btn-default-wide"
+    />
     <w:LoadingSpinner
       ui:field="loadMoreImage"
       size="31px"

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -422,6 +422,12 @@ end sticky footer
     color: $synapse-dark-text;
   }
 
+  @media (max-width: 500px) {
+    .btn-default-wide {
+      width: 100%;
+    }
+  }
+
   .btn {
     @include border-radius(2px);
     font-weight: bold;

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -422,7 +422,7 @@ end sticky footer
     color: $synapse-dark-text;
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: 768px) {
     .btn-default-wide {
       width: 100%;
     }


### PR DESCRIPTION
SWD-7165 Create a new scss class `btn-default-wide` to make the button span the width of the container on mobile. Apply this style to the LoadMoreWidgetContainerView