### PR TITLE
SWC-7851: improve size of videos in preview pane on entity page

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/VideoWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/renderer/VideoWidgetViewImpl.java
@@ -29,19 +29,21 @@ public class VideoWidgetViewImpl extends FlowPanel implements VideoWidgetView {
   ) {
     this.clear();
 
+    // Use the provided dimensions, defaulting to 640x480 if not specified.
+    // max-width:100% allows the video to shrink below its nominal width to fill
+    // smaller containers (e.g. the Files tab preview pane) while respecting the
+    // aspect ratio automatically.
+    String w = (width != null) ? SafeHtmlUtils.htmlEscape(width) : "640";
+    String h = (height != null) ? SafeHtmlUtils.htmlEscape(height) : "480";
+
     StringBuilder builder = new StringBuilder();
-
-    builder.append("<video width=\"");
-    if (width != null) builder.append(
-      SafeHtmlUtils.htmlEscape(width)
-    ); else builder.append("640");
-
-    builder.append("\" height=\"");
-    if (height != null) builder.append(
-      SafeHtmlUtils.htmlEscape(height)
-    ); else builder.append("480");
-
-    builder.append("\" controls crossorigin=\"anonymous\">");
+    builder.append(
+      "<video width=\"" +
+      w +
+      "\" height=\"" +
+      h +
+      "\" style=\"max-width:100%;height:auto;\" controls crossorigin=\"anonymous\">"
+    );
     if (mp4SynapseId != null) {
       builder.append("<source src=\"");
       builder.append(

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.java
@@ -99,7 +99,6 @@ public class FilesTabViewImpl implements FilesTabView {
 
   Widget widget;
   UserBadge createdByBadge, modifiedByBadge;
-  public static final String DEFAULT_WIDGET_HEIGHT = 197 + "px";
 
   @Inject
   public FilesTabViewImpl(UserBadge createdByBadge, UserBadge modifiedByBadge) {
@@ -110,7 +109,10 @@ public class FilesTabViewImpl implements FilesTabView {
     this.modifiedByBadge = modifiedByBadge;
   }
 
-  private ClickHandler getExpandClickHandler(final Widget w) {
+  private ClickHandler getExpandClickHandler(
+    final Widget w,
+    final String resetHeight
+  ) {
     return event -> {
       modalDialogContainer.clear();
       final Modal window = new Modal();
@@ -119,16 +121,18 @@ public class FilesTabViewImpl implements FilesTabView {
       final Div oldParent = (Div) w.getParent();
       w.removeFromParent();
       body.add(new ScrollPanel(w));
-      w.setHeight(
-        new Double(com.google.gwt.user.client.Window.getClientHeight())
-          .intValue() -
-        170 +
-        "px"
-      );
+      if (!resetHeight.isEmpty()) {
+        w.setHeight(
+          new Double(com.google.gwt.user.client.Window.getClientHeight())
+            .intValue() -
+          170 +
+          "px"
+        );
+      }
       ClickHandler closeHandler = closeEvent -> {
         w.removeFromParent();
         oldParent.add(w);
-        w.setHeight(DEFAULT_WIDGET_HEIGHT);
+        w.setHeight(resetHeight);
         window.hide();
         presenter.onExpandClosed();
       };
@@ -173,20 +177,20 @@ public class FilesTabViewImpl implements FilesTabView {
   @Override
   public void setPreview(Widget w) {
     previewWidget = w;
-    w.setHeight(DEFAULT_WIDGET_HEIGHT);
     filePreviewWidgetContainer.clear();
     filePreviewWidgetContainer.add(w);
     if (expandPreviewHandlerRegistration != null) {
       expandPreviewHandlerRegistration.removeHandler();
     }
     expandPreviewHandlerRegistration =
-      expandPreviewLink.addClickHandler(getExpandClickHandler(previewWidget));
+      expandPreviewLink.addClickHandler(
+        getExpandClickHandler(previewWidget, "")
+      );
   }
 
   @Override
   public void setProvenance(Widget w) {
     provenanceGraphWidget = w;
-    w.setHeight(DEFAULT_WIDGET_HEIGHT);
     fileProvenanceGraphContainer.clear();
     fileProvenanceGraphContainer.add(w);
     if (expandProvHandlerRegistration != null) {
@@ -195,7 +199,7 @@ public class FilesTabViewImpl implements FilesTabView {
     modalDialogContainer.clear();
     expandProvHandlerRegistration =
       expandProvenanceLink.addClickHandler(
-        getExpandClickHandler(provenanceGraphWidget)
+        getExpandClickHandler(provenanceGraphWidget, "")
       );
   }
 

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
@@ -55,12 +55,9 @@
                 pull="RIGHT"
               />
             </bh:Div>
-            <g:ScrollPanel
-              height="200px"
-              addStyleNames="padding-15 whiteBackground"
-            >
-              <bh:Div ui:field="filePreviewWidgetContainer" />
-            </g:ScrollPanel>
+            <bh:Div addStyleNames="padding-15 whiteBackground">
+              <bh:Div ui:field="filePreviewWidgetContainer" addStyleNames="file-preview-video-container" />
+            </bh:Div>
           </g:FlowPanel>
         </MUI:Grid>
         <MUI:Grid xs="12" md="6">

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -2442,6 +2442,16 @@ i.fa.small-icon {
   font-size: 15px;
 }
 
+.file-preview-video-container video {
+  width: 100%;
+  height: auto;
+}
+
+.modal-fullscreen .modal-body video {
+  width: 100%;
+  height: auto;
+}
+
 .highlight-line-min {
   padding: 5px;
 }


### PR DESCRIPTION
Verified wiki rendering is untouched.

Before:
<img width="1507" height="780" alt="Screenshot 2026-06-10 at 10 51 15 AM" src="https://github.com/user-attachments/assets/035c674c-57bc-4afa-bf8d-05d4289a1a1d" />
<img width="1508" height="735" alt="Screenshot 2026-06-10 at 10 51 07 AM" src="https://github.com/user-attachments/assets/46720b08-ddda-41be-abb9-4ed91aca30ae" />

After:
<img width="1504" height="780" alt="Screenshot 2026-06-10 at 10 51 43 AM" src="https://github.com/user-attachments/assets/e90c2f39-3e4d-43b8-af14-e9a9a159f8e9" />
<img width="1510" height="774" alt="Screenshot 2026-06-10 at 10 51 30 AM" src="https://github.com/user-attachments/assets/a18b6e90-e9af-4c42-bea9-b24967d8ffb0" />
