### PR TITLE
Add --frozen-lockfile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
               <goal>corepack</goal>
             </goals>
             <configuration>
-              <arguments>pnpm install</arguments>
+              <arguments>pnpm install --frozen-lockfile</arguments>
             </configuration>
             <phase>generate-resources</phase>
           </execution>


### PR DESCRIPTION
Scanned logs of workflow executions and noticed an 'pnpm install' without '--frozen-lockfile'. This PR adds it.