### PR TITLE
SWC-7390 - Fix Vite dynamic imports, add dynamic CDN redirect

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/PortalServletModule.java
+++ b/src/main/java/org/sagebionetworks/web/server/PortalServletModule.java
@@ -29,6 +29,7 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
 import org.sagebionetworks.web.server.servlet.AliasRedirectorServlet;
 import org.sagebionetworks.web.server.servlet.AppConfigServlet;
+import org.sagebionetworks.web.server.servlet.CdnRedirectorServlet;
 import org.sagebionetworks.web.server.servlet.ChallengeClientImpl;
 import org.sagebionetworks.web.server.servlet.DataAccessClientImpl;
 import org.sagebionetworks.web.server.servlet.DiscussionForumClientImpl;
@@ -197,6 +198,11 @@ public class PortalServletModule extends ServletModule {
     // Setup the File Uploader JNLP mapping
     bind(FileUploaderJnlp.class).in(Singleton.class);
     serve("/Portal/fileUploaderJnlp").with(FileUploaderJnlp.class);
+
+    // Redirector to CDN
+    bind(CdnRedirectorServlet.class).in(Singleton.class);
+    serve("/Portal/" + WebConstants.CDN_REDIRECTOR_SERVLET + "/*")
+      .with(CdnRedirectorServlet.class);
 
     // FileHandle upload
     bind(FileHandleServlet.class).in(Singleton.class);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
@@ -75,9 +75,9 @@ public class CdnRedirectorServlet extends HttpServlet {
           pathToAsset
         );
       logger.warning(
-        "Not redirecting to CDN, server name \"" +
+        "Not redirecting to CDN: server name \"" +
         request.getServerName() +
-        "\" does not match known CDN server names. This is expected in development."
+        "\" does not match known server names with CDNs. This is expected in development."
       );
     }
 

--- a/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
@@ -12,7 +12,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.sagebionetworks.web.shared.WebConstants;
 
 /**
  * Handles file handler uploads.
@@ -29,15 +28,6 @@ public class CdnRedirectorServlet extends HttpServlet {
 
   protected static final ThreadLocal<HttpServletRequest> perThreadRequest =
     new ThreadLocal<HttpServletRequest>();
-
-  private RequestHostProvider requestHostProvider = () ->
-    UserDataProvider.getThreadLocalRequestHost(
-      CdnRedirectorServlet.perThreadRequest.get()
-    );
-
-  public void setRequestHostProvider(RequestHostProvider requestHostProvider) {
-    this.requestHostProvider = requestHostProvider;
-  }
 
   @Override
   protected void service(HttpServletRequest arg0, HttpServletResponse arg1)
@@ -58,23 +48,16 @@ public class CdnRedirectorServlet extends HttpServlet {
     // Check the origin - if the origin is `subdomain.synapse.org`, then redirect to the CDN at `cdn-<subdomain>.synapse.org`.
     // Otherwise, redirect to the asset hosted by the servlet.
 
-    URL requestUrl = new URL(getFullURL(request));
+    URL requestUrl = new URL(request.getRequestURL().toString());
     String scheme = getOriginalScheme(request);
     String pathToAsset = request.getPathInfo();
-    logger.info(
-      "Request received on " + request.getRequestURL() + " for " + pathToAsset
-    );
 
     Matcher matcher = CDN_HOSTS_REGEX.matcher(request.getServerName());
 
-    URL redirectUrl = new URL(
-      scheme,
-      request.getServerName(),
-      requestUrl.getPort(),
-      pathToAsset
-    );
+    URL redirectUrl;
 
     if (matcher.matches()) {
+      // Redirect to asset served by CDN
       redirectUrl =
         new URL(
           scheme,
@@ -83,37 +66,23 @@ public class CdnRedirectorServlet extends HttpServlet {
           pathToAsset
         );
     } else {
-      logger.info(
+      // There is no CDN, redirect to the asset served by the Portal
+      redirectUrl =
+        new URL(
+          scheme,
+          request.getServerName(),
+          requestUrl.getPort(),
+          pathToAsset
+        );
+      logger.warning(
+        "Not redirecting to CDN, server name \"" +
         request.getServerName() +
-        " does not match ^(www|staging|tst)\\.synapse\\.org$"
+        "\" does not match known CDN server names. This is expected in development."
       );
     }
 
-    response.setHeader( // instruct not to cache
-      WebConstants.CACHE_CONTROL_KEY,
-      WebConstants.CACHE_CONTROL_VALUE_NO_CACHE
-    );
-    // Set standard HTTP/1.1 no-cache headers.
-    response.setHeader(WebConstants.PRAGMA_KEY, WebConstants.NO_CACHE_VALUE); // Set standard HTTP/1.0 no-cache header.
-    response.setDateHeader(WebConstants.EXPIRES_KEY, 0L); // Proxy
-
-    logger.info("Redirecting " + pathToAsset + " to " + redirectUrl);
-
-    // redirect
+    // Redirect with 302 Found
     response.sendRedirect(redirectUrl.toString());
-  }
-
-  public static String getFullURL(HttpServletRequest request) {
-    StringBuilder requestURL = new StringBuilder(
-      request.getRequestURL().toString()
-    );
-    String queryString = request.getQueryString();
-
-    if (queryString == null) {
-      return requestURL.toString();
-    } else {
-      return requestURL.append('?').append(queryString).toString();
-    }
   }
 
   private static String getOriginalScheme(HttpServletRequest request) {

--- a/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
@@ -14,10 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Handles file handler uploads.
- *
- * @author jay
- *
+ * Redirects a request for an asset to the correct path, referencing the CDN if one exists.
  */
 public class CdnRedirectorServlet extends HttpServlet {
 

--- a/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
@@ -1,0 +1,126 @@
+package org.sagebionetworks.web.server.servlet;
+
+import static org.sagebionetworks.web.server.servlet.filter.HtmlInjectionFilter.CDN_HOSTS_REGEX;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.sagebionetworks.web.shared.WebConstants;
+
+/**
+ * Handles file handler uploads.
+ *
+ * @author jay
+ *
+ */
+public class CdnRedirectorServlet extends HttpServlet {
+
+  private static Logger logger = Logger.getLogger(
+    CdnRedirectorServlet.class.getName()
+  );
+  private static final long serialVersionUID = 1L;
+
+  protected static final ThreadLocal<HttpServletRequest> perThreadRequest =
+    new ThreadLocal<HttpServletRequest>();
+
+  private RequestHostProvider requestHostProvider = () ->
+    UserDataProvider.getThreadLocalRequestHost(
+      CdnRedirectorServlet.perThreadRequest.get()
+    );
+
+  public void setRequestHostProvider(RequestHostProvider requestHostProvider) {
+    this.requestHostProvider = requestHostProvider;
+  }
+
+  @Override
+  protected void service(HttpServletRequest arg0, HttpServletResponse arg1)
+    throws ServletException, IOException {
+    CdnRedirectorServlet.perThreadRequest.set(arg0);
+    super.service(arg0, arg1);
+  }
+
+  @Override
+  public void service(ServletRequest arg0, ServletResponse arg1)
+    throws ServletException, IOException {
+    super.service(arg0, arg1);
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+    throws ServletException, IOException {
+    // Check the origin - if the origin is `subdomain.synapse.org`, then redirect to the CDN at `cdn-<subdomain>.synapse.org`.
+    // Otherwise, redirect to the asset hosted by the servlet.
+
+    URL requestUrl = new URL(getFullURL(request));
+    String scheme = getOriginalScheme(request);
+    String pathToAsset = request.getPathInfo();
+    logger.info(
+      "Request received on " + request.getRequestURL() + " for " + pathToAsset
+    );
+
+    Matcher matcher = CDN_HOSTS_REGEX.matcher(request.getServerName());
+
+    URL redirectUrl = new URL(
+      scheme,
+      request.getServerName(),
+      requestUrl.getPort(),
+      pathToAsset
+    );
+
+    if (matcher.matches()) {
+      redirectUrl =
+        new URL(
+          scheme,
+          "cdn-" + request.getServerName(),
+          requestUrl.getPort(),
+          pathToAsset
+        );
+    } else {
+      logger.info(
+        request.getServerName() +
+        " does not match ^(www|staging|tst)\\.synapse\\.org$"
+      );
+    }
+
+    response.setHeader( // instruct not to cache
+      WebConstants.CACHE_CONTROL_KEY,
+      WebConstants.CACHE_CONTROL_VALUE_NO_CACHE
+    );
+    // Set standard HTTP/1.1 no-cache headers.
+    response.setHeader(WebConstants.PRAGMA_KEY, WebConstants.NO_CACHE_VALUE); // Set standard HTTP/1.0 no-cache header.
+    response.setDateHeader(WebConstants.EXPIRES_KEY, 0L); // Proxy
+
+    logger.info("Redirecting " + pathToAsset + " to " + redirectUrl);
+
+    // redirect
+    response.sendRedirect(redirectUrl.toString());
+  }
+
+  public static String getFullURL(HttpServletRequest request) {
+    StringBuilder requestURL = new StringBuilder(
+      request.getRequestURL().toString()
+    );
+    String queryString = request.getQueryString();
+
+    if (queryString == null) {
+      return requestURL.toString();
+    } else {
+      return requestURL.append('?').append(queryString).toString();
+    }
+  }
+
+  private static String getOriginalScheme(HttpServletRequest request) {
+    String forwardedProtoHeader = request.getHeader("X-Forwarded-Proto");
+    if (forwardedProtoHeader != null) {
+      return forwardedProtoHeader;
+    }
+    return request.getScheme();
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/CdnRedirectorServlet.java
@@ -45,7 +45,8 @@ public class CdnRedirectorServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException {
-    // Check the origin - if the origin is `subdomain.synapse.org`, then redirect to the CDN at `cdn-<subdomain>.synapse.org`.
+    // Check the server name in the request - if it matches a subdomain with a CDN (www, staging, tst), then redirect to
+    // the CDN at `cdn-<subdomain>.synapse.org`.
     // Otherwise, redirect to the asset hosted by the servlet.
 
     URL requestUrl = new URL(request.getRequestURL().toString());

--- a/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
@@ -11,7 +11,8 @@ import org.json.JSONObject;
  */
 public class ViteHTMLGeneratorImpl implements ViteHTMLGenerator {
 
-  private static final String VITE_DEV_SERVER_URL = "http://localhost:5173";
+  private static final String VITE_DEV_SERVER_URL =
+    "http://localhost:5173/Portal/cdn/generated/vite";
 
   private static final String VITE_CLIENT_PACKAGE = "@vite/client";
 

--- a/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
  */
 public class ViteHTMLGeneratorImpl implements ViteHTMLGenerator {
 
-  private static final String VITE_DEV_SERVER_ORIGIN = "http://localhost:5713";
+  private static final String VITE_DEV_SERVER_ORIGIN = "http://localhost:5173";
   // The base path should match the value in the Vite config.
   private static final String VITE_BASE_PATH = "/Portal/cdn/generated/vite";
 

--- a/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
@@ -11,8 +11,12 @@ import org.json.JSONObject;
  */
 public class ViteHTMLGeneratorImpl implements ViteHTMLGenerator {
 
+  private static final String VITE_DEV_SERVER_ORIGIN = "http://localhost:5713";
+  // The base path should match the value in the Vite config.
+  private static final String VITE_BASE_PATH = "/Portal/cdn/generated/vite";
+
   private static final String VITE_DEV_SERVER_URL =
-    "http://localhost:5173/Portal/cdn/generated/vite";
+    VITE_DEV_SERVER_ORIGIN + VITE_BASE_PATH;
 
   private static final String VITE_CLIENT_PACKAGE = "@vite/client";
 

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
@@ -224,9 +224,9 @@ public class HtmlInjectionFilter extends OncePerRequestFilter {
         viteHTMLGenerator.getViteProductionHTML(
           VITE_IMPORTED_FILES,
           viteManifestProvider.getManifest(),
-          // Fetch the first assets through the CDN (if available) directly.
-          // If these assets are fetched through the CDN redirect servlet, then
-          // the browser will download multiple copies of this script via circular references, and everything will break!
+          // The initial Vite assets should be fetched through the CDN (if available) directly.
+          // If these assets are instead fetched through the CDN redirect servlet (/Portal/cdn), then the browser will
+          // download multiple copies of the initial assets, and everything will break!
           dataModel.get(CDN_ENDPOINT_KEY) + "/generated/vite/"
         )
       );

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/HtmlInjectionFilter.java
@@ -109,7 +109,7 @@ public class HtmlInjectionFilter extends OncePerRequestFilter {
   // that Vite generates.
   public static final List<String> VITE_IMPORTED_FILES = List.of("js/main.js");
 
-  Pattern CDN_HOSTS_REGEX = Pattern.compile(
+  public static final Pattern CDN_HOSTS_REGEX = Pattern.compile(
     "^(www|staging|tst)\\.synapse\\.org$"
   );
 
@@ -224,6 +224,9 @@ public class HtmlInjectionFilter extends OncePerRequestFilter {
         viteHTMLGenerator.getViteProductionHTML(
           VITE_IMPORTED_FILES,
           viteManifestProvider.getManifest(),
+          // Fetch the first assets through the CDN (if available) directly.
+          // If these assets are fetched through the CDN redirect servlet, then
+          // the browser will download multiple copies of this script via circular references, and everything will break!
           dataModel.get(CDN_ENDPOINT_KEY) + "/generated/vite/"
         )
       );

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -252,6 +252,7 @@ public class WebConstants {
   public static final String SLACK_SERVLET = "slack";
   public static final String APPCONFIG_SERVLET = "featureflags";
   public static final String VERSIONS_SERVLET = "versions";
+  public static final String CDN_REDIRECTOR_SERVLET = "cdn";
   public static final String FILE_HANDLE_UPLOAD_SERVLET = "filehandle";
   public static final String JSON_LD_CONTENT_SERVLET = "jsonldcontent";
   public static final String SESSION_COOKIE_SERVLET = "sessioncookie";

--- a/src/test/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImplTest.java
@@ -13,8 +13,8 @@ public class ViteHTMLGeneratorImplTest extends TestCase {
     String html = generator.getViteDevelopmentHTML(List.of("js/main.js"));
 
     assertEquals(
-      "<script type=\"module\" src=\"http://localhost:5173/@vite/client\"></script>\n" +
-      "<script type=\"module\" src=\"http://localhost:5173/js/main.js\"></script>\n",
+      "<script type=\"module\" src=\"http://localhost:5173/Portal/cdn/generated/vite/@vite/client\"></script>\n" +
+      "<script type=\"module\" src=\"http://localhost:5173/Portal/cdn/generated/vite/js/main.js\"></script>\n",
       html
     );
   }

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/CdnRedirectorServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/CdnRedirectorServletTest.java
@@ -1,0 +1,141 @@
+package org.sagebionetworks.web.unitserver.servlet;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseForbiddenException;
+import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.dao.WikiPageKey;
+import org.sagebionetworks.repo.model.table.RowReference;
+import org.sagebionetworks.repo.model.wiki.WikiPage;
+import org.sagebionetworks.web.client.cookie.CookieKeys;
+import org.sagebionetworks.web.server.servlet.CdnRedirectorServlet;
+import org.sagebionetworks.web.server.servlet.RequestHostProvider;
+import org.sagebionetworks.web.server.servlet.SynapseProvider;
+import org.sagebionetworks.web.server.servlet.TokenProvider;
+import org.sagebionetworks.web.shared.WebConstants;
+import org.sagebionetworks.web.unitserver.SynapseClientBaseTest;
+
+public class CdnRedirectorServletTest {
+
+  @Mock
+  HttpServletRequest mockRequest;
+
+  @Mock
+  HttpServletResponse mockResponse;
+
+  @Mock
+  RequestHostProvider mockRequestHostProvider;
+
+  CdnRedirectorServlet servlet;
+  ArgumentCaptor<String> redirectUrlCaptor;
+
+  @Before
+  public void setup() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    servlet = new CdnRedirectorServlet();
+    servlet.setRequestHostProvider(mockRequestHostProvider);
+    redirectUrlCaptor = ArgumentCaptor.forClass(String.class);
+  }
+
+  private void setupRequest(
+    String protocol,
+    String serverName,
+    int serverPort,
+    String pathInfo
+  ) throws IOException {
+    StringBuffer requestUrl = new StringBuffer(
+      protocol + "://" + serverName + ":" + serverPort + pathInfo
+    );
+    when(mockRequest.getScheme()).thenReturn(protocol);
+    when(mockRequest.getRequestURL()).thenReturn(requestUrl);
+    when(mockRequest.getQueryString()).thenReturn(null);
+    when(mockRequest.getPathInfo()).thenReturn(pathInfo);
+    when(mockRequest.getServerName()).thenReturn(serverName);
+    when(mockRequestHostProvider.getRequestHost())
+      .thenReturn(serverName + ":" + serverPort);
+  }
+
+  @Test
+  public void testDoGetSynapseOrg() throws Exception {
+    String serverName = "www.synapse.org";
+    String pathInfo = "/some/asset.png";
+    setupRequest("https", serverName, 80, pathInfo);
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
+    String redirectUrl = redirectUrlCaptor.getValue();
+    assertTrue(redirectUrl.startsWith("https://cdn-"));
+    assertTrue(redirectUrl.contains(serverName));
+    assertTrue(redirectUrl.endsWith(pathInfo));
+  }
+
+  @Test
+  public void testDoGetStagingSynapseOrg() throws Exception {
+    String serverName = "staging.synapse.org";
+    String pathInfo = "/some/other/asset.js";
+    setupRequest("https", serverName, 80, pathInfo);
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
+    String redirectUrl = redirectUrlCaptor.getValue();
+    assertTrue(redirectUrl.startsWith("https://cdn-"));
+    assertTrue(redirectUrl.contains(serverName));
+    assertTrue(redirectUrl.endsWith(pathInfo));
+  }
+
+  @Test
+  public void testDoGetLocalhost() throws Exception {
+    String serverName = "127.0.0.1";
+    int serverPort = 8888;
+    String pathInfo = "/my/local/file.txt";
+    setupRequest("http", serverName, serverPort, pathInfo);
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
+    String redirectUrl = redirectUrlCaptor.getValue();
+    assertTrue(redirectUrl.startsWith("http://"));
+    assertTrue(redirectUrl.contains(serverName + ":" + serverPort));
+    assertTrue(redirectUrl.endsWith(pathInfo));
+  }
+
+  @Test
+  public void testNoCacheHeaders() throws Exception {
+    setupRequest("https", "www.synapse.org", 80, "/file.css");
+    servlet.doGet(mockRequest, mockResponse);
+
+    verify(mockResponse)
+      .setHeader(
+        eq(WebConstants.CACHE_CONTROL_KEY),
+        eq(WebConstants.CACHE_CONTROL_VALUE_NO_CACHE)
+      );
+    verify(mockResponse)
+      .setHeader(eq(WebConstants.PRAGMA_KEY), eq(WebConstants.NO_CACHE_VALUE));
+    verify(mockResponse).setDateHeader(eq(WebConstants.EXPIRES_KEY), eq(0L));
+  }
+}

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/CdnRedirectorServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/CdnRedirectorServletTest.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.web.unitserver.servlet;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -46,9 +47,6 @@ public class CdnRedirectorServletTest {
   @Mock
   HttpServletResponse mockResponse;
 
-  @Mock
-  RequestHostProvider mockRequestHostProvider;
-
   CdnRedirectorServlet servlet;
   ArgumentCaptor<String> redirectUrlCaptor;
 
@@ -56,7 +54,6 @@ public class CdnRedirectorServletTest {
   public void setup() throws IOException {
     MockitoAnnotations.initMocks(this);
     servlet = new CdnRedirectorServlet();
-    servlet.setRequestHostProvider(mockRequestHostProvider);
     redirectUrlCaptor = ArgumentCaptor.forClass(String.class);
   }
 
@@ -74,68 +71,48 @@ public class CdnRedirectorServletTest {
     when(mockRequest.getQueryString()).thenReturn(null);
     when(mockRequest.getPathInfo()).thenReturn(pathInfo);
     when(mockRequest.getServerName()).thenReturn(serverName);
-    when(mockRequestHostProvider.getRequestHost())
-      .thenReturn(serverName + ":" + serverPort);
   }
 
   @Test
   public void testDoGetSynapseOrg() throws Exception {
     String serverName = "www.synapse.org";
     String pathInfo = "/some/asset.png";
-    setupRequest("https", serverName, 80, pathInfo);
+    setupRequest("https", serverName, 443, pathInfo);
 
     servlet.doGet(mockRequest, mockResponse);
 
     verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
     String redirectUrl = redirectUrlCaptor.getValue();
-    assertTrue(redirectUrl.startsWith("https://cdn-"));
-    assertTrue(redirectUrl.contains(serverName));
-    assertTrue(redirectUrl.endsWith(pathInfo));
+    assertEquals("https://cdn-www.synapse.org:443/some/asset.png", redirectUrl);
   }
 
   @Test
   public void testDoGetStagingSynapseOrg() throws Exception {
     String serverName = "staging.synapse.org";
-    String pathInfo = "/some/other/asset.js";
-    setupRequest("https", serverName, 80, pathInfo);
+    String pathInfo = "/some/asset.png";
+    setupRequest("https", serverName, 443, pathInfo);
 
     servlet.doGet(mockRequest, mockResponse);
 
     verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
     String redirectUrl = redirectUrlCaptor.getValue();
-    assertTrue(redirectUrl.startsWith("https://cdn-"));
-    assertTrue(redirectUrl.contains(serverName));
-    assertTrue(redirectUrl.endsWith(pathInfo));
+    assertEquals(
+      "https://cdn-staging.synapse.org:443/some/asset.png",
+      redirectUrl
+    );
   }
 
   @Test
   public void testDoGetLocalhost() throws Exception {
     String serverName = "127.0.0.1";
     int serverPort = 8888;
-    String pathInfo = "/my/local/file.txt";
+    String pathInfo = "/some/asset.png";
     setupRequest("http", serverName, serverPort, pathInfo);
 
     servlet.doGet(mockRequest, mockResponse);
 
     verify(mockResponse).sendRedirect(redirectUrlCaptor.capture());
     String redirectUrl = redirectUrlCaptor.getValue();
-    assertTrue(redirectUrl.startsWith("http://"));
-    assertTrue(redirectUrl.contains(serverName + ":" + serverPort));
-    assertTrue(redirectUrl.endsWith(pathInfo));
-  }
-
-  @Test
-  public void testNoCacheHeaders() throws Exception {
-    setupRequest("https", "www.synapse.org", 80, "/file.css");
-    servlet.doGet(mockRequest, mockResponse);
-
-    verify(mockResponse)
-      .setHeader(
-        eq(WebConstants.CACHE_CONTROL_KEY),
-        eq(WebConstants.CACHE_CONTROL_VALUE_NO_CACHE)
-      );
-    verify(mockResponse)
-      .setHeader(eq(WebConstants.PRAGMA_KEY), eq(WebConstants.NO_CACHE_VALUE));
-    verify(mockResponse).setDateHeader(eq(WebConstants.EXPIRES_KEY), eq(0L));
+    assertEquals("http://127.0.0.1:8888/some/asset.png", redirectUrl);
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
  * Vite config to generate the ESM & CJS bundles for Synapse React Client.
  */
 const config = defineConfig({
+  // Assets will be served from the `/Portal/cdn` servlet, which will redirect requests to the CDN when appropriate
   base: '/Portal/cdn/generated/vite/',
   server: {
     cors: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
  * Vite config to generate the ESM & CJS bundles for Synapse React Client.
  */
 const config = defineConfig({
+  base: '/Portal/cdn/generated/vite/',
   server: {
     cors: {
       origin: ['http://localhost:8888', 'http://127.0.0.1:8888'],


### PR DESCRIPTION
Fixes SWC-7390

- Add servlet endpoint to conditionally redirect to CDN
- Update Vite base path so dynamically loaded modules can be resolved through CDN servlet