### PR TITLE
SWC-7300

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
@@ -15,6 +15,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 public class CORSFilter extends OncePerRequestFilter {
 
+  public static final String HOST_HEADER = "Host";
   public static final String ORIGIN_HEADER = "origin";
   public static final String DEFAULT_ALLOW_ORIGIN = "*";
   public static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER =

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.server.servlet.filter;
 
 import static org.sagebionetworks.web.server.StackEndpoints.IS_DEV_MODE;
+import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.HOST_HEADER;
 
 import com.google.gwt.safehtml.shared.SimpleHtmlSanitizer;
 import com.google.inject.Inject;
@@ -108,8 +109,8 @@ public class HtmlInjectionFilter extends OncePerRequestFilter {
   // that Vite generates.
   public static final List<String> VITE_IMPORTED_FILES = List.of("js/main.js");
 
-  Pattern CDN_ORIGINS_REGEX = Pattern.compile(
-    "https?://((www|staging|tst)\\.synapse\\.org)$"
+  Pattern CDN_HOSTS_REGEX = Pattern.compile(
+    "^(www|staging|tst)\\.synapse\\.org$"
   );
 
   public static final String META_ROBOTS_NOINDEX =
@@ -191,12 +192,11 @@ public class HtmlInjectionFilter extends OncePerRequestFilter {
     Map<String, String> dataModel,
     HttpServletRequest request
   ) {
-    String origin = request.getHeader("origin");
-    if (origin != null) {
-      Matcher matcher = CDN_ORIGINS_REGEX.matcher(origin);
+    String host = request.getHeader(HOST_HEADER);
+    if (host != null) {
+      Matcher matcher = CDN_HOSTS_REGEX.matcher(host);
       if (matcher.matches()) {
-        String hostnameAndPort = matcher.group(1);
-        dataModel.put(CDN_ENDPOINT_KEY, "//cdn-" + hostnameAndPort);
+        dataModel.put(CDN_ENDPOINT_KEY, "//cdn-" + host);
         return;
       }
     }

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/HtmlInjectionFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/HtmlInjectionFilterTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.web.server.StackEndpoints.IS_DEV_MODE;
+import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.HOST_HEADER;
 import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.ORIGIN_HEADER;
 import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.SYNAPSE_ORG_SUFFIX;
 import static org.sagebionetworks.web.server.servlet.filter.CrawlFilter.META_ROBOTS_NOINDEX;
@@ -189,8 +190,8 @@ public class HtmlInjectionFilterTest {
     filter.init(pageTitleTemplate, mockCrawlFilter);
     when(mockSynapseProvider.createNewClient()).thenReturn(mockSynapseClient);
     filter.setSynapseProvider(mockSynapseProvider);
-    when(mockRequest.getHeader(ORIGIN_HEADER))
-      .thenReturn("https://www" + SYNAPSE_ORG_SUFFIX);
+    when(mockRequest.getHeader(HOST_HEADER))
+      .thenReturn("www" + SYNAPSE_ORG_SUFFIX);
     when(mockRequest.getServerName()).thenReturn("www" + SYNAPSE_ORG_SUFFIX);
     when(mockRequest.getScheme()).thenReturn("https");
     when(
@@ -548,7 +549,7 @@ public class HtmlInjectionFilterTest {
     );
 
     setRequestURL("https://www.synapse.org/");
-    when(mockRequest.getHeader("origin")).thenReturn("https://www.synapse.org");
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn("www.synapse.org");
 
     filter.init(template, mockCrawlFilter);
 
@@ -567,8 +568,7 @@ public class HtmlInjectionFilterTest {
     );
 
     setRequestURL("https://staging.synapse.org/");
-    when(mockRequest.getHeader("origin"))
-      .thenReturn("https://staging.synapse.org");
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn("staging.synapse.org");
 
     filter.init(template, mockCrawlFilter);
 
@@ -587,7 +587,7 @@ public class HtmlInjectionFilterTest {
     );
 
     setRequestURL("https://tst.synapse.org/");
-    when(mockRequest.getHeader("origin")).thenReturn("https://tst.synapse.org");
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn("tst.synapse.org");
 
     filter.init(template, mockCrawlFilter);
 
@@ -606,7 +606,7 @@ public class HtmlInjectionFilterTest {
     );
 
     setRequestURL("https://localhost:8888/");
-    when(mockRequest.getHeader("origin")).thenReturn("https://localhost:8888");
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn("localhost:8888");
 
     filter.init(template, mockCrawlFilter);
 


### PR DESCRIPTION
Use the `Host` header to determine whether the CDN should be used. The `Origin` header is not sent to same-origin GET requests, so it cannot be relied on for this purpose.