### PR TITLE
SWC-7736: Going back from a grid to a view using the Back key results in 'Missing Session Id' error

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/place/GridPlace.java
+++ b/src/main/java/org/sagebionetworks/web/client/place/GridPlace.java
@@ -3,17 +3,25 @@ package org.sagebionetworks.web.client.place;
 import com.google.gwt.place.shared.Place;
 import com.google.gwt.place.shared.PlaceTokenizer;
 import com.google.gwt.place.shared.Prefix;
-import com.google.gwt.user.client.Window;
 
 public class GridPlace extends Place {
 
-  public static final String SESSION_ID = "sessionId";
+  public static final String PARAM_SESSION_ID = "sessionId";
+
+  private final String sessionId;
 
   public GridPlace(String token) {
+    // If it's 'default', the ID is already in the URL parameters for React to find and use.
     if (token != null && !token.startsWith("default")) {
-      // Redirect /Grid:{sessionId} to /Grid:default?sessionId={sessionId}
-      Window.Location.assign("/Grid:default?" + SESSION_ID + "=" + token);
+      this.sessionId = token;
+    } else {
+      // token is "default", GWT only needs the path to route to GridPage.
+      this.sessionId = null;
     }
+  }
+
+  public String getSessionId() {
+    return sessionId;
   }
 
   @Prefix("Grid")
@@ -21,6 +29,11 @@ public class GridPlace extends Place {
 
     @Override
     public String getToken(GridPlace place) {
+      if (place.getSessionId() != null) {
+        return "default?" + PARAM_SESSION_ID + "=" + place.sessionId;
+      }
+
+      // if no session id, return a default token
       return "default";
     }
 

--- a/src/main/java/org/sagebionetworks/web/client/place/GridPlace.java
+++ b/src/main/java/org/sagebionetworks/web/client/place/GridPlace.java
@@ -33,7 +33,6 @@ public class GridPlace extends Place {
         return "default?" + PARAM_SESSION_ID + "=" + place.sessionId;
       }
 
-      // if no session id, return a default token
       return "default";
     }
 


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/SWC-7736?atlOrigin=eyJpIjoiZDRhYjhlZTBmYWMzNDNhOGFlYzUzMDVkNWUxZWNkZDYiLCJwIjoiaiJ9

Issue:  We have a /Grid:default in our history stack that doesn’t have a session id hence the missing session id error when we click back from a grid session.

Issue with replaceState:  file entity page -> create new working copy (ex: http://127.0.0.1:8888/Grid:default?sessionId=MTE5NDI5Ng==) -> click back button -> get redirected back to task and actions tab rather than file entity page (http://127.0.0.1:8888/Synapse:syn68899079/metadata/)

We can correct the URL in the tokenizer I think before it gets pushed to the history stack.
