### PR TITLE
SWC-6754

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/PortalServletModule.java
+++ b/src/main/java/org/sagebionetworks/web/server/PortalServletModule.java
@@ -43,7 +43,11 @@ import org.sagebionetworks.web.server.servlet.LinkedInServiceImpl;
 import org.sagebionetworks.web.server.servlet.ProjectAliasServlet;
 import org.sagebionetworks.web.server.servlet.SlackServlet;
 import org.sagebionetworks.web.server.servlet.StackConfigServiceImpl;
+import org.sagebionetworks.web.server.servlet.StackVersionProvider;
+import org.sagebionetworks.web.server.servlet.StackVersionProviderImpl;
 import org.sagebionetworks.web.server.servlet.SynapseClientImpl;
+import org.sagebionetworks.web.server.servlet.SynapseProvider;
+import org.sagebionetworks.web.server.servlet.SynapseProviderImpl;
 import org.sagebionetworks.web.server.servlet.UserAccountServiceImpl;
 import org.sagebionetworks.web.server.servlet.UserProfileClientImpl;
 import org.sagebionetworks.web.server.servlet.VersionsServlet;
@@ -202,6 +206,10 @@ public class PortalServletModule extends ServletModule {
     bind(ConfigurationProperties.class).to(ConfigurationPropertiesImpl.class);
     bind(StackConfiguration.class).to(StackConfigurationImpl.class);
     bind(StackEncrypter.class).to(StackEncrypterImpl.class);
+    bind(SynapseProvider.class).to(SynapseProviderImpl.class);
+    bind(StackVersionProvider.class)
+      .to(StackVersionProviderImpl.class)
+      .in(Singleton.class);
 
     // JSONObjectAdapter
     bind(JSONObjectAdapter.class).to(JSONObjectAdapterImpl.class);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/StackVersionProvider.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/StackVersionProvider.java
@@ -1,0 +1,7 @@
+package org.sagebionetworks.web.server.servlet;
+
+import org.sagebionetworks.web.shared.exceptions.RestServiceException;
+
+public interface StackVersionProvider {
+  String get(String httpRequestHost) throws RestServiceException;
+}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/StackVersionProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/StackVersionProviderImpl.java
@@ -1,0 +1,67 @@
+package org.sagebionetworks.web.server.servlet;
+
+import com.google.gwt.thirdparty.guava.common.cache.CacheBuilder;
+import com.google.gwt.thirdparty.guava.common.cache.CacheLoader;
+import com.google.gwt.thirdparty.guava.common.cache.LoadingCache;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
+import org.sagebionetworks.web.shared.exceptions.RestServiceException;
+
+public class StackVersionProviderImpl implements StackVersionProvider {
+
+  private static Log log = LogFactory.getLog(StackVersionProviderImpl.class);
+
+  private final SynapseProvider synapseProvider;
+
+  @Inject
+  public StackVersionProviderImpl(SynapseProvider synapseProvider) {
+    this.synapseProvider = synapseProvider;
+  }
+
+  private final CacheLoader<String, SynapseVersionInfo> versionCacheLoader =
+    new CacheLoader<>() {
+      @Override
+      public SynapseVersionInfo load(String requestHost) {
+        try {
+          SynapseClient synapseClient = synapseProvider.createNewClient(
+            requestHost
+          );
+          return synapseClient.getVersionInfo();
+        } catch (SynapseException e) {
+          log.error(e);
+          return null;
+        }
+      }
+    };
+
+  private final LoadingCache<String, SynapseVersionInfo> synapseVersionCache =
+    CacheBuilder
+      .newBuilder()
+      .maximumSize(50)
+      .expireAfterWrite(5, TimeUnit.MINUTES)
+      .build(versionCacheLoader);
+
+  private SynapseVersionInfo getSynapseVersionInfo(String httpRequestHost) {
+    try {
+      return synapseVersionCache.get(httpRequestHost);
+    } catch (ExecutionException e) {
+      log.error(e);
+      return null;
+    }
+  }
+
+  @Override
+  public String get(String httpRequestHost) throws RestServiceException {
+    return (
+      SynapseClientImpl.PortalVersionHolder.getVersionInfo() +
+      "," +
+      getSynapseVersionInfo(httpRequestHost).getVersion()
+    );
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/VersionsServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/VersionsServlet.java
@@ -1,23 +1,13 @@
 package org.sagebionetworks.web.server.servlet;
 
-import com.google.gwt.thirdparty.guava.common.base.Supplier;
-import com.google.gwt.thirdparty.guava.common.base.Suppliers;
 import java.io.IOException;
 import java.net.URLEncoder;
-import java.util.concurrent.TimeUnit;
+import java.nio.charset.StandardCharsets;
+import javax.inject.Inject;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.sagebionetworks.client.SynapseClient;
-import org.sagebionetworks.client.exceptions.SynapseException;
-import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
-import org.sagebionetworks.web.server.StackEndpoints;
-import org.sagebionetworks.web.server.servlet.SynapseClientImpl.PortalVersionHolder;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.shared.exceptions.RestServiceException;
 
@@ -26,65 +16,14 @@ import org.sagebionetworks.web.shared.exceptions.RestServiceException;
  */
 public class VersionsServlet extends HttpServlet {
 
-  private static Log log = LogFactory.getLog(VersionsServlet.class);
+  private final StackVersionProvider stackVersionProvider;
+
+  @Inject
+  public VersionsServlet(StackVersionProvider stackVersionProvider) {
+    this.stackVersionProvider = stackVersionProvider;
+  }
+
   private static final long serialVersionUID = 1L;
-  protected static final ThreadLocal<HttpServletRequest> perThreadRequest =
-    new ThreadLocal<HttpServletRequest>();
-  private final RequestHostProvider requestHostProvider = () ->
-    UserDataProvider.getThreadLocalRequestHost(
-      VersionsServlet.perThreadRequest.get()
-    );
-
-  private final Supplier<SynapseVersionInfo> synapseVersionCache =
-    Suppliers.memoizeWithExpiration(versionSupplier(), 5, TimeUnit.MINUTES);
-
-  public SynapseVersionInfo getSynapseVersionInfo() {
-    return synapseVersionCache.get();
-  }
-
-  private SynapseProvider synapseProvider = new SynapseProviderImpl();
-
-  private SynapseClient createNewClient() {
-    return synapseProvider.createNewClient(
-      this.requestHostProvider.getRequestHost()
-    );
-  }
-
-  private Supplier<SynapseVersionInfo> versionSupplier() {
-    return new Supplier<SynapseVersionInfo>() {
-      public SynapseVersionInfo get() {
-        try {
-          org.sagebionetworks.client.SynapseClient synapseClient =
-            createNewClient();
-          return synapseClient.getVersionInfo();
-        } catch (SynapseException e) {
-          log.error(e);
-          return null;
-        }
-      }
-    };
-  }
-
-  public String getSynapseVersions() throws RestServiceException {
-    return (
-      PortalVersionHolder.getVersionInfo() +
-      "," +
-      getSynapseVersionInfo().getVersion()
-    );
-  }
-
-  @Override
-  protected void service(HttpServletRequest arg0, HttpServletResponse arg1)
-    throws ServletException, IOException {
-    VersionsServlet.perThreadRequest.set(arg0);
-    super.service(arg0, arg1);
-  }
-
-  @Override
-  public void service(ServletRequest arg0, ServletResponse arg1)
-    throws ServletException, IOException {
-    super.service(arg0, arg1);
-  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -101,7 +40,13 @@ public class VersionsServlet extends HttpServlet {
     response.setStatus(HttpServletResponse.SC_OK);
 
     try {
-      response.getOutputStream().write(getSynapseVersions().getBytes("UTF-8"));
+      response
+        .getOutputStream()
+        .write(
+          stackVersionProvider
+            .get(UserDataProvider.getThreadLocalRequestHost(request))
+            .getBytes(StandardCharsets.UTF_8)
+        );
       response.getOutputStream().flush();
     } catch (RestServiceException e) {
       // redirect to error place with an entry

--- a/src/test/java/org/sagebionetworks/web/server/servlet/StackVersionProviderImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/server/servlet/StackVersionProviderImplTest.java
@@ -1,0 +1,72 @@
+package org.sagebionetworks.web.server.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
+import org.sagebionetworks.web.shared.exceptions.RestServiceException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StackVersionProviderImplTest {
+
+  @Mock
+  SynapseProvider mockSynapseProvider;
+
+  @Mock
+  SynapseClient mockProdSynapseClient;
+
+  @Mock
+  SynapseClient mockStagingSynapseClient;
+
+  @Mock
+  SynapseVersionInfo mockSynapseVersionInfo;
+
+  StackVersionProviderImpl stackVersionProviderImpl;
+
+  @Before
+  public void setUp() throws SynapseException {
+    when(mockSynapseProvider.createNewClient("www.synapse.org"))
+      .thenReturn(mockProdSynapseClient);
+    when(mockSynapseProvider.createNewClient("staging.synapse.org"))
+      .thenReturn(mockStagingSynapseClient);
+    when(mockProdSynapseClient.getVersionInfo())
+      .thenReturn(mockSynapseVersionInfo);
+    when(mockStagingSynapseClient.getVersionInfo())
+      .thenReturn(mockSynapseVersionInfo);
+    when(mockSynapseVersionInfo.getVersion()).thenReturn("mockSynapseVersion");
+
+    stackVersionProviderImpl =
+      new StackVersionProviderImpl(mockSynapseProvider);
+  }
+
+  @Test
+  public void testGetVersion() throws RestServiceException, SynapseException {
+    String result = stackVersionProviderImpl.get("www.synapse.org");
+    assertEquals("develop-SNAPSHOT,mockSynapseVersion", result);
+
+    verify(mockSynapseProvider).createNewClient("www.synapse.org");
+    verify(mockProdSynapseClient).getVersionInfo();
+
+    // Call again, make sure cache is used
+    stackVersionProviderImpl.get("www.synapse.org");
+
+    verify(mockSynapseProvider, times(1)).createNewClient("www.synapse.org");
+    verify(mockProdSynapseClient, times(1)).getVersionInfo();
+
+    // Call again with a different origin, cache should NOT be used
+    stackVersionProviderImpl.get("staging.synapse.org");
+
+    verify(mockSynapseProvider, times(1))
+      .createNewClient("staging.synapse.org");
+    verify(mockStagingSynapseClient, times(1)).getVersionInfo();
+  }
+}


### PR DESCRIPTION
SWC-6754

- VersionsServlet cache now uses request origin as a cache key, preventing cache poisoning.
- Use DI, introduce StackVersionProvider to improve testability