### PR TITLE
SWC-7046 - Retire GwtMockito 

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,181 @@
+# Migration Plan: Java 21 + Tomcat 10.x
+
+This document scopes the work to move SynapseWebClient to **Java 21** and **Tomcat 10.x
+(Jakarta EE)**, identifies the blockers, and breaks the work into discrete,
+independently reviewable/mergeable steps.
+
+## Strategy
+
+Two sequential phases:
+
+- **Phase 1 — Java 21 + GWT 2.13.** Ships independently while staying on Tomcat 9 /
+  `javax`. Lower risk.
+- **Phase 2 — Tomcat 10 / Jakarta.** Builds on Phase 1 and performs the
+  `javax.*` -> `jakarta.*` migration. Also depends on a parallel upstream effort to
+  release jakarta-compatible `org.sagebionetworks` client libraries.
+
+Guiding rule: **every merge to `main` must leave the build green.** This dictates what
+can be split into separate PRs vs. what must remain an atomic change.
+
+## Hard constraints discovered
+
+- **GWT cannot translate Java 18–21 syntax.** Client + shared code
+  (`org.sagebionetworks.web.client` / `.shared`) is permanently capped at **Java 17**
+  language features (records, switch expressions, text blocks, `instanceof` patterns).
+  Only **server-side** code gets full **Java 21**. This is inherent to GWT.
+- **Tomcat 10 forces Jakarta.** The `javax.servlet` -> `jakarta.servlet` namespace change
+  is atomic: Spring 6, Guice 7, and `gwt-servlet-jakarta` all reference the same servlet
+  namespace and must agree at once.
+
+## Key facts (verified)
+
+| Area | Finding |
+|------|---------|
+| Current state | Compiler target **11**, CI on JDK **11**, runtime **Corretto 17**, Tomcat **9**, `javax.servlet` only |
+| GWT | **2.11.0**; already ships `gwt-servlet-jakarta` (through 2.13.0) and runs on Java 21 |
+| GWT plugin | `org.codehaus.mojo:gwt-maven-plugin` **2.10.0** (frozen, June 2022); decoupled from GWT toolkit version. Fallback: `net.ltgt:gwt-maven-plugin:1.3.0` (maintained) |
+| `javax.servlet` surface | ~55 main files + ~24 test files; concentrated, no JAXB/validation/ws.rs/mail in source |
+| `@Inject` | 689 files use `com.google.inject.Inject` (jakarta-neutral); only 7 use `javax.inject.Inject` (5 client/GIN, 2 server) |
+| Spring | Shallow: no XML context, no DI, no MVC dispatcher. Only `RestTemplate`, `HttpStatus`, 3 `OncePerRequestFilter`, 1 `@Controller` |
+| Guice | 6.0.0; `guice-servlet` is `javax` -> needs Guice 7 (jakarta) |
+| Mockito | 2.28.2 (won't run on JDK 21); 267 files import the removed `org.mockito.Matchers`; 0 PowerMock; 0 static mocking |
+| GwtMockito | Abandoned at 1.1.9 (built vs Mockito 1.10.19); only **5** test files use it; drags in transitive `com.google.gwt:gwt-dev:2.8.0` |
+| Synapse libs | `synapseJavaClient` / `lib-*` are **servlet-neutral** today (verified via `dependency:tree`) |
+| Prod runtime | **Not configured in this repo** (no Dockerfile/deploy manifest); must be coordinated with ops |
+
+## Dependency graph
+
+### Overview (phase level)
+
+```mermaid
+flowchart LR
+    S0([S0: Build spike<br/>no merge])
+    X([X: Upstream synapse<br/>jakarta release])
+
+    subgraph PH1["Phase 1 — Java 21 + GWT 2.13 (Tomcat 9 / javax)"]
+        P1[P1: Retire GwtMockito]
+        P2[P2: Mockito 2 to 5]
+        P3[P3: Remove dead test deps]
+        P4[P4: GWT 2.11 to 2.13]
+        P4b[P4b: Swap to Tbroyer plugin<br/>conditional]
+        P5[[P5: JDK 11 to 21 cutover]]
+    end
+
+    subgraph PH2["Phase 2 — Jakarta / Tomcat 10"]
+        P6[P6: server @Inject normalize]
+        P7[P7: Remove unused javax.mail]
+        P8[P8: Replace tomcat7 plugin]
+        P9[[P9: Jakarta cutover - atomic]]
+        P10[P10: Prod container/JDK - ops]
+    end
+
+    S0 -. gates .-> P5
+    P1 --> P2
+    P2 --> P5
+    P3 --> P5
+    P4 --> P5
+    P4 -. if spike fails .-> P4b
+    P4b --> P5
+    S0 -. may insert .-> P4b
+
+    P5 --> P9
+    P6 --> P9
+    P7 --> P9
+    P8 --> P9
+    X --> P9
+    P9 --> P10
+```
+
+### Phase 1 detail
+
+```mermaid
+flowchart LR
+    S0([S0: Build spike])
+    P1[P1: Retire GwtMockito<br/>5 test files + drop dep]
+    P2[P2: Mockito 2 to 5<br/>267 Matchers renames]
+    P3[P3: Remove Grizzly +<br/>servlet-api 2.5]
+    P4[P4: GWT 2.11 to 2.13<br/>pin sourceLevel 17]
+    P4b[P4b: Swap to Tbroyer<br/>net.ltgt 1.3.0]
+    P5[[P5: JDK 11 to 21 cutover<br/>compiler+CI+containers]]
+
+    P1 --> P2 --> P5
+    P3 --> P5
+    P4 --> P5
+    P1 -. soft .-> P4
+    P4 -. if S0 fails .-> P4b --> P5
+    S0 -. gates .-> P5
+    S0 -. gates .-> P4b
+```
+
+### Phase 2 detail
+
+```mermaid
+flowchart LR
+    P5done([Phase 1 complete - P5])
+    X([X: Upstream synapse<br/>jakarta release])
+    P6[P6: server @Inject -><br/>com.google.inject - 2 files]
+    P7[P7: Remove unused<br/>javax.mail dep]
+    P8[P8: Replace<br/>tomcat7-maven-plugin]
+    P9[[P9: Jakarta cutover - atomic<br/>servlet+web.xml+Guice7+Spring6+<br/>gwt-servlet-jakarta+containers]]
+    P10[P10: Prod Tomcat 10 + JDK 21<br/>coordinate with ops]
+
+    P5done --> P9
+    P6 --> P9
+    P7 --> P9
+    P8 --> P9
+    X --> P9
+    P9 --> P10
+```
+
+Legend: `[[ ]]` = phase-completing milestone PR; `([ ])` = non-PR node (spike, external
+dependency, or ops coordination); dotted edges = conditional/soft dependencies.
+
+## Discrete steps
+
+| ID | Title | Scope | Depends on | Merges green on | Size |
+|----|-------|-------|-----------|-----------------|------|
+| **S0** | Build spike | Prove (a) codehaus gwt-maven-plugin 2.10 + GWT 2.13 runs on JDK 21, (b) Mockito 5 + byte-buddy green on 21. No merge. | — | n/a | ~1 day |
+| **P1** | Retire GwtMockito | Migrate the 5 `GwtMockitoTestRunner` files to plain Mockito + mocked views; remove gwtmockito dep (also drops transitive `gwt-dev:2.8.0`) | — | JDK 11 / Mockito 2 | S |
+| **P2** | Mockito 2 -> 5 | `org.mockito.Matchers` -> `ArgumentMatchers` (267 files), version bump, explicit byte-buddy >=1.14 + objenesis pins | P1 | JDK 11 (Mockito 5 runs on 11) | M (mechanical) |
+| **P3** | Remove dead test deps | Drop Grizzly + `servlet-api:2.5` | — | any | XS |
+| **P4** | GWT 2.11 -> 2.13 | Bump `gwtVersion`, pin `<sourceLevel>17</sourceLevel>`, clean stale GWT artifacts | (soft) P1 | JDK 11 | S |
+| **P4b** | *Conditional:* swap to Tbroyer plugin | Only if S0 shows codehaus 2.10 fails on JDK 21; migrate plugin config/module layout to `net.ltgt:1.3.0` | P4, S0 | JDK 11 | M–L |
+| **P5** | JDK 11 -> 21 cutover | `maven.compiler.*` -> 21, `.mvn/jvm.config` add-opens, CI JDK -> 21, `.tool-versions` -> corretto-21, codeserver image 17 -> 21 | P2, P4 (+P4b), S0 | **JDK 21**, Tomcat 9 | M |
+| **P6** | Server `@Inject` normalize | 2 server `javax.inject.Inject` -> `com.google.inject.Inject` (works under Guice 6) | — | Tomcat 9 | XS |
+| **P7** | Remove unused `javax.mail` | Delete dep | — | Tomcat 9 | XS |
+| **P8** | Replace `tomcat7-maven-plugin` | Remove dev-run plugin (rely on docker) | — | Tomcat 9 | XS |
+| **P9** | **Jakarta cutover (atomic)** | `javax.servlet` -> `jakarta.servlet` (~55 main + ~24 test), `web.xml` -> Jakarta 6.0, `gwt-servlet` -> `gwt-servlet-jakarta`, Guice 6 -> 7, Spring 5 -> 6, jackson-jakarta-xmlbind, dev+e2e containers `tomcat:9` -> `10` | P5, P6, P7, P8, **X** | **Tomcat 10** | L |
+| **P10** | Prod runtime bump | Coordinate prod Tomcat 10 + JDK 21 image with ops (outside this repo) | P9 | n/a | coord |
+
+## Why P9 cannot be split into separately-mergeable PRs
+
+The Jakarta namespace flip is **atomic by nature**: Spring 6's `OncePerRequestFilter`,
+Guice 7's `GuiceFilter`, `gwt-servlet-jakarta`'s `RemoteServiceServlet`, and the servlet
+imports all reference the *same* servlet namespace and must agree at once. You cannot land
+Spring 6 or Guice 7 on a Tomcat-9 / `javax` `main` and stay green.
+
+Two ways to keep P9 reviewable despite being one merge:
+
+- **Recommended:** develop P9 on a long-lived `jakarta` integration branch, structured as
+  ordered review-chunk commits (servlet imports -> web.xml -> gwt-servlet-jakarta/RPC ->
+  Guice 7 -> Spring 6 -> containers), CI'd against Tomcat 10, then merged as a unit once
+  `X` lands.
+- Squeeze the surface beforehand via the neutral prep PRs (P6–P8) so P9 contains only the
+  irreducible namespace change.
+
+## Ideal merge order
+
+1. `P3`, `P1` -> `P2`
+2. `P4` (-> `P4b` only if the spike requires it)
+3. **`P5`** closes Phase 1
+4. In parallel, land `P6`, `P7`, `P8` anytime (Tomcat 9, neutral prep)
+5. When `P5` is in and `X` (upstream jakarta release) is ready, open the `P9` branch
+6. Finish with `P10` (ops coordination)
+
+## Cross-cutting coordination
+
+- **Ops / infra:** production Tomcat 10 + JDK 21 image (outside this repo).
+- **Upstream:** synapse `lib-*` / `synapseJavaClient` jakarta release must land before P9
+  merges.
+- **Step 0 spike** must run first; its outcome determines whether `P4b` (Tbroyer plugin
+  swap) is needed.

--- a/pom.xml
+++ b/pom.xml
@@ -874,18 +874,6 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.gwt.gwtmockito</groupId>
-      <artifactId>gwtmockito</artifactId>
-      <version>1.1.9</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.gwt</groupId>
-          <artifactId>gwt-user</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <!-- Scribe library, imported for OAuth for LinkedIn -->
     <dependency>

--- a/src/main/java/org/sagebionetworks/web/client/GWTWrapper.java
+++ b/src/main/java/org/sagebionetworks/web/client/GWTWrapper.java
@@ -17,6 +17,8 @@ public interface GWTWrapper {
 
   void assignThisWindowWith(String url);
 
+  void replaceCurrentWindowWith(String url);
+
   String encode(String decodedURL);
 
   String encodeQueryString(String queryString);

--- a/src/main/java/org/sagebionetworks/web/client/GWTWrapperImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/GWTWrapperImpl.java
@@ -48,6 +48,11 @@ public class GWTWrapperImpl implements GWTWrapper {
   }
 
   @Override
+  public void replaceCurrentWindowWith(String url) {
+    Window.Location.replace(url);
+  }
+
+  @Override
   public String encode(String decodedURL) {
     return URL.encode(decodedURL);
   }

--- a/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinInjector.java
@@ -141,7 +141,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.SynapseAlert;
 import org.sagebionetworks.web.client.widget.entity.controller.URLProvEntryView;
 import org.sagebionetworks.web.client.widget.entity.download.AddFolderDialogWidget;
 import org.sagebionetworks.web.client.widget.entity.download.QuizInfoDialog;
-import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidgetV2;
+import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidget;
 import org.sagebionetworks.web.client.widget.entity.editor.APITableColumnConfigView;
 import org.sagebionetworks.web.client.widget.entity.editor.APITableConfigEditor;
 import org.sagebionetworks.web.client.widget.entity.editor.AttachmentConfigEditor;
@@ -725,7 +725,7 @@ public interface PortalGinInjector extends Ginjector {
 
   EntityFinderWidgetView getEntityFinderWidgetView();
 
-  UploadDialogWidgetV2 getUploadDialogWidget();
+  UploadDialogWidget getUploadDialogWidget();
 
   WikiMarkdownEditor getWikiMarkdownEditor();
 

--- a/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/ProfilePresenter.java
@@ -6,7 +6,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.place.shared.Place;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwt.user.client.ui.Widget;
@@ -814,7 +813,7 @@ public class ProfilePresenter
       updateProfileView(place.getUserId());
     } else {
       if (Profile.EDIT_PROFILE_TOKEN.equals(token)) {
-        Window.Location.replace(oneSageUtils.getAccountSettingsURL());
+        gwt.replaceCurrentWindowWith(oneSageUtils.getAccountSettingsURL());
       } else {
         // if this is a number, then treat it as a a user id
         try {
@@ -913,7 +912,7 @@ public class ProfilePresenter
         refreshTeams();
         break;
       case SETTINGS:
-        Window.Location.replace(oneSageUtils.getAccountSettingsURL());
+        gwt.replaceCurrentWindowWith(oneSageUtils.getAccountSettingsURL());
         break;
       case CHALLENGES:
         refreshChallenges();

--- a/src/main/java/org/sagebionetworks/web/client/presenter/users/PasswordResetPresenter.java
+++ b/src/main/java/org/sagebionetworks/web/client/presenter/users/PasswordResetPresenter.java
@@ -2,9 +2,9 @@ package org.sagebionetworks.web.client.presenter.users;
 
 import com.google.gwt.activity.shared.AbstractActivity;
 import com.google.gwt.event.shared.EventBus;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
+import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.OneSageUtils;
 import org.sagebionetworks.web.client.place.users.PasswordReset;
 import org.sagebionetworks.web.client.presenter.Presenter;
@@ -14,15 +14,17 @@ public class PasswordResetPresenter
   implements Presenter<PasswordReset> {
 
   private final OneSageUtils oneSageUtils;
+  private final GWTWrapper gwt;
 
   @Inject
-  public PasswordResetPresenter(OneSageUtils oneSageUtils) {
+  public PasswordResetPresenter(OneSageUtils oneSageUtils, GWTWrapper gwt) {
     this.oneSageUtils = oneSageUtils;
+    this.gwt = gwt;
   }
 
   @Override
   public void start(AcceptsOneWidget acceptsOneWidget, EventBus eventBus) {
-    Window.Location.replace(oneSageUtils.getOneSageURL("/resetPassword"));
+    gwt.replaceCurrentWindowWith(oneSageUtils.getOneSageURL("/resetPassword"));
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIcon.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIcon.java
@@ -2,10 +2,10 @@ package org.sagebionetworks.web.client.widget;
 
 import com.google.gwt.user.client.ui.HasVisibility;
 import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.UIObject;
 import org.sagebionetworks.repo.model.EntityType;
 
 public interface EntityTypeIcon extends HasVisibility, IsWidget {
   void configure(EntityType type);
   com.google.gwt.user.client.Element getElement();
+  String getIconHTML();
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/EntityTypeIconImpl.java
@@ -4,6 +4,7 @@ import com.google.gwt.dom.client.SpanElement;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.web.client.jsinterop.EntityTypeIconProps;
 import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactDOM;
 import org.sagebionetworks.web.client.jsinterop.ReactElement;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 
@@ -52,5 +53,12 @@ public class EntityTypeIconImpl
       enumValue = EntityType.valueOf(type);
     } catch (IllegalArgumentException e) {}
     setType(enumValue);
+  }
+
+  @Override
+  public String getIconHTML() {
+    // Force React to flush pending updates before reading the DOM
+    ReactDOM.flushSync();
+    return getElement().getInnerHTML();
   }
 }

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/controller/EntityActionControllerImpl.java
@@ -90,7 +90,6 @@ import org.sagebionetworks.web.client.events.EntityUpdatedEvent;
 import org.sagebionetworks.web.client.jsinterop.AlertButtonConfig;
 import org.sagebionetworks.web.client.jsinterop.EntityFinderScope;
 import org.sagebionetworks.web.client.jsinterop.KeyFactory;
-import org.sagebionetworks.web.client.jsinterop.ReactDOM;
 import org.sagebionetworks.web.client.jsinterop.ReactMouseEvent;
 import org.sagebionetworks.web.client.jsinterop.ToastMessageOptions;
 import org.sagebionetworks.web.client.jsinterop.reactquery.InvalidateQueryFilters;
@@ -130,7 +129,7 @@ import org.sagebionetworks.web.client.widget.entity.WikiPageDeleteConfirmationDi
 import org.sagebionetworks.web.client.widget.entity.act.ApproveUserAccessModal;
 import org.sagebionetworks.web.client.widget.entity.browse.EntityFinderWidget;
 import org.sagebionetworks.web.client.widget.entity.download.AddFolderDialogWidget;
-import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidgetV2;
+import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidget;
 import org.sagebionetworks.web.client.widget.entity.file.AddToDownloadListV2;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.Action;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.ActionListener;
@@ -267,7 +266,7 @@ public class EntityActionControllerImpl
   EntityAccessControlListModalWidget entityAccessControlListModalWidget;
   RenameEntityModalWidget renameEntityModalWidget;
   EntityFinderWidget.Builder entityFinderBuilder;
-  UploadDialogWidgetV2 uploadDialogWidgetV2;
+  UploadDialogWidget uploadDialogWidgetV2;
   EvaluationSubmitter submitter;
   EditFileMetadataModalWidget editFileMetadataModalWidget;
   EditProjectMetadataModalWidget editProjectMetadataModalWidget;
@@ -567,7 +566,7 @@ public class EntityActionControllerImpl
     return submitter;
   }
 
-  private UploadDialogWidgetV2 getUploadDialogWidget() {
+  private UploadDialogWidget getUploadDialogWidget() {
     if (uploadDialogWidgetV2 == null) {
       uploadDialogWidgetV2 = ginInjector.getUploadDialogWidget();
       view.setUploadDialogWidget(uploadDialogWidgetV2.asWidget());
@@ -642,7 +641,7 @@ public class EntityActionControllerImpl
   }
 
   private void configureUploader() {
-    UploadDialogWidgetV2 uploadDialogWidgetV2 = getUploadDialogWidget();
+    UploadDialogWidget uploadDialogWidgetV2 = getUploadDialogWidget();
     if (canUploadNewFileVersion() || canUploadFileToContainer()) {
       uploadDialogWidgetV2.configure(entity.getId());
     } else {
@@ -2892,10 +2891,7 @@ public class EntityActionControllerImpl
   private String getIconHTML() {
     EntityTypeIcon icon = ginInjector.getEntityTypeIcon();
     icon.configure(entityBundle.getEntityType());
-    // Pull the HTML out of the icon React component and inline it
-    // It's possible ReactDOM has not injected HTML to the widget yet, so use flushSync to force it to be written
-    ReactDOM.flushSync();
-    return icon.getElement().getInnerHTML();
+    return icon.getIconHTML();
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidget.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.web.client.widget.entity.download;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Interface for the upload dialog widget. Extracted to decouple
+ * {@link EntityActionControllerImpl} from the concrete GWT Widget subclass,
+ * enabling plain-Mockito unit tests.
+ */
+public interface UploadDialogWidget {
+  void configure(String entityId);
+
+  void show();
+
+  void clearDragAndDropHandlers();
+
+  Widget asWidget();
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetV2.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/download/UploadDialogWidgetV2.java
@@ -14,7 +14,7 @@ import org.sagebionetworks.web.client.jsinterop.ReactRefObject;
 import org.sagebionetworks.web.client.jsinterop.SRC;
 import org.sagebionetworks.web.client.widget.ReactComponent;
 
-public class UploadDialogWidgetV2 extends Widget {
+public class UploadDialogWidgetV2 extends Widget implements UploadDialogWidget {
 
   private final GlobalApplicationState globalApplicationState;
   private final EventBus eventBus;

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/GWTStub.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/GWTStub.java
@@ -31,6 +31,9 @@ public class GWTStub implements GWTWrapper {
   public void assignThisWindowWith(String url) {}
 
   @Override
+  public void replaceCurrentWindowWith(String url) {}
+
+  @Override
   public String encodeQueryString(String queryString) {
     return URLEncoder.encode(queryString);
   }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/PasswordResetPresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/PasswordResetPresenterTest.java
@@ -1,21 +1,22 @@
 package org.sagebionetworks.web.unitclient.presenter;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.sagebionetworks.web.client.ClientProperties;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.sagebionetworks.web.client.GWTWrapper;
 import org.sagebionetworks.web.client.OneSageUtils;
 import org.sagebionetworks.web.client.place.users.PasswordReset;
 import org.sagebionetworks.web.client.presenter.users.PasswordResetPresenter;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class PasswordResetPresenterTest {
 
   PasswordResetPresenter presenter;
@@ -26,19 +27,25 @@ public class PasswordResetPresenterTest {
   @Mock
   OneSageUtils oneSageUtils;
 
+  @Mock
+  GWTWrapper mockGwt;
+
   @Before
   public void setup() {
-    presenter = new PasswordResetPresenter(oneSageUtils);
-    when(place.toToken()).thenReturn(ClientProperties.DEFAULT_PLACE_TOKEN);
+    presenter = new PasswordResetPresenter(oneSageUtils, mockGwt);
   }
 
   @Test
   public void testStart() {
+    String expectedUrl = "https://accounts.synapse.org/resetPassword";
+    when(oneSageUtils.getOneSageURL("/resetPassword")).thenReturn(expectedUrl);
     presenter.setPlace(place);
 
     AcceptsOneWidget panel = mock(AcceptsOneWidget.class);
     EventBus eventBus = mock(EventBus.class);
 
     presenter.start(panel, eventBus);
+
+    verify(mockGwt).replaceCurrentWindowWith(expectedUrl);
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/presenter/ProfilePresenterTest.java
@@ -11,7 +11,6 @@ import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.place.shared.Place;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -21,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.*;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.entity.query.SortDirection;
@@ -49,7 +49,7 @@ import org.sagebionetworks.web.shared.exceptions.ConflictException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
 import org.sagebionetworks.web.unitserver.ChallengeClientImplTest;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ProfilePresenterTest {
 
   ProfilePresenter profilePresenter;
@@ -201,8 +201,6 @@ public class ProfilePresenterTest {
       .when(mockSynapseJavascriptClient)
       .getPrincipalAlias(any(), any());
     when(mockUserBundle.getUserProfile()).thenReturn(userProfile);
-    when(mockUserBundle.getIsCertified()).thenReturn(true);
-    when(mockUserBundle.getIsVerified()).thenReturn(false);
     when(mockUserBundle.getORCID()).thenReturn(ORC_ID);
     // by default, we only have a single page of results
     when(mockPaginatedTeamIds.getNextPageToken()).thenReturn(null);
@@ -272,7 +270,6 @@ public class ProfilePresenterTest {
     testEvaluationResults.add(testEvaluation);
     testBatchResults.setTotalNumberOfResults(1);
     testBatchResults.setResults(testEvaluationResults);
-    when(mockGlobalApplicationState.isEditing()).thenReturn(false);
     setupTestChallengePagedResults();
 
     when(place.toToken()).thenReturn(targetUserId);
@@ -1200,10 +1197,6 @@ public class ProfilePresenterTest {
   @Test
   public void testRefreshTeamsOwnerOnlyTeams() {
     int totalNotifications = 12; // must be even for tests to pass
-    AsyncMockStubber
-      .callSuccessWith((long) totalNotifications)
-      .when(mockSynapseJavascriptClient)
-      .getOpenMembershipInvitationCount(any(AsyncCallback.class));
     int inviteCount = 0;
     List<OpenUserInvitationBundle> invites = new ArrayList<
       OpenUserInvitationBundle
@@ -1229,10 +1222,6 @@ public class ProfilePresenterTest {
   @Test
   public void testRefreshTeamsOwnerOnlyInvites() {
     int totalNotifications = 12; // must be even for tests to pass
-    AsyncMockStubber
-      .callSuccessWith((long) totalNotifications)
-      .when(mockSynapseJavascriptClient)
-      .getOpenMembershipInvitationCount(any(AsyncCallback.class));
     int inviteCount = totalNotifications;
     List<OpenUserInvitationBundle> invites = new ArrayList<
       OpenUserInvitationBundle
@@ -1264,9 +1253,12 @@ public class ProfilePresenterTest {
 
   @Test
   public void testTabClickedSettings() {
+    String expectedUrl = "https://accounts.synapse.org/authenticated/myaccount";
+    when(mockOneSageUtils.getAccountSettingsURL()).thenReturn(expectedUrl);
     profilePresenter.setPlace(place);
     profilePresenter.showTab(ProfileArea.SETTINGS, true);
     verify(mockView).setTabSelected(eq(ProfileArea.SETTINGS));
+    verify(mockGwt).replaceCurrentWindowWith(expectedUrl);
   }
 
   @Test

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/controller/EntityActionControllerImplTest.java
@@ -45,9 +45,7 @@ import static org.sagebionetworks.web.client.widget.entity.controller.EntityActi
 
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.place.shared.Place;
-import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,6 +62,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -173,7 +172,7 @@ import org.sagebionetworks.web.client.widget.entity.controller.PreflightControll
 import org.sagebionetworks.web.client.widget.entity.controller.ProvenanceEditorWidget;
 import org.sagebionetworks.web.client.widget.entity.controller.StorageLocationWidget;
 import org.sagebionetworks.web.client.widget.entity.download.AddFolderDialogWidget;
-import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidgetV2;
+import org.sagebionetworks.web.client.widget.entity.download.UploadDialogWidget;
 import org.sagebionetworks.web.client.widget.entity.file.AddToDownloadListV2;
 import org.sagebionetworks.web.client.widget.entity.file.FileDownloadHandlerWidget;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.Action;
@@ -192,10 +191,9 @@ import org.sagebionetworks.web.shared.exceptions.BadRequestException;
 import org.sagebionetworks.web.shared.exceptions.NotFoundException;
 import org.sagebionetworks.web.shared.exceptions.UnauthorizedException;
 import org.sagebionetworks.web.test.helper.AsyncMockStubber;
-import org.sagebionetworks.web.test.helper.CallbackMockStubber;
 import org.sagebionetworks.web.test.helper.SelfReturningAnswer;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class EntityActionControllerImplTest {
 
   @Mock
@@ -237,7 +235,7 @@ public class EntityActionControllerImplTest {
   EvaluationSubmitter mockSubmitter;
 
   @Mock
-  UploadDialogWidgetV2 mockUploader;
+  UploadDialogWidget mockUploader;
 
   @Mock
   EntityActionMenu mockActionMenu;
@@ -414,9 +412,6 @@ public class EntityActionControllerImplTest {
   EntityTypeIcon mockEntityTypeIcon;
 
   @Mock
-  Element mockIconElement;
-
-  @Mock
   EntityAccessControlListModalWidget mockEntityAclModalWidget;
 
   @Captor
@@ -472,8 +467,6 @@ public class EntityActionControllerImplTest {
     when(mockKeyFactoryProvider.getKeyFactory(any()))
       .thenReturn(mockKeyFactory);
 
-    when(mockPortalGinInjector.getSynapseProperties())
-      .thenReturn(mockSynapseProperties);
     when(mockPortalGinInjector.getRenameEntityModalWidget())
       .thenReturn(mockRenameEntityModalWidget);
     when(mockPortalGinInjector.getEditFileMetadataModalWidget())
@@ -506,11 +499,8 @@ public class EntityActionControllerImplTest {
       .thenReturn(mockGlobalApplicationState);
     when(mockPortalGinInjector.getEvaluationSubmitter())
       .thenReturn(mockSubmitter);
-    when(mockSynapseProperties.getPublicPrincipalIds())
-      .thenReturn(mockPublicPrincipalIds);
     when(mockPortalGinInjector.getSynapseJavascriptClient())
       .thenReturn(mockSynapseJavascriptClient);
-    when(mockPortalGinInjector.getSynapseJSNIUtils()).thenReturn(mockJsniUtils);
     when(mockPortalGinInjector.getCreateTableViewWizard())
       .thenReturn(mockCreateTableViewWizard);
     when(mockPortalGinInjector.getCreateTableFromCsvDialog())
@@ -541,8 +531,7 @@ public class EntityActionControllerImplTest {
 
     when(mockPortalGinInjector.getEntityTypeIcon())
       .thenReturn(mockEntityTypeIcon);
-    when(mockEntityTypeIcon.getElement()).thenReturn(mockIconElement);
-    when(mockIconElement.getInnerHTML()).thenReturn("");
+    when(mockEntityTypeIcon.getIconHTML()).thenReturn("");
 
     // The controller under test.
     controller =
@@ -590,8 +579,6 @@ public class EntityActionControllerImplTest {
     entityBundle.setDoiAssociation(new DoiAssociation());
     entityBundle.setBenefactorAcl(mockACL);
     resourceAccessSet = new HashSet<>();
-    when(mockACL.getResourceAccess()).thenReturn(resourceAccessSet);
-    when(mockPublicPrincipalIds.isPublic(PUBLIC_USER_ID)).thenReturn(true);
     selected = new Reference();
     selected.setTargetId("syn9876");
 
@@ -617,10 +604,6 @@ public class EntityActionControllerImplTest {
       .when(mockEntityFinder)
       .show();
     currentEntityArea = null;
-    CallbackMockStubber
-      .invokeCallback()
-      .when(mockGWT)
-      .scheduleExecution(any(), anyInt());
 
     when(mockPromptModalConfigurationBuilder.buildConfiguration())
       .thenReturn(mockPromptModalConfiguration);
@@ -1510,10 +1493,6 @@ public class EntityActionControllerImplTest {
 
   @Test
   public void testConfigureProjectLevelTableCommandsCanEdit() {
-    when(
-      mockFeatureFlagConfig.isFeatureEnabled(FeatureFlagKey.DESCRIPTION_FIELD)
-    )
-      .thenReturn(true);
     entityBundle.setEntity(new Project());
     currentEntityArea = EntityArea.TABLES;
     boolean canCertifiedUserEdit = true;
@@ -1577,10 +1556,6 @@ public class EntityActionControllerImplTest {
 
   @Test
   public void testConfigureProjectLevelDatasetCommandsCanEdit() {
-    when(
-      mockFeatureFlagConfig.isFeatureEnabled(FeatureFlagKey.DESCRIPTION_FIELD)
-    )
-      .thenReturn(true);
     entityBundle.setEntity(new Project());
     currentEntityArea = EntityArea.DATASETS;
     boolean canCertifiedUserEdit = true;
@@ -2704,8 +2679,6 @@ public class EntityActionControllerImplTest {
       .deleteEntityById(anyString(), any(AsyncCallback.class));
     verify(mockView)
       .showErrorMessage(DisplayConstants.ERROR_ENTITY_DELETE_FAILURE + error);
-    QueryKey mockQueryKey = mock(QueryKey.class);
-    when(mockKeyFactory.getTrashCanItemsQueryKey()).thenReturn(mockQueryKey);
     verify(mockKeyFactoryProvider, never()).getKeyFactory(anyString());
     verify(mockKeyFactory, never()).getTrashCanItemsQueryKey();
     verify(mockQueryClient, never())
@@ -2752,8 +2725,6 @@ public class EntityActionControllerImplTest {
       );
     verify(mockPlaceChanger)
       .goTo(new Synapse(parentId, null, EntityArea.TABLES, null));
-    QueryKey mockQueryKey = mock(QueryKey.class);
-    when(mockKeyFactory.getTrashCanItemsQueryKey()).thenReturn(mockQueryKey);
     verify(mockKeyFactoryProvider).getKeyFactory(any());
     verify(mockKeyFactory).getTrashCanItemsQueryKey();
     verify(mockQueryClient)
@@ -2929,10 +2900,6 @@ public class EntityActionControllerImplTest {
       .callNoInvovke()
       .when(mockPreflightController)
       .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callNoInvovke()
-      .when(mockRenameEntityModalWidget)
-      .onRename(any(Entity.class), any(Callback.class));
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -2952,14 +2919,6 @@ public class EntityActionControllerImplTest {
   public void testRenameDatasetIsNotLatestVersion() {
     entityBundle.setEntity(mockDataset);
     entityBundle.setEntityType(dataset);
-    AsyncMockStubber
-      .callWithInvoke()
-      .when(mockPreflightController)
-      .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callWithInvoke()
-      .when(mockRenameEntityModalWidget)
-      .onRename(any(Entity.class), any(Callback.class));
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -3058,19 +3017,10 @@ public class EntityActionControllerImplTest {
       null,
       currentUserId
     );
-    when(mockGlobalApplicationState.getCurrentPlace()).thenReturn(currentPlace);
     AsyncMockStubber
       .callWithInvoke()
       .when(mockPreflightController)
       .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callNoInvovke()
-      .when(mockEditFileMetadataModalWidget)
-      .configure(
-        any(FileEntity.class),
-        any(FileHandle.class),
-        any(Callback.class)
-      );
 
     controller.configure(
       mockActionMenu,
@@ -3094,18 +3044,6 @@ public class EntityActionControllerImplTest {
     file.setVersionNumber(1L);
     entityBundle.setEntity(file);
     // currentPlace returns a non-null versionNumber
-    AsyncMockStubber
-      .callWithInvoke()
-      .when(mockPreflightController)
-      .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callNoInvovke()
-      .when(mockEditFileMetadataModalWidget)
-      .configure(
-        any(FileEntity.class),
-        any(FileHandle.class),
-        any(Callback.class)
-      );
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -3165,10 +3103,6 @@ public class EntityActionControllerImplTest {
       .callNoInvovke()
       .when(mockPreflightController)
       .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callNoInvovke()
-      .when(mockEditProjectMetadataModalWidget)
-      .configure(any(Project.class), anyBoolean(), any(Callback.class));
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -3216,15 +3150,6 @@ public class EntityActionControllerImplTest {
       .callWithInvoke()
       .when(mockPreflightController)
       .checkUpdateEntity(any(EntityBundle.class), any(Callback.class));
-    AsyncMockStubber
-      .callSuccessWith(new WikiPage())
-      .when(mockSynapseClient)
-      .createV2WikiPageWithV1(
-        anyString(),
-        anyString(),
-        any(WikiPage.class),
-        any(AsyncCallback.class)
-      );
     entityBundle.setRootWikiId(null);
     controller.configure(
       mockActionMenu,
@@ -4227,10 +4152,6 @@ public class EntityActionControllerImplTest {
     // project settings menu
     currentEntityArea = null;
     entityBundle.setEntity(new Project());
-    AsyncMockStubber
-      .callSuccessWith(new Challenge())
-      .when(mockChallengeClient)
-      .getChallengeForProject(any(), any());
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4266,15 +4187,7 @@ public class EntityActionControllerImplTest {
     // SWC-3876: if tools menu is set up for wiki commands, do not show the Run Challenge command (even
     // in alpha mode)
     currentEntityArea = EntityArea.WIKI;
-    when(
-      mockFeatureFlagConfig.isFeatureEnabled(FeatureFlagKey.DESCRIPTION_FIELD)
-    )
-      .thenReturn(true);
     entityBundle.setEntity(new Project());
-    AsyncMockStubber
-      .callFailureWith(new NotFoundException())
-      .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4292,10 +4205,6 @@ public class EntityActionControllerImplTest {
   public void testConfigureChallengeFoundNonEditable() throws Exception {
     entityBundle.setEntity(new Project());
     permissions.setCanEdit(false);
-    AsyncMockStubber
-      .callSuccessWith(new Challenge())
-      .when(mockChallengeClient)
-      .getChallengeForProject(anyString(), any(AsyncCallback.class));
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4767,9 +4676,7 @@ public class EntityActionControllerImplTest {
   @Test
   public void testOnEditDefiningSqlOnCancel() {
     when(mockMaterializedView.getId()).thenReturn(entityId);
-    String oldSql = "select everything";
     entityBundle.setEntity(mockMaterializedView);
-    when(mockMaterializedView.getDefiningSQL()).thenReturn(oldSql);
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -4810,9 +4717,7 @@ public class EntityActionControllerImplTest {
   @Test
   public void testOnEditDefiningSqlOnUpdate() {
     when(mockMaterializedView.getId()).thenReturn(entityId);
-    String oldSql = "select everything";
     entityBundle.setEntity(mockMaterializedView);
-    when(mockMaterializedView.getDefiningSQL()).thenReturn(oldSql);
     controller.configure(
       mockActionMenu,
       entityBundle,
@@ -5347,9 +5252,6 @@ public class EntityActionControllerImplTest {
     profile.setLastName(lastName);
     profile.setUserName(username);
     profile.setEmails(Collections.singletonList(email));
-    when(mockAuthenticationController.getCurrentUserProfile())
-      .thenReturn(profile);
-    when(mockGWT.getCurrentURL()).thenReturn(url);
     entityBundle.setEntity(new FileEntity());
     entityBundle.getEntity().setId(entityId);
 
@@ -5504,9 +5406,6 @@ public class EntityActionControllerImplTest {
 
   @Test
   public void testConfigureWithRecordSetHideCreateNewGridWithNoEdit() {
-    when(mockFeatureFlagConfig.isFeatureEnabled(FeatureFlagKey.SYNAPSE_GRID))
-      .thenReturn(true);
-
     boolean canEdit = false;
 
     RecordSet recordSet = new RecordSet();

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/BasicTitleBarTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/entity/file/BasicTitleBarTest.java
@@ -7,15 +7,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gwt.junit.GWTMockUtilities;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.function.Consumer;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.RestrictableObjectType;
@@ -30,8 +33,18 @@ import org.sagebionetworks.web.client.widget.entity.file.BasicTitleBarView;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenu;
 import org.sagebionetworks.web.client.widget.entity.menu.v3.EntityActionMenuProps;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class BasicTitleBarTest {
+
+  @BeforeClass
+  public static void disarmGwt() {
+    GWTMockUtilities.disarm();
+  }
+
+  @AfterClass
+  public static void restoreGwt() {
+    GWTMockUtilities.restore();
+  }
 
   BasicTitleBar titleBar;
 
@@ -150,7 +163,6 @@ public class BasicTitleBarTest {
     EntityActionMenuPropsJsInterop newJsInteropPropsAfterUpdate = mock(
       EntityActionMenuPropsJsInterop.class
     );
-    when(mockActionMenu.getProps()).thenReturn(newPropsAfterUpdate);
     when(newPropsAfterUpdate.toJsInterop())
       .thenReturn(newJsInteropPropsAfterUpdate);
 

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EditJSONListModalTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/table/v2/results/cell/EditJSONListModalTest.java
@@ -15,7 +15,6 @@ import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONException;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONString;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -25,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.web.client.GWTWrapper;
@@ -35,7 +35,7 @@ import org.sagebionetworks.web.client.widget.table.v2.results.cell.CellFactory;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.EditJSONListModal;
 import org.sagebionetworks.web.client.widget.table.v2.results.cell.EditJSONListModalView;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class EditJSONListModalTest {
 
   @Mock
@@ -200,7 +200,7 @@ public class EditJSONListModalTest {
   public void testConfigure_notJSONArray() {
     jsonString = "{\"actually\":\"a dictonary\"}";
     when(mockGWTWrapper.parseJSONStrict(jsonString))
-      .thenReturn(new JSONObject());
+      .thenReturn(mock(JSONObject.class));
 
     modal.configure(jsonString, mockOnSaveCallback, inputColumnModel);
 


### PR DESCRIPTION
GwtMockito was abandoned at 1.1.9 (built vs Mockito 1.10.19); only 5 test files use it; drags in transitive com.google.gwt:gwt-dev:2.8.0

As we upgrade to GWT 2.13 and Mockito 5, we are better off dropping it.