### PR TITLE
SWC-7313

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-plotly.js": "^2.6.0",
     "sass": "^1.63.6",
     "spark-md5": "^3.0.2",
-    "synapse-react-client": "3.4.14",
+    "synapse-react-client": "3.4.15",
     "universal-cookie": "^4.0.4",
     "xss": "^1.0.15"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       synapse-react-client:
-        specifier: 3.4.14
-        version: 3.4.14(@types/react@17.0.83)(csstype@3.1.3)(date-fns@2.30.0)(mapbox-gl@1.13.3)(moment@2.30.1)(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.4.15
+        version: 3.4.15(@types/react@17.0.83)(csstype@3.1.3)(date-fns@2.30.0)(mapbox-gl@1.13.3)(moment@2.30.1)(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       universal-cookie:
         specifier: ^4.0.4
         version: 4.0.4
@@ -4612,8 +4612,8 @@ packages:
   svg-path-sdf@1.1.3:
     resolution: {integrity: sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==}
 
-  synapse-react-client@3.4.14:
-    resolution: {integrity: sha512-AK1lNUKJWXfUdOoqpqBljTOZR8SsrK5vfGosprI/KQrsLkWQeW50UMwNBSovqqDMtI1Uj+eqkZlNnkR7KOl3xA==}
+  synapse-react-client@3.4.15:
+    resolution: {integrity: sha512-d91vzr9P1O04UtuYxcThCpZJUz1Klh/eRxd00OjNygJMDGEesl2I1nprfoc8JQrRBvxoDpNLvXPA9MG9aAetNA==}
     peerDependencies:
       react: 18.2.0
       react-dom: 18.2.0
@@ -10484,7 +10484,7 @@ snapshots:
       parse-svg-path: 0.1.2
       svg-path-bounds: 1.0.2
 
-  synapse-react-client@3.4.14(@types/react@17.0.83)(csstype@3.1.3)(date-fns@2.30.0)(mapbox-gl@1.13.3)(moment@2.30.1)(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  synapse-react-client@3.4.15(@types/react@17.0.83)(csstype@3.1.3)(date-fns@2.30.0)(mapbox-gl@1.13.3)(moment@2.30.1)(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
       '@aws-sdk/client-s3': 3.758.0


### PR DESCRIPTION
[SWC-7313](https://sagebionetworks.jira.com/browse/SWC-7313)

upgrade synapse-react-client to v3.4.15

[SWC-7313]: https://sagebionetworks.jira.com/browse/SWC-7313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ