### PR TITLE
IT-3849: Missed refs to portal hostname

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/StackEndpoints.java
+++ b/src/main/java/org/sagebionetworks/web/server/StackEndpoints.java
@@ -8,7 +8,7 @@ public class StackEndpoints {
 
   public static final String STAGING_SYNAPSE_ORG = "staging.synapse.org";
   public static final String TST_SYNAPSE_ORG = "tst.synapse.org";
-  public static final String PORTAL_DEV_HOST = "portal-dev.dev.sagebase.org";
+  public static final String PORTAL_DEV_HOST = "dev.synapse.org";
   private static Logger logger = Logger.getLogger(
     StackEndpoints.class.getName()
   );

--- a/src/test/java/org/sagebionetworks/web/unitserver/StackEndpointsTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/StackEndpointsTest.java
@@ -125,7 +125,7 @@ public class StackEndpointsTest {
 
   @Test
   public void testEndpointConstructionDev() {
-    String requestHostName = "portal-dev.dev.sagebase.org";
+    String requestHostName = "dev.synapse.org";
     String expected = "https://repo-dev.dev.sagebase.org";
 
     assertEquals(


### PR DESCRIPTION
Noticed in browser that we were still talking to old endpoint so looked for refs in the code.