### PR TITLE
SWC-7436 - Fix redirect on unsigned ToS

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/security/AuthenticationControllerImpl.java
@@ -60,7 +60,6 @@ public class AuthenticationControllerImpl implements AuthenticationController {
   private List<String> persistentLocalStorageKeys;
   private String currentUserAccessToken;
   private UserProfile currentUserProfile;
-  private UserAccountServiceAsync userAccountService;
   private ClientCache localStorage;
   private SessionStorage sessionStorage;
   private PortalGinInjector ginInjector;
@@ -69,15 +68,12 @@ public class AuthenticationControllerImpl implements AuthenticationController {
 
   @Inject
   public AuthenticationControllerImpl(
-    UserAccountServiceAsync userAccountService,
     ClientCache localStorage,
     SessionStorage sessionStorage,
     PortalGinInjector ginInjector,
     SynapseJSNIUtils jsniUtils,
     QueryClientProvider queryClientProvider
   ) {
-    this.userAccountService = userAccountService;
-    fixServiceEntryPoint(userAccountService);
     this.localStorage = localStorage;
     this.sessionStorage = sessionStorage;
     this.ginInjector = ginInjector;
@@ -215,8 +211,11 @@ public class AuthenticationControllerImpl implements AuthenticationController {
           } else if (forceResetQueryClientCache) {
             resetQueryClientCache();
           }
-          userAccountService.getMyProfile(
-            new AsyncCallback<UserProfile>() {
+          FluentFuture<UserProfile> userProfileFuture = ginInjector
+            .getSynapseJavascriptClient()
+            .getMyUserProfile();
+          userProfileFuture.addCallback(
+            new FutureCallback<UserProfile>() {
               @Override
               public void onSuccess(UserProfile profile) {
                 currentUserProfile = profile;
@@ -229,9 +228,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
                 currentUserProfile = null;
                 if (
                   t instanceof ForbiddenException &&
-                  ((ForbiddenException) t).getMessage()
-                    .toLowerCase()
-                    .contains("terms of use")
+                  t.getMessage().toLowerCase().contains("terms of service")
                 ) {
                   ginInjector.getSessionDetector().initializeAccessTokenState();
                   ginInjector
@@ -244,7 +241,8 @@ public class AuthenticationControllerImpl implements AuthenticationController {
                   callback.onFailure(t);
                 }
               }
-            }
+            },
+            directExecutor()
           );
         }
 

--- a/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/client/security/AuthenticationControllerImplTest.java
@@ -39,7 +39,6 @@ import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.SessionDetector;
 import org.sagebionetworks.web.client.SynapseJSNIUtils;
 import org.sagebionetworks.web.client.SynapseJavascriptClient;
-import org.sagebionetworks.web.client.UserAccountServiceAsync;
 import org.sagebionetworks.web.client.cache.ClientCache;
 import org.sagebionetworks.web.client.cache.SessionStorage;
 import org.sagebionetworks.web.client.context.QueryClientProvider;
@@ -59,9 +58,6 @@ public class AuthenticationControllerImplTest {
 
   public static final String ACCESS_TOKEN = "1111";
   AuthenticationControllerImpl authenticationController;
-
-  @Mock
-  UserAccountServiceAsync mockUserAccountService;
 
   @Mock
   ClientCache mockClientCache;
@@ -144,10 +140,7 @@ public class AuthenticationControllerImplTest {
     when(mockJsClient.getAccessToken()).thenReturn(getDoneFuture(ACCESS_TOKEN));
     when(mockJsClient.deleteSessionAccessToken())
       .thenReturn(getDoneFuture(null));
-    AsyncMockStubber
-      .callSuccessWith(profile)
-      .when(mockUserAccountService)
-      .getMyProfile(any(AsyncCallback.class));
+    when(mockJsClient.getMyUserProfile()).thenReturn(getDoneFuture(profile));
     AsyncMockStubber
       .callSuccessWith(mockNotificationEmail)
       .when(mockJsClient)
@@ -163,7 +156,6 @@ public class AuthenticationControllerImplTest {
       );
     authenticationController =
       new AuthenticationControllerImpl(
-        mockUserAccountService,
         mockClientCache,
         mockSessionStorage,
         mockGinInjector,
@@ -310,12 +302,14 @@ public class AuthenticationControllerImplTest {
   @Test
   public void testLoginUserNotAcceptedTermsOfUse() {
     // access token is returned without error (it's set and valid), but getMyProfile() fails with a special ForbiddenException
-    AsyncMockStubber
-      .callFailureWith(
-        new ForbiddenException("Terms of use have not been signed.")
-      )
-      .when(mockUserAccountService)
-      .getMyProfile(any(AsyncCallback.class));
+    when(mockJsClient.getMyUserProfile())
+      .thenReturn(
+        getFailedFuture(
+          new ForbiddenException(
+            "Login to https://synapse.org to accept the latest Terms of Service."
+          )
+        )
+      );
 
     authenticationController.initializeFromExistingAccessTokenCookie(
       mockUserProfileCallback


### PR DESCRIPTION
- Use SynapseJavaScript client request instead of servlet proxy to get current user profile in `AuthenticationController`
- Fix incorrect ToS error checking (users will now be immediately redirected to sign the ToS instead of logged out)