### PR TITLE
SWC-7004 - Global store for context props

### DIFF
--- a/devdocs/ReactIntegration.md
+++ b/devdocs/ReactIntegration.md
@@ -38,33 +38,27 @@ Make sure you specify your prop type in the type parameter, and also make sure t
 
 While you can append your React component to any element, we have [ReactComponent](../src/main/java/org/sagebionetworks/web/client/widget/ReactComponent.java) that contains logic that simplifies managing the lifecycle of a React component. Add this to your View in code or `*.ui.xml` file, and make sure you can reference it for the next step.
 
-### Passing Synapse context
+### Synapse context
 
-If your application uses Synapse context (e.g. uses authentication to call the Synapse API), then you will also need to pass a context provider. To do so, you can inject [SynapseReactClientFullContextPropsProvider](../src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProvider.java), which will create the wrapping context for you.
+The SynapseContext (which includes authentication state, experimental mode state, etc.) will be automatically passed to components through a global store when using the method `createElementWithSynapseContext` defined in our `React` overlay class.
 
 ### Render the element
 
 How you manage updating your widget's view will vary based on the scenario, but when you're ready to render the component, this is all you have to do:
 
 ```java
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 
 class MyView {
-
-  // Typically injected
-  SynapseReactClientFullContextPropsProvider propsProvider;
-
-  void renderComponent() {
-    MyProps props = props.create(/**/);
-    ReactElement reactElement = React.createElementWithSynapseContext(
-      SRC.SynapseComponents.MyComponent,
-      props,
-      propsProvider.getJsInteropContextProps()
-    );
-    reactComponent.render(reactElement);
-  }
+    void renderComponent() {
+        MyProps props = props.create(/**/);
+        ReactElement reactElement = React.createElementWithSynapseContext(
+                SRC.SynapseComponents.MyComponent,
+                props
+        );
+        reactComponent.render(reactElement);
+    }
 }
 
 ```

--- a/js/globalContext.js
+++ b/js/globalContext.js
@@ -1,0 +1,26 @@
+import { atom, createStore, Provider, useAtomValue } from 'jotai'
+import { createElement } from 'react'
+import { SynapseContext } from 'synapse-react-client'
+
+const contextStore = createStore()
+const contextAtom = atom({})
+
+function _SynapseContextProviderFromStore({ children }) {
+  const context = useAtomValue(contextAtom)
+
+  return createElement(SynapseContext.FullContextProvider, context, children)
+}
+
+function SynapseContextProviderFromStore(props) {
+  return createElement(
+    Provider,
+    { store: contextStore },
+    createElement(_SynapseContextProviderFromStore, props),
+  )
+}
+
+window.ContextUtils = {
+  setGlobalContext: ctx => contextStore.set(contextAtom, ctx),
+  contextStore: contextStore,
+  SynapseContextProviderFromStore: SynapseContextProviderFromStore,
+}

--- a/js/globalContext.js
+++ b/js/globalContext.js
@@ -2,25 +2,22 @@ import { atom, createStore, Provider, useAtomValue } from 'jotai'
 import { createElement } from 'react'
 import { SynapseContext } from 'synapse-react-client'
 
+/* A store that will be used across all React elements in the app */
 const contextStore = createStore()
-const contextAtom = atom({})
 
-function _SynapseContextProviderFromStore({ children }) {
-  const context = useAtomValue(contextAtom)
+/* Atom that can store the props for SynapseContextProvider */
+const contextProviderPropsAtom = atom({})
+
+/* Wraps children in a FullContextProvider, reading the global context store to configure the context */
+function SynapseContextProviderFromStore({ children }) {
+  const context = useAtomValue(contextProviderPropsAtom, {
+    store: contextStore,
+  })
 
   return createElement(SynapseContext.FullContextProvider, context, children)
 }
 
-function SynapseContextProviderFromStore(props) {
-  return createElement(
-    Provider,
-    { store: contextStore },
-    createElement(_SynapseContextProviderFromStore, props),
-  )
-}
-
 window.ContextUtils = {
-  setGlobalContext: ctx => contextStore.set(contextAtom, ctx),
-  contextStore: contextStore,
+  setGlobalContext: ctx => contextStore.set(contextProviderPropsAtom, ctx),
   SynapseContextProviderFromStore: SynapseContextProviderFromStore,
 }

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ import ReactDOMClient from 'react-dom/client'
 import * as ReactQuery from '@tanstack/react-query'
 import * as SRC from 'synapse-react-client'
 import './mui.js'
+import './globalContext.js'
 
 // Append to global scope so these libraries can be accessed in JsInterop classes
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap3": "npm:bootstrap@3.4.1",
     "croppie": "2.6.5",
     "font-awesome": "4.7.0",
+    "jotai": "^2.12.5",
     "jquery": "3.7.1",
     "jquery-ui": "1.13.3",
     "jsplumb": "2.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       font-awesome:
         specifier: 4.7.0
         version: 4.7.0
+      jotai:
+        specifier: ^2.12.5
+        version: 2.12.5(@types/react@19.1.8)(react@19.1.0)
       jquery:
         specifier: 3.7.1
         version: 3.7.1

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationState.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationState.java
@@ -140,4 +140,9 @@ public interface GlobalApplicationState {
 
   boolean handleRelativePathClick(String href);
   void gotoLoginPage();
+
+  /**
+   * Synchronizes the context retrieved in GWT with the global store that is passed to React components
+   */
+  void synchronizeReactContextWithGlobalStore();
 }

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
@@ -492,7 +492,7 @@ public class GlobalApplicationStateImpl implements GlobalApplicationState {
       isToastContainerInitialized = true;
 
       Element toastContainer = RootPanel.get("toastContainer").getElement();
-      ReactElement component = React.createElementWithThemeContext(
+      ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.SynapseToastContainer,
         null
       );

--- a/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GlobalApplicationStateImpl.java
@@ -36,6 +36,7 @@ import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOMClient;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.jsinterop.context.ContextUtils;
 import org.sagebionetworks.web.client.mvp.AppActivityMapper;
 import org.sagebionetworks.web.client.mvp.AppPlaceHistoryMapper;
 import org.sagebionetworks.web.client.place.LoginPlace;
@@ -706,5 +707,12 @@ public class GlobalApplicationStateImpl implements GlobalApplicationState {
   @Override
   public boolean isShowingVersionAlert() {
     return isShowingVersionAlert;
+  }
+
+  @Override
+  public void synchronizeReactContextWithGlobalStore() {
+    ContextUtils.setGlobalContext(
+      ginInjector.getReactContextPropsProvider().getJsInteropContextProps()
+    );
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/Portal.java
+++ b/src/main/java/org/sagebionetworks/web/client/Portal.java
@@ -212,6 +212,9 @@ public class Portal implements EntryPoint {
                                         ginjector
                                           .getWebStorageMaxSizeDetector()
                                           .start();
+
+                                        // SWC-7004: Update global store with current React context
+                                        globalApplicationState.synchronizeReactContextWithGlobalStore();
                                       }
                                     }
                                   );

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -6,6 +6,7 @@ import com.google.gwt.inject.client.Ginjector;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.web.client.cache.SessionStorage;
 import org.sagebionetworks.web.client.context.QueryClientProvider;
+import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.presenter.ACTAccessApprovalsPresenter;
 import org.sagebionetworks.web.client.presenter.ACTDataAccessSubmissionDashboardPresenter;
@@ -902,4 +903,5 @@ public interface PortalGinInjector extends Ginjector {
   ChatPresenter getChatPresenter();
   PlansPresenter getPlansPresenter();
   ProjectDataAvailability getProjectDataAvailability();
+  SynapseReactClientFullContextPropsProvider getReactContextPropsProvider();
 }

--- a/src/main/java/org/sagebionetworks/web/client/SessionDetector.java
+++ b/src/main/java/org/sagebionetworks/web/client/SessionDetector.java
@@ -16,21 +16,18 @@ public class SessionDetector {
   public static final String SESSION_MARKER = "SESSION_MARKER";
   public static final int FORCE_CHECK_EVERY_X_ITERATIONS = 7;
   private int loopCount = 0;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public SessionDetector(
     AuthenticationController authController,
     GlobalApplicationState globalAppState,
     GWTWrapper gwt,
-    ClientCache clientCache,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    ClientCache clientCache
   ) {
     this.clientCache = clientCache;
     this.authController = authController;
     this.globalAppState = globalAppState;
     this.gwt = gwt;
-    this.propsProvider = propsProvider;
     initializeAccessTokenState();
   }
 
@@ -42,8 +39,6 @@ public class SessionDetector {
     // SWC-4947: check for user change immediately (don't wait 10 seconds to discover the existing
     // session token).
     authController.checkForUserChange();
-    // SWC-7004: Update global store with current React context
-    propsProvider.synchronizeContextWithGlobalStore();
     checkForUserChangeLater();
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/SessionDetector.java
+++ b/src/main/java/org/sagebionetworks/web/client/SessionDetector.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.web.client;
 import com.google.inject.Inject;
 import java.util.Objects;
 import org.sagebionetworks.web.client.cache.ClientCache;
+import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 
 public class SessionDetector {
@@ -15,18 +16,21 @@ public class SessionDetector {
   public static final String SESSION_MARKER = "SESSION_MARKER";
   public static final int FORCE_CHECK_EVERY_X_ITERATIONS = 7;
   private int loopCount = 0;
+  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public SessionDetector(
     AuthenticationController authController,
     GlobalApplicationState globalAppState,
     GWTWrapper gwt,
-    ClientCache clientCache
+    ClientCache clientCache,
+    SynapseReactClientFullContextPropsProvider propsProvider
   ) {
     this.clientCache = clientCache;
     this.authController = authController;
     this.globalAppState = globalAppState;
     this.gwt = gwt;
+    this.propsProvider = propsProvider;
     initializeAccessTokenState();
   }
 
@@ -38,6 +42,8 @@ public class SessionDetector {
     // SWC-4947: check for user change immediately (don't wait 10 seconds to discover the existing
     // session token).
     authController.checkForUserChange();
+    // SWC-7004: Update global store with current React context
+    propsProvider.synchronizeContextWithGlobalStore();
     checkForUserChangeLater();
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProvider.java
@@ -21,4 +21,9 @@ public interface SynapseReactClientFullContextPropsProvider {
    * using JsInterop before using JSNI.
    */
   FullContextProviderPropsJSNIObject getJsniContextProps();
+
+  /**
+   * Synchronizes the context retrieved in GWT with the global store that is passed to React components
+   */
+  void synchronizeContextWithGlobalStore();
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProvider.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProvider.java
@@ -21,9 +21,4 @@ public interface SynapseReactClientFullContextPropsProvider {
    * using JsInterop before using JSNI.
    */
   FullContextProviderPropsJSNIObject getJsniContextProps();
-
-  /**
-   * Synchronizes the context retrieved in GWT with the global store that is passed to React components
-   */
-  void synchronizeContextWithGlobalStore();
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProviderImpl.java
@@ -8,6 +8,7 @@ import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.IsEditingStore;
 import org.sagebionetworks.web.client.jsinterop.SynapseContextJsObject;
 import org.sagebionetworks.web.client.jsinterop.SynapseReactClientFullContextProviderProps;
+import org.sagebionetworks.web.client.jsinterop.context.ContextUtils;
 import org.sagebionetworks.web.client.jsni.FullContextProviderPropsJSNIObject;
 import org.sagebionetworks.web.client.jsni.QueryClientJSNIObject;
 import org.sagebionetworks.web.client.jsni.SynapseReactClientFullContextJSNIObject;
@@ -75,5 +76,10 @@ public class SynapseReactClientFullContextPropsProviderImpl
     props.setSynapseContext(synapseContext);
     props.setQueryClient(QueryClientJSNIObject.getQueryClientSingleton());
     return props;
+  }
+
+  @Override
+  public void synchronizeContextWithGlobalStore() {
+    ContextUtils.setGlobalContext(this.getJsInteropContextProps());
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProviderImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/context/SynapseReactClientFullContextPropsProviderImpl.java
@@ -77,9 +77,4 @@ public class SynapseReactClientFullContextPropsProviderImpl
     props.setQueryClient(QueryClientJSNIObject.getQueryClientSingleton());
     return props;
   }
-
-  @Override
-  public void synchronizeContextWithGlobalStore() {
-    ContextUtils.setGlobalContext(this.getJsInteropContextProps());
-  }
 }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/React.java
@@ -3,7 +3,7 @@ package org.sagebionetworks.web.client.jsinterop;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
+import org.sagebionetworks.web.client.jsinterop.context.ContextUtils;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class React {
@@ -23,34 +23,27 @@ public class React {
   public static native <T> T createRef();
 
   /**
-   * Similar to {@link #createElementWithSynapseContext} but only includes the theme. Any components rendered will NOT get the full Synapse context, including
-   * access token + auth state, experimental mode status, and time display settings.
+   * Wraps a component in SynapseContextProvider. Nearly all Synapse React Client components must be wrapped in this context, so this utility
+   * simplifies creating the wrapper.
+   *
+   * @param <P>
+   * @param componentType
+   * @return
    */
   @JsOverlay
   public static <
     T extends ReactComponentType<P>, P extends ReactComponentProps
-  > ReactElement<?, ?> createElementWithThemeContext(
-    ReactComponentType<P> componentType,
-    P props
-  ) {
-    SynapseReactClientFullContextProviderProps emptyContext =
-      SynapseReactClientFullContextProviderProps.create(
-        SynapseContextJsObject.create(null, false, false, "synapse.org"),
-        null,
-        null
-      );
-    return createElementWithSynapseContext(componentType, props, emptyContext);
+  > ReactElement<?, ?> createElementWithSynapseContext(T componentType) {
+    return createElementWithSynapseContext(componentType, null);
   }
 
   /**
    * Wraps a component in SynapseContextProvider. Nearly all Synapse React Client components must be wrapped in this context, so this utility
    * simplifies creating the wrapper.
    *
-   * For setting props, use {@link SynapseReactClientFullContextPropsProvider}
+   * @param <P>
    * @param componentType
    * @param props
-   * @param wrapperProps
-   * @param <P>
    * @return
    */
   @JsOverlay
@@ -59,12 +52,16 @@ public class React {
   > ReactElement<?, ?> createElementWithSynapseContext(
     T componentType,
     P props,
-    SynapseReactClientFullContextProviderProps wrapperProps
+    ReactElement<?, ?>... children
   ) {
-    ReactElement componentElement = createElement(componentType, props);
+    ReactElement<T, P> componentElement = createElement(
+      componentType,
+      props,
+      children
+    );
     return createElement(
-      SRC.SynapseContext.FullContextProvider,
-      wrapperProps,
+      ContextUtils.SynapseContextProviderFromStore,
+      null,
       componentElement
     );
   }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/context/ContextUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/context/ContextUtils.java
@@ -1,0 +1,19 @@
+package org.sagebionetworks.web.client.jsinterop.context;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentProps;
+import org.sagebionetworks.web.client.jsinterop.ReactComponentType;
+import org.sagebionetworks.web.client.jsinterop.SynapseReactClientFullContextProviderProps;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+public class ContextUtils {
+
+  public static ReactComponentType<
+    ? extends ReactComponentProps
+  > SynapseContextProviderFromStore;
+
+  public static native void setGlobalContext(
+    SynapseReactClientFullContextProviderProps props
+  );
+}

--- a/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/TrashPresenter.java
@@ -4,7 +4,6 @@ import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.place.Trash;
 import org.sagebionetworks.web.client.view.TrashView;
 
@@ -14,22 +13,17 @@ public class TrashPresenter
 
   private Trash place;
   private TrashView view;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public TrashPresenter(
-    TrashView view,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public TrashPresenter(TrashView view) {
     this.view = view;
-    this.propsProvider = propsProvider;
   }
 
   @Override
   public void start(AcceptsOneWidget panel, EventBus eventBus) {
     // Install the view
     panel.setWidget(view);
-    view.createReactComponentWidget(propsProvider);
+    view.createReactComponentWidget();
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/view/CertificationQuizViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/CertificationQuizViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.widget.certificationquiz.CertificationQuiz;
 import org.sagebionetworks.web.client.widget.header.Header;
 
@@ -21,23 +20,20 @@ public class CertificationQuizViewImpl
   SimplePanel quizContainer;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public CertificationQuizViewImpl(
     CertificationViewImplUiBinder binder,
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    Header headerWidget
   ) {
     initWidget(binder.createAndBindUi(this));
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 
   @Override
   public void createReactComponentWidget() {
-    CertificationQuiz component = new CertificationQuiz(this.propsProvider);
+    CertificationQuiz component = new CertificationQuiz();
     quizContainer.clear();
     quizContainer.add(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/ChatViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ChatViewImpl.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.web.client.view;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -17,18 +15,10 @@ public class ChatViewImpl extends Composite implements ChatView {
   ReactComponent container;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
-  private GlobalApplicationState globalAppState;
 
   @Inject
-  public ChatViewImpl(
-    Header headerWidget,
-    final SynapseReactClientFullContextPropsProvider propsProvider,
-    GlobalApplicationState globalAppState
-  ) {
+  public ChatViewImpl(Header headerWidget) {
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
-    this.globalAppState = globalAppState;
     headerWidget.configure();
     container = new ReactComponent();
     initWidget(container);
@@ -50,8 +40,7 @@ public class ChatViewImpl extends Composite implements ChatView {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapseChat,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
 
     container.render(component);

--- a/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DataAccessManagementViewImpl.java
@@ -5,7 +5,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.ReviewerDashboardProps;
@@ -18,7 +17,6 @@ public class DataAccessManagementViewImpl implements DataAccessManagementView {
   public interface DataAccessManagementViewImplUiBinder
     extends UiBinder<Widget, DataAccessManagementViewImpl> {}
 
-  private SynapseReactClientFullContextPropsProvider propsProvider;
   private Header headerWidget;
 
   @UiField
@@ -29,12 +27,10 @@ public class DataAccessManagementViewImpl implements DataAccessManagementView {
   @Inject
   public DataAccessManagementViewImpl(
     DataAccessManagementViewImplUiBinder binder,
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    Header headerWidget
   ) {
     widget = binder.createAndBindUi(this);
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 
@@ -50,8 +46,7 @@ public class DataAccessManagementViewImpl implements DataAccessManagementView {
 
     ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ReviewerDashboard,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(node);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/DataCatalogPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DataCatalogPageViewImpl.java
@@ -4,9 +4,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import java.util.HashMap;
-import java.util.Map;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CardConfiguration;
 import org.sagebionetworks.web.client.jsinterop.GenericCardSchema;
 import org.sagebionetworks.web.client.widget.header.Header;
@@ -17,17 +14,12 @@ public class DataCatalogPageViewImpl implements DataCatalogPageView {
   SimplePanel container;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public DataCatalogPageViewImpl(
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public DataCatalogPageViewImpl(Header headerWidget) {
     container = new SimplePanel();
     container.addStyleName("padding-30");
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -50,7 +42,6 @@ public class DataCatalogPageViewImpl implements DataCatalogPageView {
     );
 
     QueryWrapperPlotNav plotNav = new QueryWrapperPlotNav(
-      propsProvider,
       "SELECT * FROM syn61609402 WHERE includedInDataCatalog = 'true'",
       null,
       null,

--- a/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownViewImpl.java
@@ -5,7 +5,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -18,7 +17,6 @@ public class DownViewImpl implements DownView {
   public static final String SYNAPSE_DOWN_MAINTENANCE_TITLE =
     "Sorry, Synapse is down for maintenance.";
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @UiField
   ReactComponent srcDownContainer;
@@ -40,12 +38,10 @@ public class DownViewImpl implements DownView {
   public DownViewImpl(
     Binder uiBinder,
     Header headerWidget,
-    final SynapseReactClientFullContextPropsProvider propsProvider,
     GlobalApplicationState globalAppState
   ) {
     widget = uiBinder.createAndBindUi(this);
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
     widget.addAttachHandler(event -> {
       if (event.isAttached()) {
@@ -91,8 +87,7 @@ public class DownViewImpl implements DownView {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     srcDownContainer.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/DownloadCartPageViewImpl.java
@@ -3,12 +3,10 @@ package org.sagebionetworks.web.client.view;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadCartPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
-import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 import org.sagebionetworks.web.client.widget.header.Header;
 
@@ -17,18 +15,12 @@ public class DownloadCartPageViewImpl implements DownloadCartPageView {
   ReactComponent container;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
   private Presenter presenter;
 
   @Inject
-  public DownloadCartPageViewImpl(
-    AuthenticationController authenticationController,
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public DownloadCartPageViewImpl(Header headerWidget) {
     container = new ReactComponent();
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -45,8 +37,7 @@ public class DownloadCartPageViewImpl implements DownloadCartPageView {
     });
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadCartPage,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     container.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/FollowingPageViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -23,19 +22,15 @@ public class FollowingPageViewImpl
 
   Header headerWidget;
 
-  SynapseReactClientFullContextPropsProvider propsProvider;
-
   public interface LoginViewImplBinder
     extends UiBinder<Widget, FollowingPageViewImpl> {}
 
   @Inject
   public FollowingPageViewImpl(
     LoginViewImplBinder uiBinder,
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    Header headerWidget
   ) {
     initWidget(uiBinder.createAndBindUi(this));
-    this.propsProvider = propsProvider;
     this.headerWidget = headerWidget;
     configure();
   }
@@ -63,8 +58,7 @@ public class FollowingPageViewImpl
     headerWidget.configure();
     ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubscriptionPage,
-      EmptyProps.create(),
-      propsProvider.getJsInteropContextProps()
+      EmptyProps.create()
     );
     reactContainer.render(element);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/HomeViewImpl.java
@@ -7,7 +7,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -24,20 +23,17 @@ public class HomeViewImpl extends Composite implements HomeView {
   ReactComponent container;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
   private GlobalApplicationState globalAppState;
 
   @Inject
   public HomeViewImpl(
     HomeViewImplUiBinder binder,
     Header headerWidget,
-    final SynapseReactClientFullContextPropsProvider propsProvider,
     GlobalApplicationState globalAppState
   ) {
     initWidget(binder.createAndBindUi(this));
 
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     this.globalAppState = globalAppState;
     headerWidget.configure();
   }
@@ -53,8 +49,7 @@ public class HomeViewImpl extends Composite implements HomeView {
     component =
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.SynapseHomepageV2,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       );
 
     container.render(component);

--- a/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/LoginViewImpl.java
@@ -12,7 +12,6 @@ import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.widget.FullWidthAlert;
 import org.sagebionetworks.web.client.widget.LoadingSpinner;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -53,7 +52,6 @@ public class LoginViewImpl extends Composite implements LoginView {
   private LoginWidget loginWidget;
   private Header headerWidget;
   SynapseJSNIUtils jsniUtils;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   public interface LoginViewImplBinder
     extends UiBinder<Widget, LoginViewImpl> {}
@@ -63,14 +61,12 @@ public class LoginViewImpl extends Composite implements LoginView {
     LoginViewImplBinder uiBinder,
     Header headerWidget,
     LoginWidget loginWidget,
-    SynapseJSNIUtils jsniUtils,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    SynapseJSNIUtils jsniUtils
   ) {
     initWidget(uiBinder.createAndBindUi(this));
     this.loginWidget = loginWidget;
     this.headerWidget = headerWidget;
     this.jsniUtils = jsniUtils;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/view/OAuthClientEditorViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/OAuthClientEditorViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.widget.header.Header;
 import org.sagebionetworks.web.client.widget.oauthclient.OAuthClientEditor;
 
@@ -21,23 +20,20 @@ public class OAuthClientEditorViewImpl
   SimplePanel componentContainer;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public OAuthClientEditorViewImpl(
     OAuthClientEditorViewImplUiBinder binder,
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    Header headerWidget
   ) {
     initWidget(binder.createAndBindUi(this));
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 
   @Override
   public void createReactComponentWidget() {
-    OAuthClientEditor component = new OAuthClientEditor(this.propsProvider);
+    OAuthClientEditor component = new OAuthClientEditor();
     componentContainer.clear();
     componentContainer.add(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/PlansViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/PlansViewImpl.java
@@ -4,7 +4,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -17,17 +16,14 @@ public class PlansViewImpl extends Composite implements PlansView {
   ReactComponent container;
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
   private GlobalApplicationState globalAppState;
 
   @Inject
   public PlansViewImpl(
     Header headerWidget,
-    final SynapseReactClientFullContextPropsProvider propsProvider,
     GlobalApplicationState globalAppState
   ) {
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     this.globalAppState = globalAppState;
     headerWidget.configure();
     container = new ReactComponent();
@@ -45,8 +41,7 @@ public class PlansViewImpl extends Composite implements PlansView {
 
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapsePlansPage,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
 
     container.render(component);

--- a/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/ProfileViewImpl.java
@@ -15,7 +15,6 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import java.util.Arrays;
-import java.util.Collections;
 import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
@@ -37,7 +36,6 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -233,7 +231,6 @@ public class ProfileViewImpl extends Composite implements ProfileView {
   AnchorListItem loadingTeamsListItem = new AnchorListItem("Loading...");
 
   CookieProvider cookies;
-  SynapseReactClientFullContextPropsProvider propsProvider;
   JSONObjectAdapter jsonObjectAdapter;
 
   @Inject
@@ -241,14 +238,12 @@ public class ProfileViewImpl extends Composite implements ProfileView {
     ProfileViewImplUiBinder binder,
     Header headerWidget,
     CookieProvider cookies,
-    SynapseReactClientFullContextPropsProvider propsProvider,
     OrientationBanner orientationBanner,
     JSONObjectAdapter jsonObjectAdapter
   ) {
     initWidget(binder.createAndBindUi(this));
     this.headerWidget = headerWidget;
     this.cookies = cookies;
-    this.propsProvider = propsProvider;
     this.orientationBanner = orientationBanner;
     this.jsonObjectAdapter = jsonObjectAdapter;
     headerWidget.configure();
@@ -646,8 +641,7 @@ public class ProfileViewImpl extends Composite implements ProfileView {
       EmptyProps props = EmptyProps.create();
       ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.FavoritesPage,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       );
       favoritesTabContainer.render(component);
 

--- a/src/main/java/org/sagebionetworks/web/client/view/TrashView.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/TrashView.java
@@ -1,10 +1,7 @@
 package org.sagebionetworks.web.client.view;
 
 import com.google.gwt.user.client.ui.IsWidget;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 
 public interface TrashView extends IsWidget {
-  void createReactComponentWidget(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  );
+  void createReactComponentWidget();
 }

--- a/src/main/java/org/sagebionetworks/web/client/view/TrashViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/TrashViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.widget.header.Header;
 import org.sagebionetworks.web.client.widget.trash.TrashCanList;
 
@@ -28,10 +27,8 @@ public class TrashViewImpl extends Composite implements TrashView {
   }
 
   @Override
-  public void createReactComponentWidget(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    TrashCanList component = new TrashCanList(propsProvider);
+  public void createReactComponentWidget() {
+    TrashCanList component = new TrashCanList();
     componentContainer.clear();
     componentContainer.add(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/view/TrustCenterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/TrustCenterViewImpl.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.view;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.GovernanceMarkdownGithubProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -16,17 +15,12 @@ public class TrustCenterViewImpl extends Composite implements TrustCenterView {
   ReactComponent container = new ReactComponent();
 
   private Header headerWidget;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public TrustCenterViewImpl(
-    Header headerWidget,
-    final SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public TrustCenterViewImpl(Header headerWidget) {
     initWidget(container);
 
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 
@@ -49,8 +43,7 @@ public class TrustCenterViewImpl extends Composite implements TrustCenterView {
     component =
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.GovernanceMarkdownGithub,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       );
 
     container.render(component);

--- a/src/main/java/org/sagebionetworks/web/client/view/UserAccessRequestHistoryViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/view/UserAccessRequestHistoryViewImpl.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.view;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.ReviewerDashboardProps;
@@ -14,18 +13,13 @@ import org.sagebionetworks.web.client.widget.header.Header;
 public class UserAccessRequestHistoryViewImpl
   implements UserAccessRequestHistoryView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   private final Header headerWidget;
 
   private final ReactComponent reactComponent = new ReactComponent();
 
   @Inject
-  public UserAccessRequestHistoryViewImpl(
-    Header headerWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public UserAccessRequestHistoryViewImpl(Header headerWidget) {
     this.headerWidget = headerWidget;
-    this.propsProvider = propsProvider;
     headerWidget.configure();
   }
 
@@ -41,8 +35,7 @@ public class UserAccessRequestHistoryViewImpl
 
     ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserAccessRequestHistoryPlace,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(node);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityCitationImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityCitationImpl.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.web.client.widget;
 
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityCitationProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -9,14 +8,8 @@ import org.sagebionetworks.web.client.jsinterop.SRC;
 
 public class EntityCitationImpl extends ReactComponent {
 
-  private final SynapseReactClientFullContextPropsProvider contextPropsProvider;
-
   @Inject
-  public EntityCitationImpl(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider
-  ) {
-    this.contextPropsProvider = contextPropsProvider;
-  }
+  public EntityCitationImpl() {}
 
   public void configure(String projectId, String entityId, Double version) {
     EntityCitationProps props = EntityCitationProps.create(
@@ -26,8 +19,7 @@ public class EntityCitationImpl extends ReactComponent {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityCitation,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
@@ -23,7 +23,7 @@ public class EntityTypeIconImpl
   @Override
   public void configure(EntityType type) {
     EntityTypeIconProps props = EntityTypeIconProps.create(type);
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityTypeIcon,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/FullWidthAlert.java
@@ -60,7 +60,7 @@ public class FullWidthAlert implements IsWidget {
       isGlobal,
       alertType
     );
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.FullWidthAlert,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/HelpWidget.java
@@ -54,7 +54,7 @@ public class HelpWidget implements IsWidget {
       showCloseButton,
       className
     );
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HelpPopover,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/IconSvg.java
@@ -24,7 +24,7 @@ public class IconSvg extends ReactComponent {
 
   private void renderComponent() {
     IconSvgProps props = IconSvgProps.create(icon, label);
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.IconSvg,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/OrientationBanner.java
@@ -43,7 +43,7 @@ public class OrientationBanner implements IsWidget {
       primaryButtonConfig,
       secondaryButtonConfig
     );
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.OrientationBanner,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/PortalBannersWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/PortalBannersWidget.java
@@ -23,7 +23,7 @@ public class PortalBannersWidget extends ReactComponent {
     SynapsePortalBannersProps props = SynapsePortalBannersProps.create(
       entityId
     );
-    ReactElement component = React.createElementWithThemeContext(
+    ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapsePortalBanners,
       props
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/ReactComponentV2.java
@@ -56,7 +56,11 @@ public abstract class ReactComponentV2<
   public ReactComponentV2(T reactComponentType, P props, String tag) {
     this.reactComponentType = reactComponentType;
     this.props = props;
-    setElement(Document.get().createElement(tag));
+    Element el = Document.get().createElement(tag);
+    // For the element that wraps this React root, `display: contents;`, which causes an element's children to appear
+    // as if they were direct children of the element's parent
+    el.setAttribute("style", "display: contents;");
+    setElement(el);
   }
 
   /**
@@ -142,10 +146,10 @@ public abstract class ReactComponentV2<
     }
   }
 
-  private ReactElement<T, P> createReactElement() {
+  private ReactElement<?, ?> createReactElement() {
     detachNonReactChildElements();
     maybeUpdatePropsWithCallbackRef();
-    return React.createElement(
+    return React.createElementWithSynapseContext(
       reactComponentType,
       props,
       getChildReactElements()
@@ -248,7 +252,7 @@ public abstract class ReactComponentV2<
    *
    * @param child the widget to be added
    * @throws UnsupportedOperationException if this method is not supported (most
-   *           often this means that a specific overload must be called)
+   *                                       often this means that a specific overload must be called)
    */
   @Override
   public void add(Widget child) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/AccessRequirementRelatedProjectsList.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.widget.accessrequirements;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementRelatedProjectsListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -16,16 +15,13 @@ public class AccessRequirementRelatedProjectsList implements IsWidget {
 
   ReactComponent container;
   public IsACTMemberAsyncHandler isACTMemberAsyncHandler;
-  public SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public AccessRequirementRelatedProjectsList(
-    IsACTMemberAsyncHandler isACTMemberAsyncHandler,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    IsACTMemberAsyncHandler isACTMemberAsyncHandler
   ) {
     container = new ReactComponent();
     this.isACTMemberAsyncHandler = isACTMemberAsyncHandler;
-    this.propsProvider = propsProvider;
     container.setVisible(false);
   }
 
@@ -34,8 +30,7 @@ public class AccessRequirementRelatedProjectsList implements IsWidget {
       AccessRequirementRelatedProjectsListProps.create(accessRequirementId);
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.AccessRequirementRelatedProjectsList,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     container.render(component);
     showIfACTMember();

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/EntitySubjectsWidgetViewImpl.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.widget.accessrequirements;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.repo.model.request.ReferenceList;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityHeaderTableProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -13,15 +12,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class EntitySubjectsWidgetViewImpl implements EntitySubjectsWidgetView {
 
   ReactComponent reactContainer;
-  SynapseReactClientFullContextPropsProvider propsProvider;
   Presenter presenter;
 
   @Inject
-  public EntitySubjectsWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public EntitySubjectsWidgetViewImpl() {
     reactContainer = new ReactComponent();
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -56,8 +51,7 @@ public class EntitySubjectsWidgetViewImpl implements EntitySubjectsWidgetView {
         newEntityIDsValue -> {
           presenter.onChangeEntityIDsValue(newEntityIDsValue);
         }
-      ),
-      propsProvider.getJsInteropContextProps()
+      )
     );
     reactContainer.render(element);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/ManagedACTAccessRequirementWidgetViewImpl.java
@@ -19,7 +19,6 @@ import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.repo.model.RestrictableObjectType;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -131,7 +130,6 @@ public class ManagedACTAccessRequirementWidgetViewImpl
   @UiField
   Div subjectsDefinedInAccessRequirementUI;
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   Callback onAttachCallback;
   public static final String DEFAULT_AR_DESCRIPTION = "these data";
 
@@ -144,11 +142,9 @@ public class ManagedACTAccessRequirementWidgetViewImpl
   @Inject
   public ManagedACTAccessRequirementWidgetViewImpl(
     Binder binder,
-    GlobalApplicationState globalAppState,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    GlobalApplicationState globalAppState
   ) {
     this.w = binder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
     cancelRequestButton.addClickHandler(event -> {
       presenter.onCancelRequest();
     });
@@ -403,8 +399,7 @@ public class ManagedACTAccessRequirementWidgetViewImpl
     requestDataAccessWidget.render(
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.AccessRequirementList,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       )
     );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateManagedACTAccessRequirementStep3ViewImpl.java
@@ -4,7 +4,6 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorHandler;
 import org.sagebionetworks.web.client.jsinterop.AccessRequirementAclEditorProps;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -26,16 +25,11 @@ public class CreateManagedACTAccessRequirementStep3ViewImpl
 
   ReactRef<AccessRequirementAclEditorHandler> componentRef;
 
-  SynapseReactClientFullContextPropsProvider propsProvider;
   Presenter presenter;
 
   @Inject
-  public CreateManagedACTAccessRequirementStep3ViewImpl(
-    Binder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public CreateManagedACTAccessRequirementStep3ViewImpl(Binder binder) {
     widget = binder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -50,8 +44,7 @@ public class CreateManagedACTAccessRequirementStep3ViewImpl
           presenter.onSaveComplete(saveSuccessful);
         },
         componentRef
-      ),
-      propsProvider.getJsInteropContextProps()
+      )
     );
     reactContainer.render(element);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/accessrequirements/createaccessrequirement/CreateOrUpdateAccessRequirementWizard.java
@@ -5,7 +5,6 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateAccessRequirementWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -13,8 +12,6 @@ import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
-
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   private final ReactComponent reactComponent;
 
@@ -25,11 +22,8 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
   private CreateOrUpdateAccessRequirementWizardProps.OnCancel onCancel;
 
   @Inject
-  public CreateOrUpdateAccessRequirementWizard(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public CreateOrUpdateAccessRequirementWizard() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -45,8 +39,7 @@ public class CreateOrUpdateAccessRequirementWizard implements IsWidget {
 
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateOrUpdateAccessRequirementWizard,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/breadcrumb/BreadcrumbViewImpl.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.BreadcrumbItem;
 import org.sagebionetworks.web.client.jsinterop.EntityPageBreadcrumbsProps;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -16,15 +15,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class BreadcrumbViewImpl implements BreadcrumbView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   ReactComponent container;
   private Presenter presenter;
 
   @Inject
-  public BreadcrumbViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
+  public BreadcrumbViewImpl() {
     container = new ReactComponent();
   }
 
@@ -83,8 +78,7 @@ public class BreadcrumbViewImpl implements BreadcrumbView {
 
     ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageBreadcrumbs,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
 
     container.render(element);

--- a/src/main/java/org/sagebionetworks/web/client/widget/certificationquiz/CertificationQuiz.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/certificationquiz/CertificationQuiz.java
@@ -1,20 +1,16 @@
 package org.sagebionetworks.web.client.widget.certificationquiz;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class CertificationQuiz extends ReactComponent {
 
-  public CertificationQuiz(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider
-  ) {
+  public CertificationQuiz() {
     this.render(
         React.createElementWithSynapseContext(
           SRC.SynapseComponents.CertificationQuiz,
-          null,
-          contextPropsProvider.getJsInteropContextProps()
+          null
         )
       );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadViewImpl.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.widget.discussion;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DiscussionThreadProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -9,16 +8,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class DiscussionThreadViewImpl extends ReactComponent {
 
-  public DiscussionThreadViewImpl(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider,
-    String threadId,
-    int limit
-  ) {
+  public DiscussionThreadViewImpl(String threadId, int limit) {
     DiscussionThreadProps props = DiscussionThreadProps.create(threadId, limit);
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DiscussionThread,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumSearchWrapper.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.widget.discussion;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps;
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps.OnSearchResultsVisibleHandler;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -11,7 +10,6 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class ForumSearchWrapper extends ReactComponent {
 
   public ForumSearchWrapper(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider,
     String forumId,
     String projectId,
     OnSearchResultsVisibleHandler onSearchResultsVisible
@@ -23,8 +21,7 @@ public class ForumSearchWrapper extends ReactComponent {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ForumSearch,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/ForumWidgetViewImpl.java
@@ -10,7 +10,6 @@ import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ForumSearchProps.OnSearchResultsVisibleHandler;
 
 public class ForumWidgetViewImpl implements ForumWidgetView {
@@ -74,18 +73,13 @@ public class ForumWidgetViewImpl implements ForumWidgetView {
   Div newThreadButtonFlexContainer;
 
   private Presenter presenter;
-  private SynapseReactClientFullContextPropsProvider propsProvider;
   Widget widget;
 
   public interface Binder extends UiBinder<Widget, ForumWidgetViewImpl> {}
 
   @Inject
-  public ForumWidgetViewImpl(
-    Binder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public ForumWidgetViewImpl(Binder binder) {
     widget = binder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
     newThreadButton.addClickHandler(event -> {
       presenter.onClickNewThread();
     });
@@ -228,7 +222,6 @@ public class ForumWidgetViewImpl implements ForumWidgetView {
       setSearchResultsVisible(visible);
     };
     ForumSearchWrapper widget = new ForumSearchWrapper(
-      propsProvider,
       forumId,
       projectId,
       onSearchUIVisible
@@ -245,7 +238,6 @@ public class ForumWidgetViewImpl implements ForumWidgetView {
   @Override
   public void configureDiscussionThread(String threadId, int limit) {
     DiscussionThreadViewImpl widget = new DiscussionThreadViewImpl(
-      propsProvider,
       threadId,
       limit
     );

--- a/src/main/java/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModal.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/doi/CreateOrUpdateDoiModal.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import javax.annotation.Nullable;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.ObjectType;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateOrUpdateDoiModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -13,20 +12,13 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class CreateOrUpdateDoiModal extends ReactComponent {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   @Inject
-  public CreateOrUpdateDoiModal(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
-  }
+  public CreateOrUpdateDoiModal() {}
 
   private void renderComponent(CreateOrUpdateDoiModalProps props) {
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateOrUpdateDoiModal,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadge.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadge.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.events.DownloadListUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.EntityBadgeIconsProps;
 import org.sagebionetworks.web.client.place.LoginPlace;
@@ -42,7 +41,6 @@ public class EntityBadge
   private final PopupUtilsView popupUtils;
   private final EventBus eventBus;
   private ClickHandler customClickHandler;
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   private final EntityBadgeIconsProps.OnUnlinkSuccess onUnlinkSuccess;
   private final EntityBadgeIconsProps.OnUnlinkError onUnlinkError;
@@ -55,8 +53,7 @@ public class EntityBadge
     LazyLoadHelper lazyLoadHelper,
     PopupUtilsView popupUtils,
     EventBus eventBus,
-    AuthenticationController authController,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    AuthenticationController authController
   ) {
     this.view = view;
     this.globalAppState = globalAppState;
@@ -65,7 +62,6 @@ public class EntityBadge
     this.popupUtils = popupUtils;
     this.eventBus = eventBus;
     this.authController = authController;
-    this.propsProvider = propsProvider;
 
     Callback loadDataCallback = this::getEntityBundle;
 
@@ -138,7 +134,7 @@ public class EntityBadge
       onUnlinkError
     );
 
-    view.setIcons(iconsProps, propsProvider.getJsInteropContextProps());
+    view.setIcons(iconsProps);
 
     // In experimental mode, check if there's a bound JSON Schema + check validity
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeView.java
@@ -20,10 +20,7 @@ public interface EntityBadgeView extends IsWidget, SupportsLazyLoadInterface {
 
   void setMd5(String s);
 
-  void setIcons(
-    EntityBadgeIconsProps props,
-    SynapseReactClientFullContextProviderProps contextProps
-  );
+  void setIcons(EntityBadgeIconsProps props);
 
   void setError(String error);
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityBadgeViewImpl.java
@@ -281,14 +281,10 @@ public class EntityBadgeViewImpl extends Composite implements EntityBadgeView {
   }
 
   @Override
-  public void setIcons(
-    EntityBadgeIconsProps props,
-    SynapseReactClientFullContextProviderProps providerProps
-  ) {
+  public void setIcons(EntityBadgeIconsProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityBadgeIcons,
-      props,
-      providerProps
+      props
     );
 
     iconsContainer.render(reactElement);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityModalWidgetViewImpl.java
@@ -2,21 +2,19 @@ package org.sagebionetworks.web.client.widget.entity;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
-import org.sagebionetworks.web.client.jsinterop.*;
+import org.sagebionetworks.web.client.jsinterop.EntityModalProps;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class EntityModalWidgetViewImpl implements EntityModalWidgetView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   private final ReactComponent reactComponent;
 
   @Inject
-  public EntityModalWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public EntityModalWidgetViewImpl() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -24,8 +22,7 @@ public class EntityModalWidgetViewImpl implements EntityModalWidgetView {
   public void renderComponent(EntityModalProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityModal,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityViewScopeEditorModalWidgetViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.entity;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityViewScopeEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -12,15 +11,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class EntityViewScopeEditorModalWidgetViewImpl
   implements EntityViewScopeEditorModalWidgetView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   private final ReactComponent reactComponent;
 
   @Inject
-  public EntityViewScopeEditorModalWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public EntityViewScopeEditorModalWidgetViewImpl() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -28,8 +23,7 @@ public class EntityViewScopeEditorModalWidgetViewImpl
   public void renderComponent(EntityViewScopeEditorModalProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityViewScopeEditorModal,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/ModifiedCreatedByWidgetViewImpl.java
@@ -4,7 +4,6 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreatedByModifiedByProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -22,15 +21,11 @@ public class ModifiedCreatedByWidgetViewImpl
 
   private Widget widget;
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   @Inject
   public ModifiedCreatedByWidgetViewImpl(
-    ModifiedCreatedByWidgetViewImplUiBinder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    ModifiedCreatedByWidgetViewImplUiBinder binder
   ) {
     widget = binder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -42,8 +37,7 @@ public class ModifiedCreatedByWidgetViewImpl
   public void setProps(CreatedByModifiedByProps props) {
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreatedByModifiedBy,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     container.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/SqlDefinedEditorModalWidgetViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.entity;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -12,15 +11,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class SqlDefinedEditorModalWidgetViewImpl
   implements SqlDefinedEditorModalWidgetView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   private final ReactComponent reactComponent;
 
   @Inject
-  public SqlDefinedEditorModalWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public SqlDefinedEditorModalWidgetViewImpl() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -28,8 +23,7 @@ public class SqlDefinedEditorModalWidgetViewImpl
   public void renderComponent(SqlDefinedTableEditorModalProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SqlDefinedTableEditorModal,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/browse/EntityFinderWidgetViewImpl.java
@@ -15,9 +15,6 @@ import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.PopupUtilsView;
-import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityFinderProps;
 import org.sagebionetworks.web.client.jsinterop.EntityFinderScope;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -35,9 +32,7 @@ public class EntityFinderWidgetViewImpl implements EntityFinderWidgetView {
 
   private Presenter presenter;
 
-  private SynapseJSNIUtils jsniUtils;
   private SynapseAlert synAlert;
-  private SynapseReactClientFullContextPropsProvider contextPropsProvider;
 
   // the modal dialog
   private Modal modal;
@@ -64,18 +59,10 @@ public class EntityFinderWidgetViewImpl implements EntityFinderWidgetView {
   SimplePanel synAlertPanel;
 
   @Inject
-  public EntityFinderWidgetViewImpl(
-    Binder uiBinder,
-    SynapseJSNIUtils jsniUtils,
-    SynapseAlert synAlert,
-    final SynapseReactClientFullContextPropsProvider propsProvider,
-    final PopupUtilsView popupUtils
-  ) {
+  public EntityFinderWidgetViewImpl(Binder uiBinder, SynapseAlert synAlert) {
     this.modal = (Modal) uiBinder.createAndBindUi(this);
 
-    this.jsniUtils = jsniUtils;
     this.synAlert = synAlert;
-    this.contextPropsProvider = propsProvider;
 
     synAlertPanel.setWidget(synAlert);
 
@@ -158,8 +145,7 @@ public class EntityFinderWidgetViewImpl implements EntityFinderWidgetView {
 
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityFinder,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     entityFinderContainer.render(component);
     modal.show();

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/StuAlertViewImpl.java
@@ -8,7 +8,6 @@ import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ErrorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -21,7 +20,6 @@ public class StuAlertViewImpl implements StuAlertView {
   public interface Binder extends UiBinder<Widget, StuAlertViewImpl> {}
 
   Widget widget;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @UiField
   ReactComponent errorPageContainer;
@@ -38,11 +36,7 @@ public class StuAlertViewImpl implements StuAlertView {
   GlobalApplicationState globalAppState;
 
   @Inject
-  public StuAlertViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider,
-    GlobalApplicationState globalAppState
-  ) {
-    this.propsProvider = propsProvider;
+  public StuAlertViewImpl(GlobalApplicationState globalAppState) {
     this.globalAppState = globalAppState;
   }
 
@@ -94,8 +88,7 @@ public class StuAlertViewImpl implements StuAlertView {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ErrorPage,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     errorPageContainer.render(component);
     errorPageContainer.setVisible(true);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetV2.java
@@ -6,7 +6,6 @@ import com.google.inject.Inject;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.FileList;
 import org.sagebionetworks.web.client.GlobalApplicationState;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.EntityUploadHandle;
 import org.sagebionetworks.web.client.jsinterop.EntityUploadModalProps;
@@ -19,7 +18,6 @@ public class UploadDialogWidgetV2 extends Widget {
 
   private final GlobalApplicationState globalApplicationState;
   private final EventBus eventBus;
-  private final SynapseReactClientFullContextPropsProvider contextProvider;
   private int keyCounter = 0;
 
   private final ReactComponent reactComponent;
@@ -30,12 +28,10 @@ public class UploadDialogWidgetV2 extends Widget {
   @Inject
   public UploadDialogWidgetV2(
     GlobalApplicationState globalApplicationState,
-    EventBus eventBus,
-    SynapseReactClientFullContextPropsProvider contextProvider
+    EventBus eventBus
   ) {
     this.globalApplicationState = globalApplicationState;
     this.eventBus = eventBus;
-    this.contextProvider = contextProvider;
     this.reactComponent = new ReactComponent();
   }
 
@@ -59,8 +55,7 @@ public class UploadDialogWidgetV2 extends Widget {
     reactComponent.render(
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.EntityUploadModal,
-        props,
-        contextProvider.getJsInteropContextProps()
+        props
       )
     );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/AddToDownloadListV2Impl.java
@@ -6,7 +6,6 @@ import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.QueryBundleRequest;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.DownloadConfirmationProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -15,8 +14,6 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class AddToDownloadListV2Impl implements AddToDownloadListV2 {
 
-  private SynapseReactClientFullContextPropsProvider propsProvider;
-
   ReactComponent container = new ReactComponent();
 
   String queryBundleRequestJson;
@@ -24,11 +21,7 @@ public class AddToDownloadListV2Impl implements AddToDownloadListV2 {
   JSONObjectAdapter adapter;
 
   @Inject
-  public AddToDownloadListV2Impl(
-    SynapseReactClientFullContextPropsProvider propsProvider,
-    JSONObjectAdapter adapter
-  ) {
-    this.propsProvider = propsProvider;
+  public AddToDownloadListV2Impl(JSONObjectAdapter adapter) {
     this.adapter = adapter;
   }
 
@@ -74,8 +67,7 @@ public class AddToDownloadListV2Impl implements AddToDownloadListV2 {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.DownloadConfirmation,
-      editorProps,
-      propsProvider.getJsInteropContextProps()
+      editorProps
     );
     container.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/file/BasicTitleBarViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityPageTitleBarProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -15,8 +14,6 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class BasicTitleBarViewImpl implements BasicTitleBarView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   @UiField
   ReactComponent reactComponentContainer;
 
@@ -24,8 +21,7 @@ public class BasicTitleBarViewImpl implements BasicTitleBarView {
   public void setProps(EntityPageTitleBarProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityPageTitleBar,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponentContainer.render(reactElement);
   }
@@ -39,11 +35,8 @@ public class BasicTitleBarViewImpl implements BasicTitleBarView {
   Widget widget;
 
   @Inject
-  public BasicTitleBarViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public BasicTitleBarViewImpl() {
     widget = uiBinder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/EntityActionMenuViewImpl.java
@@ -5,7 +5,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -15,19 +14,13 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class EntityActionMenuViewImpl implements EntityActionMenuView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   private final FlowPanel panel = new FlowPanel();
   private final ReactComponent menuComponent = new ReactComponent();
   private final ReactComponent loaderComponent = new ReactComponent();
   private final SimplePanel controllerWidgetContainer = new SimplePanel();
 
   @Inject
-  private EntityActionMenuViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
-
+  private EntityActionMenuViewImpl() {
     renderLoaderComponent();
 
     panel.add(menuComponent);
@@ -54,8 +47,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   private void renderMenuComponent(EntityActionMenuPropsJsInterop props) {
     ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EntityActionMenu,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     menuComponent.render(node);
   }
@@ -63,8 +55,7 @@ public class EntityActionMenuViewImpl implements EntityActionMenuView {
   private void renderLoaderComponent() {
     ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SkeletonButton,
-      SkeletonButtonProps.create("Tools Menu Placeholder"),
-      propsProvider.getJsInteropContextProps()
+      SkeletonButtonProps.create("Tools Menu Placeholder")
     );
     loaderComponent.render(node);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/HtmlPreviewViewImpl.java
@@ -6,7 +6,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.html.Div;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HtmlPreviewProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -27,15 +26,10 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
   ReactComponent container;
 
   Widget w;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public HtmlPreviewViewImpl(
-    Binder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public HtmlPreviewViewImpl(Binder binder) {
     w = binder.createAndBindUi(this);
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -49,8 +43,7 @@ public class HtmlPreviewViewImpl implements HtmlPreviewView {
 
     ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HtmlPreview,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
 
     container.render(element);

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/IntendedDataUseReportWidgetViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.entity.renderer;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.IDUReportProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -13,15 +12,10 @@ public class IntendedDataUseReportWidgetViewImpl
   implements IntendedDataUseReportWidgetView {
 
   ReactComponent reactComponent;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public IntendedDataUseReportWidgetViewImpl(
-    ReactComponent reactComponent,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public IntendedDataUseReportWidgetViewImpl(ReactComponent reactComponent) {
     this.reactComponent = reactComponent;
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -30,8 +24,7 @@ public class IntendedDataUseReportWidgetViewImpl
 
     ReactElement node = React.createElementWithSynapseContext(
       SRC.SynapseComponents.IDUReport,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(node);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/restriction/v2/RestrictionWidgetViewImpl.java
@@ -10,7 +10,6 @@ import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
 import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.HasAccessProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -55,17 +54,14 @@ public class RestrictionWidgetViewImpl implements RestrictionWidgetView {
   // this UI widget
   Widget widget;
   RestrictionWidgetModalsViewImpl modals;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public RestrictionWidgetViewImpl(
     Binder binder,
-    RestrictionWidgetModalsViewImpl modals,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    RestrictionWidgetModalsViewImpl modals
   ) {
     this.widget = binder.createAndBindUi(this);
     this.modals = modals;
-    this.propsProvider = propsProvider;
     modalsContainer.add(modals);
 
     changeLink.addClickHandler(event -> {
@@ -196,8 +192,7 @@ public class RestrictionWidgetViewImpl implements RestrictionWidgetView {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.HasAccess,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     hasAccessContainer.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/AdministerEvaluationsListViewImpl.java
@@ -8,7 +8,6 @@ import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EvaluationCardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -23,7 +22,6 @@ public class AdministerEvaluationsListViewImpl
     extends UiBinder<Widget, AdministerEvaluationsListViewImpl> {}
 
   private EvaluationActionHandler presenter;
-  private SynapseReactClientFullContextPropsProvider contextPropsProvider;
 
   @UiField
   Div rows;
@@ -37,12 +35,10 @@ public class AdministerEvaluationsListViewImpl
   @Inject
   public AdministerEvaluationsListViewImpl(
     Binder binder,
-    PortalGinInjector ginInjector,
-    final SynapseReactClientFullContextPropsProvider contextPropsProvider
+    PortalGinInjector ginInjector
   ) {
     this.ginInjector = ginInjector;
     widget = binder.createAndBindUi(this);
-    this.contextPropsProvider = contextPropsProvider;
   }
 
   @Override
@@ -83,8 +79,7 @@ public class AdministerEvaluationsListViewImpl
 
     ReactElement element = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationCard,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     container.render(element);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
@@ -8,7 +8,6 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.Anchor;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EvaluationEditorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactDOM;
@@ -20,8 +19,6 @@ public class EvaluationEditorReactComponentPage extends Composite {
 
   public interface Binder
     extends UiBinder<Widget, EvaluationEditorReactComponentPage> {}
-
-  private SynapseReactClientFullContextPropsProvider propsProvider;
 
   @UiField
   Anchor backToChallenge;
@@ -36,11 +33,7 @@ public class EvaluationEditorReactComponentPage extends Composite {
   boolean utc;
 
   @Inject
-  public EvaluationEditorReactComponentPage(
-    Binder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
+  public EvaluationEditorReactComponentPage(Binder binder) {
     initWidget(binder.createAndBindUi(this));
   }
 
@@ -68,8 +61,7 @@ public class EvaluationEditorReactComponentPage extends Composite {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.EvaluationEditorPage,
-      editorProps,
-      propsProvider.getJsInteropContextProps()
+      editorProps
     );
     evaluationEditorContainer.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationListViewImpl.java
@@ -5,7 +5,6 @@ import com.google.inject.Inject;
 import java.util.List;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.web.client.DisplayUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.AvailableEvaluationQueueListProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -14,15 +13,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class EvaluationListViewImpl implements EvaluationListView {
 
-  SynapseReactClientFullContextPropsProvider propsProvider;
   ReactComponent reactContainer;
   Presenter presenter;
 
   @Inject
-  public EvaluationListViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
+  public EvaluationListViewImpl() {
     reactContainer = new ReactComponent();
   }
 
@@ -36,8 +31,7 @@ public class EvaluationListViewImpl implements EvaluationListView {
         evaluation -> {
           presenter.onChangeSelectedEvaluation(evaluation);
         }
-      ),
-      propsProvider.getJsInteropContextProps()
+      )
     );
     reactContainer.render(element);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/SubmissionViewScopeEditorModalWidgetViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.evaluation;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -12,15 +11,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class SubmissionViewScopeEditorModalWidgetViewImpl
   implements SubmissionViewScopeEditorModalWidgetView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
   private final ReactComponent reactComponent;
 
   @Inject
-  public SubmissionViewScopeEditorModalWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public SubmissionViewScopeEditorModalWidgetViewImpl() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -28,8 +23,7 @@ public class SubmissionViewScopeEditorModalWidgetViewImpl
   public void renderComponent(SubmissionViewScopeEditorModalProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SubmissionViewScopeEditorModal,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/footer/FooterViewImpl.java
@@ -8,7 +8,6 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -24,16 +23,10 @@ public class FooterViewImpl implements FooterView, IsWidget {
 
   String portalVersion, repoVersion, srcVersion;
   PortalGinInjector ginInjector;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public FooterViewImpl(
-    PortalGinInjector ginInjector,
-    GWTWrapper gwt,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public FooterViewImpl(PortalGinInjector ginInjector, GWTWrapper gwt) {
     this.ginInjector = ginInjector;
-    this.propsProvider = propsProvider;
     // defer constructing this view (to give a chance for other page components to load first)
     Callback constructViewCallback = () -> {
       wrapper.add(container);
@@ -93,8 +86,7 @@ public class FooterViewImpl implements FooterView, IsWidget {
       );
       ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.SynapseFooter,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       );
       container.render(component);
     }

--- a/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/header/HeaderViewImpl.java
@@ -19,7 +19,6 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CookieNotificationProps;
 import org.sagebionetworks.web.client.jsinterop.EmptyProps;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -75,19 +74,16 @@ public class HeaderViewImpl extends Composite implements HeaderView {
 
   private Presenter presenter;
   String portalHref = "";
-  SynapseReactClientFullContextPropsProvider propsProvider;
   PortalGinInjector ginInjector;
 
   @Inject
   public HeaderViewImpl(
     Binder binder,
-    SynapseReactClientFullContextPropsProvider propsProvider,
     PortalGinInjector ginInjector,
     OrientationBanner donationBanner
   ) {
     this.initWidget(binder.createAndBindUi(this));
     this.ginInjector = ginInjector;
-    this.propsProvider = propsProvider;
     nihNotificationAlert.setOnClose(() -> {
       presenter.onNIHNotificationDismissed();
     });
@@ -113,8 +109,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
     });
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CookiesNotification,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     cookieNotificationContainer.render(component);
 
@@ -128,8 +123,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
     EmptyProps props = EmptyProps.create();
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.GoogleAnalytics,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     googleAnalyticsContainer.render(component);
   }
@@ -147,8 +141,7 @@ public class HeaderViewImpl extends Composite implements HeaderView {
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.SynapseNavDrawer,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     synapseNavDrawerContainer.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/login/LoginWidgetViewImpl.java
@@ -9,7 +9,6 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.LoginPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -36,21 +35,18 @@ public class LoginWidgetViewImpl implements LoginWidgetView, IsWidget {
   SynapseJSNIUtils jsniUtils;
   GlobalApplicationState globalAppState;
   AuthenticationController authController;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public LoginWidgetViewImpl(
     LoginWidgetViewImplUiBinder binder,
     SynapseJSNIUtils jsniUtils,
     GlobalApplicationState globalAppState,
-    AuthenticationController authController,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    AuthenticationController authController
   ) {
     widget = binder.createAndBindUi(this);
     this.jsniUtils = jsniUtils;
     this.globalAppState = globalAppState;
     this.authController = authController;
-    this.propsProvider = propsProvider;
     widget.addAttachHandler(event -> {
       if (event.isAttached()) {
         LoginPageProps props = LoginPageProps.create(
@@ -60,8 +56,7 @@ public class LoginWidgetViewImpl implements LoginWidgetView, IsWidget {
         );
         ReactElement component = React.createElementWithSynapseContext(
           SRC.SynapseComponents.LoginPage,
-          props,
-          propsProvider.getJsInteropContextProps()
+          props
         );
         srcLoginContainer.render(component);
       }

--- a/src/main/java/org/sagebionetworks/web/client/widget/oauthclient/OAuthClientEditor.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/oauthclient/OAuthClientEditor.java
@@ -1,20 +1,15 @@
 package org.sagebionetworks.web.client.widget.oauthclient;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class OAuthClientEditor extends ReactComponent {
 
-  public OAuthClientEditor(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider
-  ) {
+  public OAuthClientEditor() {
     this.render(
         React.createElementWithSynapseContext(
-          SRC.SynapseComponents.OAuthManagement,
-          null,
-          contextPropsProvider.getJsInteropContextProps()
+          SRC.SynapseComponents.OAuthManagement
         )
       );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/pageprogress/PageProgressWidgetViewImpl.java
@@ -5,9 +5,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.SynapseProperties;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.PageProgressProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -25,20 +22,11 @@ public class PageProgressWidgetViewImpl
   ReactComponent srcContainer;
 
   Widget widget;
-  SynapseJSNIUtils jsniUtils;
-  SynapseReactClientFullContextPropsProvider propsProvider;
   boolean isConfigured = false;
 
   @Inject
-  public PageProgressWidgetViewImpl(
-    PageProgressWidgetViewImplUiBinder binder,
-    SynapseJSNIUtils jsniUtils,
-    SynapseProperties synapseProperties,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public PageProgressWidgetViewImpl(PageProgressWidgetViewImplUiBinder binder) {
     widget = binder.createAndBindUi(this);
-    this.jsniUtils = jsniUtils;
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -62,8 +50,7 @@ public class PageProgressWidgetViewImpl
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.PageProgress,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     srcContainer.render(component);
     isConfigured = true;

--- a/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/profile/UserProfileWidgetViewImpl.java
@@ -22,10 +22,7 @@ import org.gwtbootstrap3.client.ui.html.Paragraph;
 import org.sagebionetworks.repo.model.UserBundle;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.OneSageUtils;
-import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
-import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.AccountLevelBadgesProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -121,23 +118,14 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
 
   private Widget widget;
 
-  SynapseJSNIUtils jsniUtils;
-  SynapseReactClientFullContextPropsProvider propsProvider;
-  CookieProvider cookies;
   SynapseJavascriptClient jsClient;
 
   @Inject
   public UserProfileWidgetViewImpl(
     Binder binder,
-    SynapseJSNIUtils jsniUtils,
-    SynapseReactClientFullContextPropsProvider propsProvider,
-    CookieProvider cookies,
     SynapseJavascriptClient jsClient,
     OneSageUtils oneSageUtils
   ) {
-    this.jsniUtils = jsniUtils;
-    this.propsProvider = propsProvider;
-    this.cookies = cookies;
     this.jsClient = jsClient;
     widget = binder.createAndBindUi(this);
     editProfileButton.addClickHandler(event -> {
@@ -256,8 +244,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
     ReactElement accountLevelBadgesComponent =
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.AccountLevelBadges,
-        AccountLevelBadgesProps.create(userId),
-        propsProvider.getJsInteropContextProps()
+        AccountLevelBadgesProps.create(userId)
       );
     accountLevelBadgesContainer.render(accountLevelBadgesComponent);
     setAccountTypeVisibility(Long.parseLong(userId));
@@ -265,8 +252,7 @@ public class UserProfileWidgetViewImpl implements UserProfileWidgetView {
     UserProfileLinksProps props = UserProfileLinksProps.create(userId);
     ReactElement profileLinksComponent = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserProfileLinks,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     userProfileLinksReactComponentContainer.render(profileLinksComponent);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/projectdataavailability/ProjectDataAvailabilityViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/projectdataavailability/ProjectDataAvailabilityViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.projectdataavailability;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ProjectDataAvailabilityProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -13,14 +12,9 @@ public class ProjectDataAvailabilityViewImpl
   implements ProjectDataAvailabilityView {
 
   ReactComponent container = new ReactComponent();
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
-  public ProjectDataAvailabilityViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
-    this.propsProvider = propsProvider;
-  }
+  public ProjectDataAvailabilityViewImpl() {}
 
   @Override
   public Widget asWidget() {
@@ -35,8 +29,7 @@ public class ProjectDataAvailabilityViewImpl
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ProjectDataAvailability,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     container.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/provenance/v2/ProvenanceWidgetViewImpl.java
@@ -4,7 +4,6 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.inject.Inject;
 import java.util.List;
 import org.sagebionetworks.repo.model.Reference;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps;
 import org.sagebionetworks.web.client.jsinterop.ProvenanceGraphProps.OnUpdateJavaScriptObject;
 import org.sagebionetworks.web.client.jsinterop.React;
@@ -24,14 +23,9 @@ public class ProvenanceWidgetViewImpl
   OnUpdateJavaScriptObject nodesListener;
   OnUpdateJavaScriptObject edgesListener;
 
-  SynapseReactClientFullContextPropsProvider contextPropsProvider;
-
   @Inject
-  public ProvenanceWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider
-  ) {
+  public ProvenanceWidgetViewImpl() {
     addStyleName("overflowHidden");
-    this.contextPropsProvider = contextPropsProvider;
     this.nodesListener =
       jsObject -> {
         initialNodes = jsObject;
@@ -59,8 +53,7 @@ public class ProvenanceWidgetViewImpl
     );
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.ProvenanceGraph,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/sharing/EntityAccessControlListModalWidgetImpl.java
@@ -4,7 +4,6 @@ import static org.sagebionetworks.web.client.jsinterop.SRC.SynapseComponents.Ent
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.EntityAclEditorModalProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -14,17 +13,12 @@ public class EntityAccessControlListModalWidgetImpl
   implements EntityAccessControlListModalWidget {
 
   private final ReactComponent reactComponent;
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   private EntityAclEditorModalProps componentProps;
 
   @Inject
-  EntityAccessControlListModalWidgetImpl(
-    ReactComponent reactComponent,
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  EntityAccessControlListModalWidgetImpl(ReactComponent reactComponent) {
     this.reactComponent = reactComponent;
-    this.propsProvider = propsProvider;
   }
 
   @Override
@@ -66,8 +60,7 @@ public class EntityAccessControlListModalWidgetImpl
   private void renderComponent() {
     ReactElement node = React.createElementWithSynapseContext(
       EntityAclEditorModal,
-      componentProps,
-      propsProvider.getJsInteropContextProps()
+      componentProps
     );
     reactComponent.render(node);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/QueryWrapperPlotNav.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.web.client.widget.table.explore;
 
-import java.util.Map;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CardConfiguration;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryCallback;
@@ -16,7 +14,6 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class QueryWrapperPlotNav extends ReactComponent {
 
   public QueryWrapperPlotNav(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider,
     String sql,
     String initQueryJson,
     OnQueryCallback onQueryChange,
@@ -49,8 +46,7 @@ public class QueryWrapperPlotNav extends ReactComponent {
 
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.QueryWrapperPlotNav,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/StandaloneQueryWrapper.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.widget.table.explore;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -9,15 +8,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class StandaloneQueryWrapper extends ReactComponent {
 
-  public StandaloneQueryWrapper(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider,
-    String sql
-  ) {
+  public StandaloneQueryWrapper(String sql) {
     StandaloneQueryWrapperProps props = StandaloneQueryWrapperProps.create(sql);
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.StandaloneQueryWrapper,
-      props,
-      contextPropsProvider.getJsInteropContextProps()
+      props
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/modal/fileview/CreateTableViewWizard.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.web.client.widget.table.modal.fileview;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.CreateTableViewWizardProps;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -12,27 +11,21 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class CreateTableViewWizard implements IsWidget {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   private final ReactComponent reactComponent;
   private String parentId;
   private CreateTableViewWizardProps.OnComplete onComplete;
   private CreateTableViewWizardProps.OnCancel onCancel;
 
   @Inject
-  public CreateTableViewWizard(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public CreateTableViewWizard() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
   private void renderComponent(CreateTableViewWizardProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.CreateTableViewWizard,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/TableEntityWidgetViewImpl.java
@@ -14,7 +14,6 @@ import org.gwtbootstrap3.client.ui.html.Div;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnQueryResultBundleCallback;
 import org.sagebionetworks.web.client.jsinterop.QueryWrapperPlotNavProps.OnViewSharingSettingsHandler;
@@ -82,15 +81,13 @@ public class TableEntityWidgetViewImpl
   EntityViewScopeWidget scopeWidget;
   SubmissionViewScopeWidget submissionViewScopeWidget;
   TableEntityWidgetView.Presenter presenter;
-  SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Inject
   public TableEntityWidgetViewImpl(
     final Binder uiBinder,
     PortalGinInjector ginInjector,
     EntityViewScopeWidget scopeWidget,
-    SubmissionViewScopeWidget submissionViewScopeWidget,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    SubmissionViewScopeWidget submissionViewScopeWidget
   ) {
     initWidget(uiBinder.createAndBindUi(this));
     this.ginInjector = ginInjector;
@@ -100,7 +97,6 @@ public class TableEntityWidgetViewImpl
     this.submissionViewScopeWidget = submissionViewScopeWidget;
     this.scopePanel.add(scopeWidget.asWidget());
     this.scopePanel.add(submissionViewScopeWidget.asWidget());
-    this.propsProvider = propsProvider;
     schemaCollapseCloseButton.addClickHandler(event ->
       this.presenter.toggleSchemaCollapse()
     );
@@ -191,8 +187,7 @@ public class TableEntityWidgetViewImpl
     if (visible) {
       ReactElement component = React.createElementWithSynapseContext(
         SRC.SynapseComponents.DatasetItemsEditor,
-        this.presenter.getItemsEditorProps(),
-        propsProvider.getJsInteropContextProps()
+        this.presenter.getItemsEditorProps()
       );
       itemsEditorContainer.render(component);
     } else {
@@ -202,10 +197,7 @@ public class TableEntityWidgetViewImpl
 
   @Override
   public void configureTableOnly(String sql) {
-    StandaloneQueryWrapper widget = new StandaloneQueryWrapper(
-      propsProvider,
-      sql
-    );
+    StandaloneQueryWrapper widget = new StandaloneQueryWrapper(sql);
     plotNavContainer.clear();
     plotNavContainer.add(widget);
   }
@@ -220,7 +212,6 @@ public class TableEntityWidgetViewImpl
     boolean hideSqlEditorControl
   ) {
     QueryWrapperPlotNav plotNav = new QueryWrapperPlotNav(
-      propsProvider,
       sql,
       initQueryJson,
       onQueryChange,

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/v2/schema/ColumnModelsEditorWidgetViewImpl.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.web.client.widget.table.v2.schema;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -12,16 +11,11 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 public class ColumnModelsEditorWidgetViewImpl
   implements ColumnModelsEditorWidgetView {
 
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-
   private final ReactComponent reactComponent;
 
   @Inject
-  public ColumnModelsEditorWidgetViewImpl(
-    SynapseReactClientFullContextPropsProvider propsProvider
-  ) {
+  public ColumnModelsEditorWidgetViewImpl() {
     super();
-    this.propsProvider = propsProvider;
     reactComponent = new ReactComponent();
   }
 
@@ -29,8 +23,7 @@ public class ColumnModelsEditorWidgetViewImpl
   public void renderComponent(TableColumnSchemaEditorProps props) {
     ReactElement reactElement = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TableColumnSchemaEditor,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     reactComponent.render(reactElement);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/trash/TrashCanList.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.widget.trash;
 
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -8,13 +7,10 @@ import org.sagebionetworks.web.client.widget.ReactComponent;
 
 public class TrashCanList extends ReactComponent {
 
-  public TrashCanList(
-    SynapseReactClientFullContextPropsProvider contextPropsProvider
-  ) {
+  public TrashCanList() {
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.TrashCanList,
-      null,
-      contextPropsProvider.getJsInteropContextProps()
+      null
     );
     this.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/user/UserBadgeViewImpl.java
@@ -20,7 +20,6 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.MenuAction;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
@@ -47,7 +46,6 @@ public class UserBadgeViewImpl extends Div implements UserBadgeView {
   boolean showCardOnHover = true;
   AdapterFactory adapterFactory;
   SynapseJSNIUtils jsniUtils;
-  SynapseReactClientFullContextPropsProvider propsProvider;
   BadgeType badgeType = BadgeType.SMALL_CARD;
   AvatarSize avatarSize = AvatarSize.MEDIUM;
   FocusPanel userBadgeContainer = new FocusPanel();
@@ -61,14 +59,12 @@ public class UserBadgeViewImpl extends Div implements UserBadgeView {
     GlobalApplicationState globalAppState,
     SynapseJSNIUtils jsniUtils,
     AdapterFactory adapterFactory,
-    AuthenticationController authController,
-    final SynapseReactClientFullContextPropsProvider propsProvider
+    AuthenticationController authController
   ) {
     placeChanger = globalAppState.getPlaceChanger();
     this.adapterFactory = adapterFactory;
     this.jsniUtils = jsniUtils;
     this.authController = authController;
-    this.propsProvider = propsProvider;
     setMarginRight(2);
     setMarginLeft(2);
     addStyleName("UserBadge");
@@ -120,8 +116,7 @@ public class UserBadgeViewImpl extends Div implements UserBadgeView {
 
     ReactElement component = React.createElementWithSynapseContext(
       SRC.SynapseComponents.UserCard,
-      props,
-      propsProvider.getJsInteropContextProps()
+      props
     );
     userBadgeReactDiv.render(component);
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionModalViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionModalViewImpl.java
@@ -24,7 +24,6 @@ import org.sagebionetworks.repo.model.verification.VerificationState;
 import org.sagebionetworks.repo.model.verification.VerificationStateEnum;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseProperties;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.RejectProfileValidationRequestModalProps;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -131,7 +130,6 @@ public class VerificationSubmissionModalViewImpl
 
   private final CellFactory cellFactory;
   private final SynapseProperties synapseProperties;
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   @Override
   public void setPresenter(Presenter presenter) {
@@ -142,13 +140,11 @@ public class VerificationSubmissionModalViewImpl
   public VerificationSubmissionModalViewImpl(
     Binder binder,
     CellFactory cellFactory,
-    SynapseProperties synapseProperties,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    SynapseProperties synapseProperties
   ) {
     widget = binder.createAndBindUi(this);
     this.cellFactory = cellFactory;
     this.synapseProperties = synapseProperties;
-    this.propsProvider = propsProvider;
 
     // click handlers
     submitButton.addClickHandler(event -> {
@@ -391,8 +387,7 @@ public class VerificationSubmissionModalViewImpl
     promptModalV2.render(
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.RejectProfileValidationRequestModal,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       )
     );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionRowViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionRowViewImpl.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.repo.model.verification.VerificationState;
 import org.sagebionetworks.repo.model.verification.VerificationStateEnum;
 import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.SynapseProperties;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.React;
 import org.sagebionetworks.web.client.jsinterop.RejectProfileValidationRequestModalProps;
 import org.sagebionetworks.web.client.jsinterop.SRC;
@@ -33,7 +32,6 @@ public class VerificationSubmissionRowViewImpl
   Widget widget;
 
   private final SynapseProperties synapseProperties;
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
 
   @UiField
   Span firstName;
@@ -94,11 +92,9 @@ public class VerificationSubmissionRowViewImpl
   @Inject
   public VerificationSubmissionRowViewImpl(
     Binder binder,
-    SynapseProperties synapseProperties,
-    SynapseReactClientFullContextPropsProvider propsProvider
+    SynapseProperties synapseProperties
   ) {
     this.synapseProperties = synapseProperties;
-    this.propsProvider = propsProvider;
 
     widget = binder.createAndBindUi(this);
 
@@ -313,8 +309,7 @@ public class VerificationSubmissionRowViewImpl
     promptModalV2.render(
       React.createElementWithSynapseContext(
         SRC.SynapseComponents.RejectProfileValidationRequestModal,
-        props,
-        propsProvider.getJsInteropContextProps()
+        props
       )
     );
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/verification/VerificationSubmissionWidget.java
@@ -19,9 +19,7 @@ import org.sagebionetworks.web.client.DisplayUtils;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.SynapseProperties;
 import org.sagebionetworks.web.client.UserProfileClientAsync;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.widget.entity.PromptForValuesModalView;
 import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
@@ -44,8 +42,6 @@ public class VerificationSubmissionWidget
   private final GlobalApplicationState globalAppState;
   private final PortalGinInjector ginInjector;
   private final GWTWrapper gwt;
-  private final SynapseReactClientFullContextPropsProvider propsProvider;
-  private final SynapseProperties synapseProperties;
   // this could be Reject or Suspend. We store this state while the reason is being collected from the
   // ACT user
   private VerificationStateEnum actRejectState;
@@ -61,9 +57,7 @@ public class VerificationSubmissionWidget
     SynapseAlert synAlert,
     FileHandleList fileHandleList,
     GlobalApplicationState globalAppState,
-    GWTWrapper gwt,
-    SynapseReactClientFullContextPropsProvider propsProvider,
-    SynapseProperties synapseProperties
+    GWTWrapper gwt
   ) {
     this.ginInjector = ginInjector;
     this.userProfileClient = userProfileClient;
@@ -72,8 +66,6 @@ public class VerificationSubmissionWidget
     this.fileHandleList = fileHandleList;
     this.globalAppState = globalAppState;
     this.gwt = gwt;
-    this.propsProvider = propsProvider;
-    this.synapseProperties = synapseProperties;
   }
 
   public void initView(boolean isModal) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SessionDetector;
 import org.sagebionetworks.web.client.cache.ClientCache;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.utils.Callback;
 
@@ -37,9 +36,6 @@ public class SessionDetectorTest {
   @Mock
   ClientCache mockClientCache;
 
-  @Mock
-  SynapseReactClientFullContextPropsProvider mockPropsProvider;
-
   @Captor
   ArgumentCaptor<Callback> callbackCaptor;
 
@@ -50,8 +46,7 @@ public class SessionDetectorTest {
         mockAuthController,
         mockGlobalAppState,
         mockGWT,
-        mockClientCache,
-        mockPropsProvider
+        mockClientCache
       );
   }
 
@@ -59,7 +54,6 @@ public class SessionDetectorTest {
   public void testSessionChanges() {
     sessionDetector.start();
 
-    verify(mockPropsProvider).synchronizeContextWithGlobalStore();
     verify(mockGWT)
       .scheduleExecution(
         callbackCaptor.capture(),

--- a/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/SessionDetectorTest.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.SessionDetector;
 import org.sagebionetworks.web.client.cache.ClientCache;
+import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.security.AuthenticationController;
 import org.sagebionetworks.web.client.utils.Callback;
 
@@ -36,6 +37,9 @@ public class SessionDetectorTest {
   @Mock
   ClientCache mockClientCache;
 
+  @Mock
+  SynapseReactClientFullContextPropsProvider mockPropsProvider;
+
   @Captor
   ArgumentCaptor<Callback> callbackCaptor;
 
@@ -46,7 +50,8 @@ public class SessionDetectorTest {
         mockAuthController,
         mockGlobalAppState,
         mockGWT,
-        mockClientCache
+        mockClientCache,
+        mockPropsProvider
       );
   }
 
@@ -54,6 +59,7 @@ public class SessionDetectorTest {
   public void testSessionChanges() {
     sessionDetector.start();
 
+    verify(mockPropsProvider).synchronizeContextWithGlobalStore();
     verify(mockGWT)
       .scheduleExecution(
         callbackCaptor.capture(),

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/TrashPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/TrashPresenterTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.place.Trash;
 import org.sagebionetworks.web.client.presenter.TrashPresenter;
 import org.sagebionetworks.web.client.view.TrashView;
@@ -25,9 +24,6 @@ public class TrashPresenterTest {
   TrashView mockView;
 
   @Mock
-  SynapseReactClientFullContextPropsProvider mockPropsProvider;
-
-  @Mock
   Trash mockPlace;
 
   @Mock
@@ -39,14 +35,14 @@ public class TrashPresenterTest {
   @Before
   public void setup() throws JSONObjectAdapterException {
     mockView = mock(TrashView.class);
-    presenter = new TrashPresenter(mockView, mockPropsProvider);
+    presenter = new TrashPresenter(mockView);
   }
 
   @Test
   public void testStart() {
     presenter.start(mockPanel, mockEventBus);
     verify(mockPanel).setWidget(mockView);
-    verify(mockView).createReactComponentWidget(mockPropsProvider);
+    verify(mockView).createReactComponentWidget();
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityBadgeTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/EntityBadgeTest.java
@@ -43,7 +43,6 @@ import org.sagebionetworks.web.client.PlaceChanger;
 import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
 import org.sagebionetworks.web.client.SynapseProperties;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.events.DownloadListUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.EntityBadgeIconsProps;
@@ -105,9 +104,6 @@ public class EntityBadgeTest {
   @Mock
   CookieProvider mockCookies;
 
-  @Mock
-  SynapseReactClientFullContextPropsProvider propsProvider;
-
   @Captor
   ArgumentCaptor<EntityBadgeIconsProps> iconsPropsArgumentCaptor;
 
@@ -128,8 +124,7 @@ public class EntityBadgeTest {
         mockLazyLoadHelper,
         mockPopupUtils,
         mockEventBus,
-        mockAuthController,
-        propsProvider
+        mockAuthController
       );
 
     when(mockAuthController.isLoggedIn()).thenReturn(true);
@@ -202,7 +197,7 @@ public class EntityBadgeTest {
         entityBundleRequestCaptor.capture(),
         any(AsyncCallback.class)
       );
-    verify(mockView).setIcons(any(), any());
+    verify(mockView).setIcons(any());
     verify(mockView, never()).showAddToDownloadList();
     EntityBundleRequest request = entityBundleRequestCaptor.getValue();
     assertTrue(request.getIncludeEntity());
@@ -231,7 +226,7 @@ public class EntityBadgeTest {
         any(AsyncCallback.class)
       );
     verify(mockView).clearIcons();
-    verify(mockView).setIcons(any(), any());
+    verify(mockView).setIcons(any());
     verify(mockView).showAddToDownloadList();
   }
 
@@ -280,7 +275,7 @@ public class EntityBadgeTest {
     widget.setEntityBundle(bundle);
 
     // Simulate successful delete of Link entity by invoking the prop passed to the React component
-    verify(mockView).setIcons(iconsPropsArgumentCaptor.capture(), any());
+    verify(mockView).setIcons(iconsPropsArgumentCaptor.capture());
     iconsPropsArgumentCaptor
       .getValue()
       .getOnUnlinkSuccess()
@@ -301,7 +296,7 @@ public class EntityBadgeTest {
     widget.setEntityBundle(bundle);
 
     // Simulate the error by invoking the prop passed to the React component
-    verify(mockView).setIcons(iconsPropsArgumentCaptor.capture(), any());
+    verify(mockView).setIcons(iconsPropsArgumentCaptor.capture());
     iconsPropsArgumentCaptor
       .getValue()
       .getOnUnlinkError()

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/verification/VerificationSubmissionWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/verification/VerificationSubmissionWidgetTest.java
@@ -35,9 +35,7 @@ import org.sagebionetworks.repo.model.verification.VerificationSubmission;
 import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.SynapseProperties;
 import org.sagebionetworks.web.client.UserProfileClientAsync;
-import org.sagebionetworks.web.client.context.SynapseReactClientFullContextPropsProvider;
 import org.sagebionetworks.web.client.jsinterop.RejectProfileValidationRequestModalProps;
 import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.CallbackP;
@@ -85,12 +83,6 @@ public class VerificationSubmissionWidgetTest {
 
   @Mock
   GWTWrapper mockGWT;
-
-  @Mock
-  SynapseReactClientFullContextPropsProvider mockPropsProvider;
-
-  @Mock
-  SynapseProperties mockSynapseProperties;
 
   @Mock
   HashMap<String, WikiPageKey> mockWikiPageMap;
@@ -144,9 +136,7 @@ public class VerificationSubmissionWidgetTest {
         mockSynapseAlert,
         mockFileHandleList,
         mockGlobalApplicationState,
-        mockGWT,
-        mockPropsProvider,
-        mockSynapseProperties
+        mockGWT
       );
 
     when(mockGWT.getHostPageBaseURL()).thenReturn(hostPageURL);


### PR DESCRIPTION
Move context to global store so it can be passed/retrieved outside of dependency injection.

The primary motivation for this is so we can instantiate via GWT UiBinder widgets that encapsulate React components with access to the MUI theme context. This is not possible with Guice dependency injection unless we explicitly provide the context in every widget that uses one of these components in their ui.xml, which is too much boilerplate to bear.

Here is an example commit of the types of changes that this enables: [`280d5db` (#5741)](https://github.com/Sage-Bionetworks/SynapseWebClient/pull/5741/commits/280d5db54cbe06af5eafdef8dd37a9cb4fd0c0ac#diff-297fbdadc2e58f0ec7bfb7575e7c3a9e250e61708071060e3df777a14f1d47dfR82-R90)