### PR TITLE
SWC-7906: Update title style for other sections of entity page to match provenance section title

### DIFF
--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
@@ -17,7 +17,7 @@
       <MUI:Grid container="true" columnSpacing="15px">
         <MUI:Grid xs="12" md="6">
           <b:Panel addStyleNames="margin-bottom-15">
-            <bh:Div addStyleNames="highlight-title">
+            <bh:Div addStyleNames="entity-title">
               <bh:Text text="Docker Pull Command" />
             </bh:Div>
             <b:PanelBody addStyleNames="margin-15">
@@ -32,14 +32,8 @@
         </MUI:Grid>
         <MUI:Grid xs="12" md="6">
           <g:FlowPanel addStyleNames="margin-bottom-15">
-            <bh:Div addStyleNames="highlight-title">
+            <bh:Div addStyleNames="entity-title">
               <bh:Text>Tags</bh:Text>
-              <w:HelpWidget
-                helpMarkdown="An image name is made up of slash-separated name components, optionally prefixed by a registry hostname."
-                href="https://docs.docker.com/engine/reference/commandline/tag/"
-                addStyleNames="margin-left-5"
-                placement="BOTTOM"
-              />
             </bh:Div>
             <bh:Div
               addStyleNames="padding-15"
@@ -57,16 +51,13 @@
             ui:field="provenancePanel"
             addStyleNames="margin-bottom-15"
           >
-            <bh:Div addStyleNames="highlight-title">
+            <bh:Div addStyleNames="entity-title">
               <bh:Text>Provenance</bh:Text>
-              <w:HelpWidget
-                helpMarkdown="Provenance tracks the relationship between data, code and analytical results"
-                href="https://help.synapse.org/docs/Provenance.1972470373.html"
-                addStyleNames="margin-left-5"
-                placement="BOTTOM"
-              />
             </bh:Div>
-            <bh:Div ui:field="dockerRepoProvenanceContainer" />
+            <bh:Div
+              ui:field="dockerRepoProvenanceContainer"
+              addStyleNames="contentSectionContainer"
+            />
           </g:FlowPanel>
         </MUI:Grid>
       </MUI:Grid>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
@@ -41,7 +41,7 @@
       >
         <MUI:Grid xs="12" md="6" ui:field="filePreviewContainer">
           <g:FlowPanel>
-            <bh:Div addStyleNames="highlight-title">
+            <bh:Div addStyleNames="entity-title">
               <bh:Text>Preview</bh:Text>
               <b:Anchor
                 addStyleNames="lightGreyText"
@@ -50,7 +50,7 @@
                 pull="RIGHT"
               />
             </bh:Div>
-            <bh:Div addStyleNames="padding-15 whiteBackground">
+            <bh:Div addStyleNames="contentSectionContainer">
               <bh:Div ui:field="filePreviewWidgetContainer" addStyleNames="file-preview-video-container" />
             </bh:Div>
           </g:FlowPanel>
@@ -66,18 +66,19 @@
                 pull="RIGHT"
               />
             </bh:Div>
-            <bh:Div
-              ui:field="fileProvenanceGraphContainer"
-              addStyleNames="whiteBackground"
-            />
+            <bh:Div addStyleNames="contentSectionContainer">
+              <bh:Div
+                ui:field="fileProvenanceGraphContainer"
+              />
+            </bh:Div>
           </g:FlowPanel>
         </MUI:Grid>
       </MUI:Grid>
       <g:FlowPanel ui:field="discussionContainer" addStyleNames="margin-top-10">
-        <bh:Div addStyleNames="highlight-title">
+        <bh:Div addStyleNames="entity-title">
           <bh:Text ui:field="discussionText" />
         </bh:Div>
-        <bh:Div ui:field="discussionThreadsContainer" />
+          <bh:Div ui:field="discussionThreadsContainer" />
       </g:FlowPanel>
     </bh:Div>
     <g:SimplePanel ui:field="fileModifiedAndCreatedContainer" />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
@@ -61,18 +61,12 @@
         <MUI:Grid container="true">
           <MUI:Grid xs="12" ui:field="provenanceContainer">
             <g:FlowPanel addStyleNames="margin-bottom-15 margin-top-15">
-              <bh:Div addStyleNames="highlight-title">
+              <bh:Div addStyleNames="entity-title">
                 <bh:Text>Provenance</bh:Text>
-                <w:HelpWidget
-                  helpMarkdown="Provenance tracks the relationship between data, code and analytical results"
-                  href="https://help.synapse.org/docs/Provenance.1972470373.html"
-                  addStyleNames="margin-left-5"
-                  placement="BOTTOM"
-                />
               </bh:Div>
               <bh:Div
                 ui:field="provenanceContainerHighlightBox"
-                addStyleNames="margin-top-10 margin-bottom-10"
+                addStyleNames="margin-bottom-10 contentSectionContainer"
               />
             </g:FlowPanel>
           </MUI:Grid>

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -1684,11 +1684,13 @@ h6 {
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
+  background-color: #fff;
 }
 
 .previewtable tbody td {
   border: 1px solid #ededed;
   padding: 4px;
+  background-color: #fff;
 }
 
 .markdowntable {

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -1878,6 +1878,12 @@ h6 {
   background-color: #f9f9f9;
 }
 
+.contentSectionContainer,
+#rootPanel .contentSectionContainer {
+  background-color: #f9f9f9;
+  padding: 15px;
+}
+
 .highlight-reply,
 #rootPanel .highlight-reply {
   background-color: #fcf7e8;


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/SWC-7906

SRC: https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/3049

<img width="1512" height="982" alt="Screenshot 2026-07-27 at 12 50 28 PM" src="https://github.com/user-attachments/assets/f70d0777-8085-428b-acec-35d531adff66" />
Section styling updates for datasets, tables, docker as well
<img width="1512" height="982" alt="Screenshot 2026-07-27 at 12 50 59 PM" src="https://github.com/user-attachments/assets/e895b446-c1f3-4368-990c-4c356563a8fd" />
<img width="1512" height="982" alt="Screenshot 2026-07-27 at 12 51 15 PM" src="https://github.com/user-attachments/assets/eb20d235-1f43-42fa-b36a-cc4d7999b77b" />
<img width="1512" height="982" alt="Screenshot 2026-07-27 at 12 51 35 PM" src="https://github.com/user-attachments/assets/c80bbc2e-f05e-45f4-bcf8-86d67d1e560a" />
