### PR TITLE
SWC-7394-search-term-logic

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/presenter/SearchPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SearchPresenter.java
@@ -334,6 +334,14 @@ public class SearchPresenter
       }
     }
 
+    // Clean up query terms to handle whitespace issues and empty strings
+    if (query.getQueryTerm() != null) {
+      List<String> terms = new ArrayList<>(query.getQueryTerm());
+      terms.removeIf(term -> term == null || term.trim().isEmpty());
+      terms.replaceAll(s -> s.trim());
+      query.setQueryTerm(terms);
+    }
+
     return query;
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/presenter/SearchUtil.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SearchUtil.java
@@ -6,6 +6,7 @@ import org.sagebionetworks.web.client.GlobalApplicationState;
 import org.sagebionetworks.web.client.place.PeopleSearch;
 import org.sagebionetworks.web.client.place.Search;
 import org.sagebionetworks.web.client.place.Synapse;
+import org.sagebionetworks.web.shared.WebConstants;
 
 /**
  * This logic was removed from the search presenter so we could make a clean SearchPresenterProxy.
@@ -34,17 +35,13 @@ public class SearchUtil {
    * @return
    */
   public static Place willRedirect(String queryTerm) {
+    queryTerm = queryTerm.toLowerCase().trim();
     if (queryTerm == null || queryTerm.trim().length() == 0) {
       return null;
     }
-    if (queryTerm.startsWith(ClientProperties.SYNAPSE_ID_PREFIX)) {
-      String remainder = queryTerm.replaceFirst(
-        ClientProperties.SYNAPSE_ID_PREFIX,
-        ""
-      );
-      if (remainder.matches("^[0-9]+$")) {
-        return new Synapse(queryTerm);
-      }
+
+    if (queryTerm.matches(WebConstants.SYNAPSE_ENTITY_ID_REGEX)) {
+      return new Synapse(queryTerm);
     } else if (queryTerm.charAt(0) == '@') {
       return new PeopleSearch(queryTerm.substring(1));
     }

--- a/src/main/java/org/sagebionetworks/web/client/presenter/SearchUtil.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/SearchUtil.java
@@ -35,10 +35,11 @@ public class SearchUtil {
    * @return
    */
   public static Place willRedirect(String queryTerm) {
-    queryTerm = queryTerm.toLowerCase().trim();
     if (queryTerm == null || queryTerm.trim().length() == 0) {
       return null;
     }
+
+    queryTerm = queryTerm.toLowerCase().trim();
 
     if (queryTerm.matches(WebConstants.SYNAPSE_ENTITY_ID_REGEX)) {
       return new Synapse(queryTerm);

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -74,7 +74,7 @@ public class WebConstants {
   public static final String VALID_ENTITY_ID_REGEX =
     "^[Ss]{1}[Yy]{1}[Nn]{1}\\d+";
   // Regex that matches Synapse entity ID with optional version (e.g., syn123 or syn123.4)
-  // Equivalent to client-side SYNAPSE_ENTITY_ID_REGEX = /^(syn\d+)(?:\.(\d+))?$/i
+  // Equivalent to client-side SYNAPSE_ENTITY_ID_REGEX = /^(syn\d+)(?:\.(\d+))?$/i but without the 'i' (since case is not ignored in this regex)
   public static final String SYNAPSE_ENTITY_ID_REGEX =
     "^(syn\\d+)(?:\\.(\\d+))?$";
   public static final String VALID_POSITIVE_NUMBER_REGEX = "^[0-9]+";

--- a/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
+++ b/src/main/java/org/sagebionetworks/web/shared/WebConstants.java
@@ -73,6 +73,10 @@ public class WebConstants {
     "^" + WIDGET_NAME_REGEX + "+";
   public static final String VALID_ENTITY_ID_REGEX =
     "^[Ss]{1}[Yy]{1}[Nn]{1}\\d+";
+  // Regex that matches Synapse entity ID with optional version (e.g., syn123 or syn123.4)
+  // Equivalent to client-side SYNAPSE_ENTITY_ID_REGEX = /^(syn\d+)(?:\.(\d+))?$/i
+  public static final String SYNAPSE_ENTITY_ID_REGEX =
+    "^(syn\\d+)(?:\\.(\\d+))?$";
   public static final String VALID_POSITIVE_NUMBER_REGEX = "^[0-9]+";
   public static final String VALID_BOOKMARK_ID_REGEX = "[_A-Za-z0-9-.[^\\s]]+";
   public static final String HTML_ELLIPSIS = "&hellip;";

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
@@ -453,7 +453,10 @@ public class SearchPresenterTest {
     String userName = "VaderLabTech";
     Place redirectPlace = SearchUtil.willRedirect("@" + userName);
     assertTrue(redirectPlace instanceof PeopleSearch);
-    assertEquals(userName, ((PeopleSearch) redirectPlace).getSearchTerm());
+    assertEquals(
+      userName.toLowerCase(),
+      ((PeopleSearch) redirectPlace).getSearchTerm()
+    );
   }
 
   private List<KeyValue> getFacet(String facetName) {

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/SearchPresenterTest.java
@@ -448,6 +448,53 @@ public class SearchPresenterTest {
     assertEquals(new Synapse(term), SearchUtil.willRedirect(new Search(term)));
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSetPlaceSynapseIdPrefixWithVersion() throws Exception {
+    // test for a versioned synapse ID
+    String term = ClientProperties.SYNAPSE_ID_PREFIX + "1234567890.5"; // # 'syn1234567890.5'
+    assertEquals(new Synapse(term), SearchUtil.willRedirect(new Search(term)));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSearchUtilWillRedirectWithWhitespace() throws Exception {
+    String termWithWhitespace = " syn1234567890 ";
+    assertEquals(
+      new Synapse("syn1234567890"),
+      SearchUtil.willRedirect(termWithWhitespace)
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSearchTermsWithEmptyStringsFromJson() throws Exception {
+    // Test JSON query with empty strings in queryTerm array
+    SearchQuery queryWithEmptyTerms = SearchQueryUtils.getDefaultSearchQuery();
+    queryWithEmptyTerms.setQueryTerm(Arrays.asList("syn1234567890", "", "  "));
+
+    String jsonQuery = queryWithEmptyTerms
+      .writeToJSONObject(jsonObjectAdapter.createNew())
+      .toJSONString();
+
+    searchPresenter.setPlace(new Search(jsonQuery));
+
+    // Should redirect to Synapse place since only one valid term remains after cleanup
+    verify(mockPlaceChanger).goTo(new Synapse("syn1234567890"));
+    verify(mockJsClient, never())
+      .getSearchResults(any(SearchQuery.class), any(AsyncCallback.class));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testSearchTermsWithWhitespaceOnly() throws Exception {
+    // Test search term that contains only whitespace characters
+    String whitespaceOnlyTerm = "   \t  \n  ";
+
+    // Should return null since no valid terms remain after cleanup
+    assertNull(SearchUtil.willRedirect(whitespaceOnlyTerm));
+  }
+
   @Test
   public void testSetPlaceUsernamePrefix() throws Exception {
     String userName = "VaderLabTech";


### PR DESCRIPTION
Relevant Jira: https://sagebionetworks.jira.com/browse/SWC-7394?focusedCommentId=263125&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&sourceType=mention#comment-263125

Previous fix (logic in SynapseHomepageChatSearch) only applied to search on the synapse homepage.

In SWC, when we do a search, the query is a JSON.

Example search in project nav search: syn68899079

We get a query string that looks like this: '%7B%22queryTerm%22%3A%5B%22syn68899101%22%5D%2C%22facetOptions%22%3A%5B%7B%22name%22%3A%22EntityType%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22Consortium%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22ModifiedOn%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22ModifiedBy%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22CreatedOn%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22Tissue%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%2C%7B%22name%22%3A%22CreatedBy%22%2C%22maxResultCount%22%3A300%2C%22sortType%22%3A%22COUNT%22%7D%5D%2C%22start%22%3A0%2C%22size%22%3A30%2C%22booleanQuery%22%3A%5B%7B%22key%22%3A%22node_type%22%2C%22value%22%3A%22project%22%7D%5D%7D'

that is then parsed. queryTerm will look like this: ["syn68899101"]. If we have any spaces, that gets included in the same array via split. Possible solution is to clean up the query terms after parsing the JSON to handle simple text queries and JSON queries.

