### PR TITLE
SWC-7311

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientBase.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientBase.java
@@ -134,11 +134,10 @@ public class SynapseClientBase
     synapseClient.appendUserAgent(PORTAL_USER_AGENT);
     if (this.getThreadLocalRequest() != null) {
       // SWC-7311 - Do not add the user IP address (X-Forwarded-For header) if the request is made to a local instance
-      if (
-        !LOCAL_HOSTS_REGEX
-          .matcher(this.getThreadLocalRequest().getHeader(HOST_HEADER))
-          .matches()
-      ) {
+      String host = this.getThreadLocalRequest().getHeader(HOST_HEADER);
+      boolean isRequestToLocalIp =
+        host != null && LOCAL_HOSTS_REGEX.matcher(host).matches();
+      if (!isRequestToLocalIp) {
         synapseClient.setUserIpAddress(
           getIpAddress(this.getThreadLocalRequest())
         );

--- a/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientBase.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/SynapseClientBase.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.web.server.servlet;
 
+import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.HOST_HEADER;
+
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 import com.google.gwt.user.server.rpc.SerializationPolicy;
 import java.io.IOException;
@@ -7,10 +9,10 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import org.sagebionetworks.schema.adapter.AdapterFactory;
 import org.sagebionetworks.schema.adapter.org.json.AdapterFactoryImpl;
-import org.sagebionetworks.web.server.StackEndpoints;
 
 @SuppressWarnings("serial")
 public class SynapseClientBase
@@ -22,6 +24,10 @@ public class SynapseClientBase
     "Synapse-Web-Client/" + PortalVersionHolder.getVersionInfo();
 
   public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+  Pattern LOCAL_HOSTS_REGEX = Pattern.compile(
+    "^(localhost|127\\.0\\.0\\.1)(:\\d+)?$"
+  );
 
   private static class PortalVersionHolder {
 
@@ -127,9 +133,16 @@ public class SynapseClientBase
     // Append the portal's version information to the user agent.
     synapseClient.appendUserAgent(PORTAL_USER_AGENT);
     if (this.getThreadLocalRequest() != null) {
-      synapseClient.setUserIpAddress(
-        getIpAddress(this.getThreadLocalRequest())
-      );
+      // SWC-7311 - Do not add the user IP address (X-Forwarded-For header) if the request is made to a local instance
+      if (
+        !LOCAL_HOSTS_REGEX
+          .matcher(this.getThreadLocalRequest().getHeader(HOST_HEADER))
+          .matches()
+      ) {
+        synapseClient.setUserIpAddress(
+          getIpAddress(this.getThreadLocalRequest())
+        );
+      }
     }
     return synapseClient;
   }

--- a/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientBaseTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/SynapseClientBaseTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.HOST_HEADER;
 
 import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
@@ -36,7 +37,7 @@ public class SynapseClientBaseTest {
   HttpServletRequest mockRequest;
 
   String userIp = "127.0.0.1";
-  String requestHost = "www.synapse.org";
+  String prodRequestHost = "www.synapse.org";
   public static final String ENDPOINT_PREFIX =
     "https://repo-test.prod.sagebase.org";
   public static final String FILE_BASE = ENDPOINT_PREFIX + "/file/v1";
@@ -69,6 +70,7 @@ public class SynapseClientBaseTest {
     userIp = "127.0.0.1";
     when(mockThreadLocal.get()).thenReturn(mockRequest);
     when(mockRequest.getRemoteAddr()).thenReturn(userIp);
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn(prodRequestHost);
     SynapseClientBaseTest.setupTestEndpoints();
   }
 
@@ -76,7 +78,7 @@ public class SynapseClientBaseTest {
   public void testCreateSynapseClient() {
     String sessionToken = "fakeSessionToken";
     SynapseClient createdClient = synapseClientBase.createSynapseClient(
-      requestHost,
+      prodRequestHost,
       sessionToken
     );
     assertEquals(mockSynapseClient, createdClient);
@@ -87,11 +89,59 @@ public class SynapseClientBaseTest {
   }
 
   @Test
+  public void testRequestToLocalIp() {
+    String localIp = "127.0.0.1";
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn(localIp);
+    String sessionToken = "fakeSessionToken";
+    SynapseClient createdClient = synapseClientBase.createSynapseClient(
+      localIp,
+      sessionToken
+    );
+    verify(mockSynapseClient, never()).setUserIpAddress(anyString());
+  }
+
+  @Test
+  public void testRequestToLocalIpWithPort() {
+    String localIpWithPort = "127.0.0.1:8888";
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn(localIpWithPort);
+    String sessionToken = "fakeSessionToken";
+    SynapseClient createdClient = synapseClientBase.createSynapseClient(
+      localIpWithPort,
+      sessionToken
+    );
+    verify(mockSynapseClient, never()).setUserIpAddress(anyString());
+  }
+
+  @Test
+  public void testRequestToLocalhost() {
+    String localhost = "localhost";
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn(localhost);
+    String sessionToken = "fakeSessionToken";
+    SynapseClient createdClient = synapseClientBase.createSynapseClient(
+      localhost,
+      sessionToken
+    );
+    verify(mockSynapseClient, never()).setUserIpAddress(anyString());
+  }
+
+  @Test
+  public void testRequestToLocalhostWithPort() {
+    String localhostWithPort = "localhost:8888";
+    when(mockRequest.getHeader(HOST_HEADER)).thenReturn(localhostWithPort);
+    String sessionToken = "fakeSessionToken";
+    SynapseClient createdClient = synapseClientBase.createSynapseClient(
+      localhostWithPort,
+      sessionToken
+    );
+    verify(mockSynapseClient, never()).setUserIpAddress(anyString());
+  }
+
+  @Test
   public void testNullThreadLocalRequest() {
     when(mockThreadLocal.get()).thenReturn(null);
     String sessionToken = "fakeSessionToken";
     SynapseClient createdClient = synapseClientBase.createSynapseClient(
-      requestHost,
+      prodRequestHost,
       sessionToken
     );
     verify(mockSynapseClient, never()).setUserIpAddress(userIp);


### PR DESCRIPTION
When the request is made to a local IP address, do not append X-Forwarded-For

X-Forwarded-For is used in this context to tell the server the IP of the original requester (for warehouse statistics, potentially rate-limiting).

The implementation of the georestriction filter (PLFM-8923) also happens to filter against unrecognized X-Forwarded-For IPs. When the application is deployed to a Docker container, requests appear to come from an unrecognized IP. Since we currently only use containers for local development, do not add the X-Forwarded-For header when the request host is a local IP.