### PR TITLE
remove unnecessary padding/outline from file browser

### DIFF
--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/FilesBrowserViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/browse/FilesBrowserViewImpl.ui.xml
@@ -19,10 +19,9 @@
       <bh:Div ui:field="actionMenuContainer" />
     </bh:Div>
     <bh:Div ui:field="addToDownloadListContainer" />
-    <bh:Div ui:field="reactFileBrowserContainer" />
     <bh:Div
       ui:field="files"
-      styleName="highlight-box padding-top-0-imp overflow-auto"
+      styleName="overflow-auto"
       marginTop="0"
     />
   </bh:Div>


### PR DESCRIPTION
Fixing a minor annoyance

| Before | After |
| --- | --- |
| <img width="2116" height="538" alt="image" src="https://github.com/user-attachments/assets/ec8861f9-ac4d-4ad7-a591-073ed072de7a" /> | <img width="2116" height="538" alt="image" src="https://github.com/user-attachments/assets/c9ea460b-9508-41b5-bdce-986d4d4540dc" /> |
