### PR TITLE
fix: upgrade com.fasterxml.jackson.core:jackson-core to 2.18.8, 2.21.4, 2.22.1 (GHSA-r7wm-3cxj-wff9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     <daggerVersion>2.59.2</daggerVersion>
     <xstream.version>1.3.1</xstream.version>
     <schema-to-pojo.version>0.6.10</schema-to-pojo.version>
-    <jackson.version>2.18.6</jackson.version>
-    <jackson.databind.version>2.18.6</jackson.databind.version>
+    <jackson.version>2.18.8</jackson.version>
+    <jackson.databind.version>2.18.8</jackson.databind.version>
     <log4j.version>2.25.4</log4j.version>
     <gwtbootstrap3.version>1.5.10</gwtbootstrap3.version>
     <gwtbootstrap3.extras.version>1.5.2</gwtbootstrap3.extras.version>


### PR DESCRIPTION
## Summary
Upgrade com.fasterxml.jackson.core:jackson-core from 2.18.6 to 2.18.8, 2.21.4, 2.22.1 to fix GHSA-r7wm-3cxj-wff9.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-r7wm-3cxj-wff9 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-r7wm-3cxj-wff9` |
| **File** | `pom.xml` |
| **Assessment** | Pattern match — needs manual review |

**Description**: jackson-core: Async parser maxNumberLength bypass via chunked digit accumulation (incomplete fix for GHSA-72hv-8253-57qq)

## Evidence

**Scanner confirmation**: trivy rule `GHSA-r7wm-3cxj-wff9` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `pom.xml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
