### PR TITLE
IT-3849: Change endpoint for onesage

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/OneSageUtilsImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/OneSageUtilsImpl.java
@@ -20,8 +20,8 @@ public class OneSageUtilsImpl implements OneSageUtils {
     switch (gwtWrapper.getHostName().toLowerCase()) {
       case "staging.synapse.org":
         return "https://staging.accounts.synapse.org";
-      case "portal-dev.dev.sagebase.org":
-        return "https://accounts-dev.dev.sagebase.org";
+      case "dev.synapse.org":
+        return "https://dev.accounts.synapse.org";
       case "localhost":
       case "127.0.0.1":
         return "http://" + Window.Location.getHostName() + ":3000";
@@ -34,7 +34,7 @@ public class OneSageUtilsImpl implements OneSageUtils {
     switch (gwtWrapper.getHostName().toLowerCase()) {
       case "staging.synapse.org":
         return "staging.synapse.org";
-      case "portal-dev.dev.sagebase.org":
+      case "dev.synapse.org":
         return "dev.synapse.org";
       case "localhost":
       case "127.0.0.1":


### PR DESCRIPTION
These are the proposed changes to make the Synapse dev portal work at https://dev.synapse.org and the accounts dev endpoint at https://dev.accounts.synapse.org. 

Don't merge, needs redeploy of portal stack and some DNS changes.