### PR TITLE
SWC-7839

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       ${project.build.directory}/${project.build.finalName}
     </webappDirectory>
 
-    <synapse.version>587.0-35-g5f6fcf2aa9</synapse.version>
+    <synapse.version>590.0-2-g176723d14c</synapse.version>
     <gwtVersion>2.11.0</gwtVersion>
     <org.springframework.version>5.3.39</org.springframework.version>
     <guiceVersion>6.0.0</guiceVersion>

--- a/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
@@ -10,6 +10,7 @@ import org.sagebionetworks.repo.model.Link;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.docker.DockerRepository;
+import org.sagebionetworks.repo.model.search.table.SearchIndex;
 import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.DatasetCollection;
 import org.sagebionetworks.repo.model.table.EntityView;
@@ -33,6 +34,7 @@ public class EntityTypeUtils {
   public static final String DATASET_COLLECTION_DISPLAY_NAME =
     "Dataset Collection";
   public static final String TABLE_ENTITY_DISPLAY_NAME = "Table";
+  public static final String SEARCH_INDEX_DISPLAY_NAME = "Search Index";
   public static final String UNKNOWN_TABLE_TYPE = "Unknown Table Type";
 
   public static String getEntityClassNameForEntityType(String entityType) {
@@ -193,6 +195,8 @@ public class EntityTypeUtils {
       friendlyName = SUBMISSION_VIEW_DISPLAY_NAME;
     } else if (DatasetCollection.class.getName().equals(className)) {
       friendlyName = DATASET_COLLECTION_DISPLAY_NAME;
+    } else if (SearchIndex.class.getName().equals(className)) {
+      friendlyName = SEARCH_INDEX_DISPLAY_NAME;
     }
     return friendlyName;
   }

--- a/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
+++ b/src/main/java/org/sagebionetworks/web/client/EntityTypeUtils.java
@@ -118,6 +118,12 @@ public class EntityTypeUtils {
       type = EntityType.dataset;
     } else if (DatasetCollection.class.getName().equals(className)) {
       type = EntityType.datasetcollection;
+    } else if (
+      org.sagebionetworks.repo.model.search.table
+        .SearchIndex.class.getName()
+        .equals(className)
+    ) {
+      type = EntityType.searchindex;
     }
     return type;
   }

--- a/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
+++ b/src/main/java/org/sagebionetworks/web/client/SynapseJavascriptClient.java
@@ -1451,7 +1451,8 @@ public class SynapseJavascriptClient {
       EntityType.entityview,
       EntityType.materializedview,
       EntityType.submissionview,
-      EntityType.virtualtable
+      EntityType.virtualtable,
+      EntityType.searchindex
     );
     getEntityChildren(request, getEntityChildrenExistCallback(callback));
   }

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -50,6 +50,9 @@ public class SRC {
       QueryWrapperPlotNavProps
     > QueryWrapperPlotNav;
     public static ReactComponentType<
+      SearchQueryWrapperPlotNavProps
+    > SearchQueryWrapperPlotNav;
+    public static ReactComponentType<
       StandaloneQueryWrapperProps
     > StandaloneQueryWrapper;
     public static ReactComponentType<ForumSearchProps> ForumSearch;

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SearchQueryWrapperPlotNavProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SearchQueryWrapperPlotNavProps.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsNullable;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class SearchQueryWrapperPlotNavProps extends ReactComponentProps {
+
+  String searchIndexId;
+
+  @JsNullable
+  String name;
+
+  @JsNullable
+  boolean defaultShowPlots;
+
+  @JsNullable
+  boolean defaultShowSearchBar;
+
+  @JsNullable
+  boolean hideCopyToClipboard;
+
+  @JsOverlay
+  public static SearchQueryWrapperPlotNavProps create(
+    String searchIndexId,
+    String name
+  ) {
+    SearchQueryWrapperPlotNavProps props = new SearchQueryWrapperPlotNavProps();
+    props.searchIndexId = searchIndexId;
+    props.name = name;
+    props.defaultShowPlots = false;
+    props.defaultShowSearchBar = true;
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SearchQueryWrapperPlotNavProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SearchQueryWrapperPlotNavProps.java
@@ -22,6 +22,9 @@ public class SearchQueryWrapperPlotNavProps extends ReactComponentProps {
   @JsNullable
   boolean hideCopyToClipboard;
 
+  @JsNullable
+  SynapseTableProps tableConfiguration;
+
   @JsOverlay
   public static SearchQueryWrapperPlotNavProps create(
     String searchIndexId,
@@ -32,6 +35,9 @@ public class SearchQueryWrapperPlotNavProps extends ReactComponentProps {
     props.name = name;
     props.defaultShowPlots = false;
     props.defaultShowSearchBar = true;
+    SynapseTableProps tableConfig = SynapseTableProps.create();
+    tableConfig.showDownloadColumn = false;
+    props.tableConfiguration = tableConfig;
     return props;
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
@@ -22,6 +22,7 @@ import org.sagebionetworks.repo.model.curation.ListCurationTaskResponse;
 import org.sagebionetworks.repo.model.docker.DockerRepository;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundleRequest;
+import org.sagebionetworks.repo.model.search.table.SearchIndex;
 import org.sagebionetworks.repo.model.table.EntityRefCollectionView;
 import org.sagebionetworks.repo.model.table.Table;
 import org.sagebionetworks.web.client.DisplayConstants;
@@ -853,6 +854,8 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget {
       area = getDefaultProjectArea();
     } else if (entity instanceof EntityRefCollectionView) {
       area = EntityArea.DATASETS;
+    } else if (entity instanceof SearchIndex) {
+      area = EntityArea.TABLES;
     } else if (entity instanceof Table) {
       area = EntityArea.TABLES;
     } else if (entity instanceof DockerRepository) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/EntityPageTop.java
@@ -648,6 +648,8 @@ public class EntityPageTop implements SynapseWidgetPresenter, IsWidget {
         fileChanged(bundle, currentTargetVersionNumber);
       } else if (entity instanceof EntityRefCollectionView) {
         datasetChanged(bundle, currentTargetVersionNumber);
+      } else if (entity instanceof SearchIndex) {
+        tableChanged(bundle, currentTargetVersionNumber);
       } else if (entity instanceof Table) {
         tableChanged(bundle, currentTargetVersionNumber);
       } else if (entity instanceof DockerRepository) {

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -1802,10 +1802,6 @@ public class EntityActionControllerImpl
     );
   }
 
-  public static boolean isDefinedBySql(Entity entity) {
-    return entity instanceof HasDefiningSql;
-  }
-
   public static boolean isEditCellValuesSupported(Entity entity) {
     // EntityRefCollectionView results are not editable, even if the user has permissions, because rows may reference immutable versions (SWC-5870, SWC-5903)
     return QueryResultEditorWidget.isTableTypeQueryResultEditable(

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -1365,6 +1365,22 @@ public class EntityActionControllerImpl
   }
 
   private void configureTableCommands() {
+    if (entityBundle.getEntity() instanceof HasDefiningSql) {
+      actionMenu.setActionVisible(
+        Action.EDIT_DEFINING_SQL,
+        permissions.getCanCertifiedUserEdit() && isCurrentVersion
+      );
+      actionMenu.setActionListener(Action.EDIT_DEFINING_SQL, this);
+      actionMenu.setActionVisible(
+        Action.VIEW_DEFINING_SQL,
+        !permissions.getCanCertifiedUserEdit() && isCurrentVersion
+      );
+      actionMenu.setActionListener(Action.VIEW_DEFINING_SQL, this);
+    } else {
+      actionMenu.setActionVisible(Action.VIEW_DEFINING_SQL, false);
+      actionMenu.setActionVisible(Action.EDIT_DEFINING_SQL, false);
+    }
+
     if (entityBundle.getEntity() instanceof Table) {
       boolean isEntityRefCollectionView = entityBundle.getEntity() instanceof
       EntityRefCollectionView;
@@ -1389,21 +1405,6 @@ public class EntityActionControllerImpl
         isEntityRefCollectionView &&
         isCurrentVersion
       );
-      actionMenu.setActionVisible(
-        Action.EDIT_DEFINING_SQL,
-        permissions.getCanCertifiedUserEdit() &&
-        isDefinedBySql(entityBundle.getEntity()) &&
-        isCurrentVersion
-      );
-      actionMenu.setActionListener(Action.EDIT_DEFINING_SQL, this);
-
-      actionMenu.setActionVisible(
-        Action.VIEW_DEFINING_SQL,
-        !permissions.getCanCertifiedUserEdit() &&
-        isDefinedBySql(entityBundle.getEntity()) &&
-        isCurrentVersion
-      );
-      actionMenu.setActionListener(Action.VIEW_DEFINING_SQL, this);
     } else {
       actionMenu.setActionVisible(Action.UPLOAD_TABLE_DATA, false);
       actionMenu.setActionVisible(Action.EDIT_TABLE_DATA, false);
@@ -1413,7 +1414,6 @@ public class EntityActionControllerImpl
         Action.EDIT_ENTITYREF_COLLECTION_ITEMS,
         false
       );
-      actionMenu.setActionVisible(Action.EDIT_DEFINING_SQL, false);
     }
   }
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/DefaultEntityActionMenuLayoutUtil.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/menu/v3/DefaultEntityActionMenuLayoutUtil.java
@@ -538,6 +538,43 @@ public class DefaultEntityActionMenuLayoutUtil {
           )
         );
         break;
+      case searchindex:
+        layout.setPrimaryMenuText(
+          EntityTypeUtils.getDisplayName(entityType) + TOOLS_SUFFIX
+        );
+        layout.setButtonActions(
+          Arrays.asList(
+            ActionViewProps.create(Action.EDIT_DEFINING_SQL, "edit"),
+            ActionViewProps.create(Action.VIEW_DEFINING_SQL, "article"),
+            ActionViewProps.create(Action.SHOW_ANNOTATIONS, "label"),
+            ActionViewProps.create(Action.SHARE_THIS_PAGE, "share")
+          )
+        );
+        layout.setPrimaryMenuActions(
+          Arrays.asList(
+            Arrays.asList(
+              ActionViewProps.create(Action.VIEW_SHARING_SETTINGS),
+              ActionViewProps.create(Action.EDIT_PROVENANCE)
+            ),
+            Arrays.asList(
+              ActionViewProps.create(Action.CREATE_OR_UPDATE_DOI),
+              ActionViewProps.create(Action.CREATE_LINK)
+            ),
+            Arrays.asList(
+              ActionViewProps.create(Action.MOVE_ENTITY),
+              ActionViewProps.create(Action.CHANGE_ENTITY_NAME),
+              ActionViewProps.create(
+                Action.DELETE_ENTITY,
+                null,
+                deleteTextStyle,
+                null
+              )
+            ),
+            reportViolationMenuGroup,
+            actMenuGroup
+          )
+        );
+        break;
     }
     return layout;
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
@@ -8,6 +8,7 @@ import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.place.shared.Place;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
+import org.sagebionetworks.repo.model.search.table.SearchIndex;
 import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.Table;
@@ -47,6 +49,7 @@ import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBar;
 import org.sagebionetworks.web.client.widget.provenance.v2.ProvenanceWidget;
 import org.sagebionetworks.web.client.widget.table.QueryChangeHandler;
 import org.sagebionetworks.web.client.widget.table.TableListWidget;
+import org.sagebionetworks.web.client.widget.table.explore.SearchIndexWidget;
 import org.sagebionetworks.web.client.widget.table.explore.TableEntityWidgetV2;
 import org.sagebionetworks.web.client.widget.table.v2.QueryTokenProvider;
 import org.sagebionetworks.web.client.widget.table.v2.results.QueryBundleUtils;
@@ -132,6 +135,13 @@ public abstract class AbstractTablesTab
     this.ginInjector = ginInjector;
     this.featureFlagConfig = featureFlagConfig;
     this.jsniUtils = jsniUtils;
+  }
+
+  protected IsWidget createSearchIndexWidget(
+    String entityId,
+    String entityName
+  ) {
+    return new SearchIndexWidget(entityId, entityName);
   }
 
   public void configure(
@@ -369,6 +379,37 @@ public abstract class AbstractTablesTab
   public void setTargetBundle(EntityBundle bundle, Long versionNumber) {
     this.entityBundle = bundle;
     Entity entity = bundle.getEntity();
+
+    if (entity instanceof SearchIndex) {
+      version = null;
+      view.setTitle(getTabDisplayName());
+      view.setEntityMetadataVisible(true);
+      view.setBreadcrumbVisible(true);
+      view.setTableListVisible(false);
+      view.setTitlebarVisible(true);
+      view.clearTableEntityWidget();
+      modifiedCreatedBy.setVisible(false);
+      view.setTableUIVisible(true);
+      view.setActionMenu(tab.getEntityActionMenu());
+      tab.configureEntityActionController(bundle, true, null, null);
+      view.setProjectLevelUIVisible(false);
+      breadcrumb.configure(bundle.getPath(), getTabArea());
+      titleBar.configure(bundle, tab.getEntityActionMenu());
+      modifiedCreatedBy.configure(entity.getId(), null);
+      updateVersionAndAreaToken(entity.getId(), null, areaToken);
+      view.setTableEntityWidget(null);
+      IsWidget searchWidget = createSearchIndexWidget(
+        entity.getId(),
+        entity.getName()
+      );
+      if (searchWidget != null) {
+        view.setTableEntityWidget(searchWidget.asWidget());
+      }
+      view.setWikiPageVisible(false);
+      view.setVersionAlertVisible(false);
+      return;
+    }
+
     boolean isShownInTab = isEntityShownInTab(entity);
     boolean isProject = entity instanceof Project;
     boolean isVersionSupported = EntityActionControllerImpl.isVersionSupported(

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/AbstractTablesTab.java
@@ -380,36 +380,6 @@ public abstract class AbstractTablesTab
     this.entityBundle = bundle;
     Entity entity = bundle.getEntity();
 
-    if (entity instanceof SearchIndex) {
-      version = null;
-      view.setTitle(getTabDisplayName());
-      view.setEntityMetadataVisible(true);
-      view.setBreadcrumbVisible(true);
-      view.setTableListVisible(false);
-      view.setTitlebarVisible(true);
-      view.clearTableEntityWidget();
-      modifiedCreatedBy.setVisible(false);
-      view.setTableUIVisible(true);
-      view.setActionMenu(tab.getEntityActionMenu());
-      tab.configureEntityActionController(bundle, true, null, null);
-      view.setProjectLevelUIVisible(false);
-      breadcrumb.configure(bundle.getPath(), getTabArea());
-      titleBar.configure(bundle, tab.getEntityActionMenu());
-      modifiedCreatedBy.configure(entity.getId(), null);
-      updateVersionAndAreaToken(entity.getId(), null, areaToken);
-      view.setTableEntityWidget(null);
-      IsWidget searchWidget = createSearchIndexWidget(
-        entity.getId(),
-        entity.getName()
-      );
-      if (searchWidget != null) {
-        view.setTableEntityWidget(searchWidget.asWidget());
-      }
-      view.setWikiPageVisible(false);
-      view.setVersionAlertVisible(false);
-      return;
-    }
-
     boolean isShownInTab = isEntityShownInTab(entity);
     boolean isProject = entity instanceof Project;
     boolean isVersionSupported = EntityActionControllerImpl.isVersionSupported(
@@ -426,7 +396,8 @@ public abstract class AbstractTablesTab
     view.setTableUIVisible(isShownInTab);
     view.setActionMenu(tab.getEntityActionMenu());
     boolean isCurrentVersion =
-      !isProject && ((Table) entity).getIsLatestVersion();
+      !isProject &&
+      (!(entity instanceof Table) || ((Table) entity).getIsLatestVersion());
 
     tab.configureEntityActionController(bundle, isCurrentVersion, null, null);
     if (isShownInTab) {
@@ -438,75 +409,87 @@ public abstract class AbstractTablesTab
       breadcrumb.configure(bundle.getPath(), getTabArea());
       titleBar.configure(bundle, tab.getEntityActionMenu());
       modifiedCreatedBy.configure(entity.getId(), version);
-      tableEntityWidget = ginInjector.createNewTableEntityWidgetV2();
-      view.setTableEntityWidget(tableEntityWidget.asWidget());
-      boolean isShowTableOnly = false;
-      tableEntityWidget.configure(
-        bundle,
-        version,
-        canEdit,
-        isShowTableOnly,
-        this,
-        tab.getEntityActionMenu()
-      );
-      // Configure wiki
-      view.setWikiPageVisible(true);
-      final WikiPageWidget.Callback wikiCallback =
-        new WikiPageWidget.Callback() {
-          @Override
-          public void pageUpdated() {
-            ginInjector
-              .getEventBus()
-              .fireEvent(new EntityUpdatedEvent(entity.getId()));
-          }
+      if (entity instanceof SearchIndex) {
+        IsWidget searchWidget = createSearchIndexWidget(
+          entity.getId(),
+          entity.getName()
+        );
+        if (searchWidget != null) {
+          view.setTableEntityWidget(searchWidget.asWidget());
+        }
+        view.setWikiPageVisible(false);
+        view.setVersionAlertVisible(false);
+      } else {
+        tableEntityWidget = ginInjector.createNewTableEntityWidgetV2();
+        view.setTableEntityWidget(tableEntityWidget.asWidget());
+        boolean isShowTableOnly = false;
+        tableEntityWidget.configure(
+          bundle,
+          version,
+          canEdit,
+          isShowTableOnly,
+          this,
+          tab.getEntityActionMenu()
+        );
+        // Configure wiki
+        view.setWikiPageVisible(true);
+        final WikiPageWidget.Callback wikiCallback =
+          new WikiPageWidget.Callback() {
+            @Override
+            public void pageUpdated() {
+              ginInjector
+                .getEventBus()
+                .fireEvent(new EntityUpdatedEvent(entity.getId()));
+            }
 
+            @Override
+            public void noWikiFound() {
+              view.setWikiPageVisible(false);
+            }
+          };
+        wikiPageWidget.configure(
+          new WikiPageKey(
+            entity.getId(),
+            ObjectType.ENTITY.toString(),
+            bundle.getRootWikiId(),
+            versionNumber
+          ),
+          canEdit,
+          wikiCallback
+        );
+        CallbackP<String> wikiReloadHandler = new CallbackP<String>() {
           @Override
-          public void noWikiFound() {
-            view.setWikiPageVisible(false);
+          public void invoke(String wikiPageId) {
+            wikiPageWidget.configure(
+              new WikiPageKey(
+                entity.getId(),
+                ObjectType.ENTITY.toString(),
+                wikiPageId,
+                versionNumber
+              ),
+              canEdit,
+              wikiCallback
+            );
           }
         };
-      wikiPageWidget.configure(
-        new WikiPageKey(
-          entity.getId(),
-          ObjectType.ENTITY.toString(),
-          bundle.getRootWikiId(),
-          versionNumber
-        ),
-        canEdit,
-        wikiCallback
-      );
-      CallbackP<String> wikiReloadHandler = new CallbackP<String>() {
-        @Override
-        public void invoke(String wikiPageId) {
-          wikiPageWidget.configure(
-            new WikiPageKey(
-              entity.getId(),
-              ObjectType.ENTITY.toString(),
-              wikiPageId,
-              versionNumber
-            ),
-            canEdit,
-            wikiCallback
-          );
-        }
-      };
-      wikiPageWidget.setWikiReloadHandler(wikiReloadHandler);
-      getLatestSnapshotVersionNumber()
-        .addCallback(
-          new FutureCallback<Long>() {
-            @Override
-            public void onSuccess(@Nullable Long result) {
-              latestSnapshotVersionNumber = result;
-              configureVersionAlert();
-            }
+        wikiPageWidget.setWikiReloadHandler(wikiReloadHandler);
+        getLatestSnapshotVersionNumber()
+          .addCallback(
+            new FutureCallback<Long>() {
+              @Override
+              public void onSuccess(@Nullable Long result) {
+                latestSnapshotVersionNumber = result;
+                configureVersionAlert();
+              }
 
-            @Override
-            public void onFailure(Throwable t) {
-              synAlert.showError(t.getMessage());
-            }
-          },
-          directExecutor()
-        );
+              @Override
+              public void onFailure(Throwable t) {
+                synAlert.showError(t.getMessage());
+              }
+            },
+            directExecutor()
+          );
+      }
     } else if (isProject) {
       view.setProjectLevelUIVisible(true);
       areaToken = null;

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/TablesTab.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityType;
+import org.sagebionetworks.repo.model.search.table.SearchIndex;
 import org.sagebionetworks.repo.model.table.Dataset;
 import org.sagebionetworks.repo.model.table.Table;
 import org.sagebionetworks.web.client.DisplayConstants;
@@ -81,11 +82,15 @@ public class TablesTab extends AbstractTablesTab {
     types.add(EntityType.submissionview);
     types.add(EntityType.materializedview);
     types.add(EntityType.virtualtable);
+    types.add(EntityType.searchindex);
     return types;
   }
 
   @Override
   protected boolean isEntityShownInTab(Entity entity) {
-    return entity instanceof Table && !(entity instanceof Dataset);
+    return (
+      (entity instanceof Table || entity instanceof SearchIndex) &&
+      !(entity instanceof Dataset)
+    );
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/table/explore/SearchIndexWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/table/explore/SearchIndexWidget.java
@@ -1,0 +1,20 @@
+package org.sagebionetworks.web.client.widget.table.explore;
+
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+import org.sagebionetworks.web.client.jsinterop.SearchQueryWrapperPlotNavProps;
+import org.sagebionetworks.web.client.widget.ReactComponent;
+
+public class SearchIndexWidget extends ReactComponent {
+
+  public SearchIndexWidget(String searchIndexId, String name) {
+    SearchQueryWrapperPlotNavProps props =
+      SearchQueryWrapperPlotNavProps.create(searchIndexId, name);
+    ReactElement component = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.SearchQueryWrapperPlotNav,
+      props
+    );
+    this.render(component);
+  }
+}

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -19,7 +19,6 @@ import static org.sagebionetworks.web.client.utils.FutureUtils.getDoneFuture;
 
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.gwt.place.shared.Place;
-import com.google.gwt.user.client.ui.Widget;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,13 +32,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.EntityHeader;
-import org.sagebionetworks.repo.model.EntityPath;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.entitybundle.v2.EntityBundle;
+import org.sagebionetworks.repo.model.search.table.SearchIndex;
 import org.sagebionetworks.repo.model.table.EntityView;
 import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.SortDirection;
@@ -117,10 +116,16 @@ public class TablesTabTest {
   EntityBundle mockTableEntityBundle;
 
   @Mock
+  EntityBundle mockSearchIndexEntityBundle;
+
+  @Mock
   TableEntity mockTableEntity;
 
   @Mock
   EntityView mockFileViewEntity;
+
+  @Mock
+  SearchIndex mockSearchIndexEntity;
 
   @Mock
   Project mockProjectEntity;
@@ -196,7 +201,15 @@ public class TablesTabTest {
         mockPortalGinInjector,
         mockFeatureFlagConfig,
         mockJsniUtils
-      );
+      ) {
+        @Override
+        protected com.google.gwt.user.client.ui.IsWidget createSearchIndexWidget(
+          String entityId,
+          String entityName
+        ) {
+          return null;
+        }
+      };
     when(mockTab.getEntityActionMenu()).thenReturn(mockActionMenuWidget);
     when(mockPortalGinInjector.getCookieProvider()).thenReturn(mockCookies);
     when(mockPortalGinInjector.getTablesTabView()).thenReturn(mockView);
@@ -237,6 +250,15 @@ public class TablesTabTest {
 
     when(mockFileViewEntity.getId()).thenReturn(tableEntityId);
     when(mockFileViewEntity.getName()).thenReturn(tableName);
+
+    String searchIndexEntityId = "syn99";
+    String searchIndexEntityName = "test search index";
+    when(mockSearchIndexEntityBundle.getEntity())
+      .thenReturn(mockSearchIndexEntity);
+    when(mockSearchIndexEntityBundle.getPermissions())
+      .thenReturn(mockPermissions);
+    when(mockSearchIndexEntity.getId()).thenReturn(searchIndexEntityId);
+    when(mockSearchIndexEntity.getName()).thenReturn(searchIndexEntityName);
 
     VersionInfo latestSnapshot = new VersionInfo();
     latestSnapshot.setVersionNumber(latestSnapshotVersionNumber);
@@ -391,7 +413,8 @@ public class TablesTabTest {
           EntityType.entityview,
           EntityType.submissionview,
           EntityType.materializedview,
-          EntityType.virtualtable
+          EntityType.virtualtable,
+          EntityType.searchindex
         )
       );
 
@@ -400,6 +423,34 @@ public class TablesTabTest {
     assertNull(place.getVersionNumber());
     assertEquals(EntityArea.TABLES, place.getArea());
     assertNull(place.getAreaToken());
+  }
+
+  @Test
+  public void testConfigureUsingSearchIndex() {
+    tab.setProject(projectEntityId, mockProjectEntityBundle, null);
+    tab.configure(mockSearchIndexEntityBundle, null, null);
+
+    String searchIndexEntityId = mockSearchIndexEntity.getId();
+    String searchIndexEntityName = mockSearchIndexEntity.getName();
+
+    verify(mockView, atLeastOnce()).setTitle(any());
+    verify(mockView).setEntityMetadataVisible(true);
+    verify(mockView).setBreadcrumbVisible(true);
+    verify(mockView).setTableListVisible(false);
+    verify(mockView).setTitlebarVisible(true);
+    verify(mockView).clearTableEntityWidget();
+    verify(mockModifiedCreatedBy).setVisible(false);
+    verify(mockView).setTableUIVisible(true);
+    verify(mockView).setProjectLevelUIVisible(false);
+    verify(mockBreadcrumb).configure(any(), eq(EntityArea.TABLES));
+    verify(mockTitleBar)
+      .configure(mockSearchIndexEntityBundle, mockActionMenuWidget);
+    verify(mockModifiedCreatedBy).configure(searchIndexEntityId, null);
+    verify(mockView).setTableEntityWidget(null);
+    verify(mockView).setWikiPageVisible(false);
+    verify(mockView).setVersionAlertVisible(false);
+    // TableEntityWidgetV2 should NOT be used for SearchIndex
+    verify(mockPortalGinInjector, never()).createNewTableEntityWidgetV2();
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/tabs/TablesTabTest.java
@@ -446,7 +446,6 @@ public class TablesTabTest {
     verify(mockTitleBar)
       .configure(mockSearchIndexEntityBundle, mockActionMenuWidget);
     verify(mockModifiedCreatedBy).configure(searchIndexEntityId, null);
-    verify(mockView).setTableEntityWidget(null);
     verify(mockView).setWikiPageVisible(false);
     verify(mockView).setVersionAlertVisible(false);
     // TableEntityWidgetV2 should NOT be used for SearchIndex


### PR DESCRIPTION
## Overview
Adds full support for rendering `SearchIndex` entities in the GWT portal. A
`SearchIndex` is a new Synapse entity type that defines an OpenSearch index via a
SQL query. The changes wire it into the Tables tab, entity action menus, and the
React-based `SearchQueryWrapperPlotNav` component.

---

## New Files

### `SearchIndexWidget.java`
A thin GWT `ReactComponent` wrapper that instantiates the React
`SearchQueryWrapperPlotNav` component using the entity's ID and name as props.

### `SearchQueryWrapperPlotNavProps.java`
JsInterop props bridge for `SearchQueryWrapperPlotNav`. Configures the component
with `defaultShowPlots: false`, `defaultShowSearchBar: true`, and a
`tableConfiguration` with `showDownloadColumn: false`.

---

## Modified Files

### `EntityTypeUtils.java`
- Added `SEARCH_INDEX_DISPLAY_NAME = "Search Index"` constant.
- Added `SearchIndex` import.
- `getEntityTypeForEntityClassName()`: returns `EntityType.searchindex` for
  `SearchIndex` class name (previously fell through to the `file` default, causing
  "File Tools" in the action menu and wrong icon resolution).
- `getFriendlyTableTypeName()`: returns `"Search Index"` for the type label in the
  table list.

### `SynapseJavascriptClient.java`
- `isTable()`: added `EntityType.searchindex` to the entity children API request
  so the Tables tab badge/indicator counts SearchIndex entities.

### `SRC.java`
- Registered `SearchQueryWrapperPlotNav` as a typed `ReactComponentType`.

### `EntityPageTop.java`
- `getAreaForEntity()`: routes `SearchIndex` to `EntityArea.TABLES` (before the
  generic `Table` check, which doesn't match `SearchIndex`).
- Entity-loaded callback: dispatches `SearchIndex` to `tableChanged()` so the
  Tables tab is activated on direct navigation.

### `AbstractTablesTab.java`
- `setTargetBundle()`: added an early-return branch for `SearchIndex` that renders
  the entity detail view (breadcrumb, title bar, action menu) and mounts a
  `SearchIndexWidget` into the tab content area.
- `createSearchIndexWidget()`: protected factory method (overridable in tests to
  return `null`, avoiding GWT class-loading issues in plain JUnit).

### `TablesTab.java`
- `getTypesShownInList()`: added `EntityType.searchindex` so SearchIndex entities
  appear in the project's Tables list.
- `isEntityShownInTab()`: extended to accept `SearchIndex` (which does not extend
  `Table`).

### `EntityActionControllerImpl.java`
- `configureTableCommands()` refactored into two independent checks:
  1. **`instanceof HasDefiningSql`** (covers `SearchIndex`, `MaterializedView`,
     `VirtualTable`): shows `EDIT_DEFINING_SQL` (if user can edit) or
     `VIEW_DEFINING_SQL` (if read-only). Previously this logic only ran inside
     the `Table` branch, so SearchIndex never exposed SQL editing.
  2. **`instanceof Table`**: configures table-specific actions
     (`UPLOAD_TABLE_DATA`, `EDIT_TABLE_DATA`, `SHOW_TABLE_SCHEMA`, etc.)
     unchanged.

### `DefaultEntityActionMenuLayoutUtil.java`
- Added `case searchindex:` to `getLayout(EntityType)` with:
  - **Button actions**: `EDIT_DEFINING_SQL`, `VIEW_DEFINING_SQL`,
    `SHOW_ANNOTATIONS`, `SHARE_THIS_PAGE`.
  - **Primary menu**: sharing settings, provenance, DOI/link, move/rename/delete,
    report violation, ACT actions.
  - Label: `"Search Index Tools"` (previously fell through to no case, which
    caused the menu to render as `"File Tools"` after `getEntityTypeForEntityClassName`
    defaulted to `EntityType.file`).

---

## Tests
`TablesTabTest`: added `testConfigureUsingSearchIndex` and updated the test
subclass to override `createSearchIndexWidget()` returning `null` to avoid GWT
class-loading errors in plain JUnit.