### PR TITLE
SWC-7760: fix challenges evaluation editor back navigation and unsaved changes modal display

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOM.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/ReactDOM.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.web.client.jsinterop;
 
-import com.google.gwt.dom.client.Element;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
@@ -13,8 +12,6 @@ public class ReactDOM {
   public interface Callback {
     void run();
   }
-
-  public static native boolean unmountComponentAtNode(Element container);
 
   /**
    * flushSync lets you force React to flush any updates inside the provided callback synchronously. This ensures that the DOM is updated immediately.

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/ChallengeTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/ChallengeTab.java
@@ -4,7 +4,9 @@ import com.google.inject.Inject;
 import java.util.function.Consumer;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
+import org.sagebionetworks.web.client.DisplayConstants;
 import org.sagebionetworks.web.client.GlobalApplicationState;
+import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.PortalGinInjector;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.place.Synapse.EntityArea;
@@ -25,6 +27,7 @@ public class ChallengeTab implements ChallengeTabView.Presenter {
   PortalGinInjector ginInjector;
   AuthenticationController authenticationController;
   GlobalApplicationState globalApplicationState;
+  PopupUtilsView popupUtils;
   EntityActionMenu actionMenuWidget;
 
   String entityId;
@@ -35,12 +38,14 @@ public class ChallengeTab implements ChallengeTabView.Presenter {
     Tab tab,
     PortalGinInjector ginInjector,
     AuthenticationController authenticationController,
-    GlobalApplicationState globalApplicationState
+    GlobalApplicationState globalApplicationState,
+    PopupUtilsView popupUtils
   ) {
     this.tab = tab;
     this.ginInjector = ginInjector;
     this.authenticationController = authenticationController;
     this.globalApplicationState = globalApplicationState;
+    this.popupUtils = popupUtils;
     tab.configure(
       "Challenge",
       "challenge",
@@ -107,7 +112,11 @@ public class ChallengeTab implements ChallengeTabView.Presenter {
   private void showEvaluationEditor(String entityId, String evaluationId) {
     EvaluationEditorReactComponentPage evaluationEditor =
       ginInjector.createEvaluationEditorReactComponentPage();
-    globalApplicationState.setIsEditing(true);
+    Runnable doNavigateBack = () -> {
+      evaluationEditor.removeFromParent();
+      view.showAdminTabContents();
+      evaluationList.refresh();
+    };
     evaluationEditor.configure(
       evaluationId,
       entityId,
@@ -115,10 +124,18 @@ public class ChallengeTab implements ChallengeTabView.Presenter {
       globalApplicationState.isShowingUTCTime(),
       // onPageBack() callback
       () -> {
-        evaluationEditor.removeFromParent();
-        view.showAdminTabContents();
-        evaluationList.refresh();
-        globalApplicationState.setIsEditing(false);
+        if (globalApplicationState.isEditing()) {
+          popupUtils.showConfirmDialog(
+            "",
+            DisplayConstants.NAVIGATE_AWAY_CONFIRMATION_MESSAGE,
+            () -> {
+              globalApplicationState.setIsEditing(false);
+              doNavigateBack.run();
+            }
+          );
+        } else {
+          doNavigateBack.run();
+        }
       }
     );
     view.hideAdminTabContents();

--- a/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/evaluation/EvaluationEditorReactComponentPage.java
@@ -10,7 +10,6 @@ import com.google.inject.Inject;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.sagebionetworks.web.client.jsinterop.EvaluationEditorPageProps;
 import org.sagebionetworks.web.client.jsinterop.React;
-import org.sagebionetworks.web.client.jsinterop.ReactDOM;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
@@ -68,11 +67,7 @@ public class EvaluationEditorReactComponentPage extends Composite {
 
   @UiHandler(value = { "backToChallenge" })
   void onBackToChallengeClick(ClickEvent event) {
-    unmountReactComponents();
+    event.preventDefault();
     onPageBack.run();
-  }
-
-  private void unmountReactComponents() {
-    ReactDOM.unmountComponentAtNode(evaluationEditorContainer.getElement());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/ChallengeTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/ChallengeTabTest.java
@@ -4,13 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.gwt.junit.GWTMockUtilities;
-import com.google.gwt.user.client.ui.Widget;
 import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
@@ -21,12 +20,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.web.client.GlobalApplicationState;
+import org.sagebionetworks.web.client.PopupUtilsView;
 import org.sagebionetworks.web.client.PortalGinInjector;
-import org.sagebionetworks.web.client.cookie.CookieProvider;
 import org.sagebionetworks.web.client.jsinterop.EvaluationEditorPageProps;
 import org.sagebionetworks.web.client.place.Synapse;
 import org.sagebionetworks.web.client.place.Synapse.EntityArea;
 import org.sagebionetworks.web.client.security.AuthenticationController;
+import org.sagebionetworks.web.client.utils.Callback;
 import org.sagebionetworks.web.client.utils.CallbackP;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenu;
 import org.sagebionetworks.web.client.widget.entity.tabs.ChallengeTab;
@@ -71,6 +71,9 @@ public class ChallengeTabTest {
   GlobalApplicationState mockGlobalApplicationState;
 
   @Mock
+  PopupUtilsView mockPopupUtils;
+
+  @Mock
   EvaluationEditorReactComponentPage mockEvaluationEditorReactComponentPage;
 
   @Captor
@@ -89,7 +92,8 @@ public class ChallengeTabTest {
         mockTab,
         mockPortalGinInjector,
         mockAuthenticationController,
-        mockGlobalApplicationState
+        mockGlobalApplicationState,
+        mockPopupUtils
       );
     when(mockTab.getEntityActionMenu()).thenReturn(mockActionMenuWidget);
     when(mockPortalGinInjector.getChallengeTabView()).thenReturn(mockView);
@@ -141,7 +145,7 @@ public class ChallengeTabTest {
 
     consumerCaptor.getValue().accept(evaluationId);
 
-    verify(mockGlobalApplicationState).setIsEditing(true);
+    verify(mockGlobalApplicationState, never()).setIsEditing(true);
     verify(mockEvaluationEditorReactComponentPage)
       .configure(
         eq(evaluationId),
@@ -151,9 +155,45 @@ public class ChallengeTabTest {
         callbackCaptor.capture()
       );
 
+    when(mockGlobalApplicationState.isEditing()).thenReturn(false);
     callbackCaptor.getValue().run();
     verify(mockEvaluationEditorReactComponentPage).removeFromParent();
+    verify(mockGlobalApplicationState, never()).setIsEditing(false);
+  }
+
+  @Test
+  public void testConfigure_backWhileEditing() {
+    String entityId = "syn1";
+    String entityName = "challenge project test";
+    tab.configure(entityId, entityName, mockProjectEntityBundle);
+
+    verify(mockAdministerEvaluationsList)
+      .configure(eq(entityId), consumerCaptor.capture());
+
+    String evaluationId = "88288282";
+    consumerCaptor.getValue().accept(evaluationId);
+
+    verify(mockEvaluationEditorReactComponentPage)
+      .configure(
+        eq(evaluationId),
+        any(),
+        any(),
+        anyBoolean(),
+        callbackCaptor.capture()
+      );
+
+    when(mockGlobalApplicationState.isEditing()).thenReturn(true);
+    ArgumentCaptor<Callback> confirmCaptor = ArgumentCaptor.forClass(
+      Callback.class
+    );
+    callbackCaptor.getValue().run();
+    verify(mockPopupUtils)
+      .showConfirmDialog(any(), any(), confirmCaptor.capture());
+    verify(mockEvaluationEditorReactComponentPage, never()).removeFromParent();
+
+    confirmCaptor.getValue().invoke();
     verify(mockGlobalApplicationState).setIsEditing(false);
+    verify(mockEvaluationEditorReactComponentPage).removeFromParent();
   }
 
   @Test


### PR DESCRIPTION
Fixes three navigation bugs in the challenges evaluation editor (see [SWC-7760](https://sagebionetworks.jira.com/browse/SWC-7760)):
1. the "Back to challenge" button was non-functional due to use of `ReactDOM.unmountComponentAtNode` (removed in React 18)
2. the "Unsaved changes" modal was incorrectly shown even when no edits had been made, because the editing flag was set unconditionally on editor open rather than on actual user edits and the modal continued to appear after saving changes

Updates in https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/2620 will ensure React components accurately report when there are unsaved changes in the forms.

"Back to Challenge" button is functional: 

https://github.com/user-attachments/assets/af9374ca-a050-4253-88ba-55b25a4e09cf

"Unsaved changes" modal shown when there are changes in the form, but not after the form has been saved: 

https://github.com/user-attachments/assets/050d41e0-71ff-4010-a17c-2bdb3e24d588

"Unsaved changes" modal is not shown when form is clean and user clicks on another tab: 

https://github.com/user-attachments/assets/8d8ff294-cc78-46ae-8e4f-ecfc8465e1bc


[SWC-7760]: https://sagebionetworks.jira.com/browse/SWC-7760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ