### PR TITLE
PORTALS-4327: Entity Page Redesign:  Entity thread list table

### DIFF
--- a/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
+++ b/src/main/java/org/sagebionetworks/web/client/PortalGinModule.java
@@ -135,6 +135,8 @@ import org.sagebionetworks.web.client.widget.CreateTableFromCsvDialog;
 import org.sagebionetworks.web.client.widget.CreateTableFromCsvDialogImpl;
 import org.sagebionetworks.web.client.widget.CsvPreview;
 import org.sagebionetworks.web.client.widget.CsvPreviewImpl;
+import org.sagebionetworks.web.client.widget.DiscussionEmpty;
+import org.sagebionetworks.web.client.widget.DiscussionEmptyImpl;
 import org.sagebionetworks.web.client.widget.DownloadSpeedTester;
 import org.sagebionetworks.web.client.widget.DownloadSpeedTesterImpl;
 import org.sagebionetworks.web.client.widget.EntityCitation;
@@ -2444,6 +2446,9 @@ public abstract class PortalGinModule {
 
   @Binds
   abstract EntityCitation bindEntityCitation(EntityCitationImpl impl);
+
+  @Binds
+  abstract DiscussionEmpty bindDiscussionEmpty(DiscussionEmptyImpl impl);
 
   @Binds
   abstract ProjectVisibilityChip bindProjectVisibilityChip(

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/DiscussionEmptyProps.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/DiscussionEmptyProps.java
@@ -1,0 +1,24 @@
+package org.sagebionetworks.web.client.jsinterop;
+
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class DiscussionEmptyProps extends ReactComponentProps {
+
+  @JsFunction
+  public interface Callback {
+    void run();
+  }
+
+  public Callback onViewForumClicked;
+
+  @JsOverlay
+  public static DiscussionEmptyProps create(Callback onViewForumClicked) {
+    DiscussionEmptyProps props = new DiscussionEmptyProps();
+    props.onViewForumClicked = onViewForumClicked;
+    return props;
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
+++ b/src/main/java/org/sagebionetworks/web/client/jsinterop/SRC.java
@@ -24,6 +24,7 @@ public class SRC {
     public static ReactComponentType<DiscussionThreadProps> DiscussionThread;
     public static ReactComponentType<ShareThisPageProps> ShareThisPage;
     public static ReactComponentType<EntityCitationProps> EntityCitation;
+    public static ReactComponentType<DiscussionEmptyProps> DiscussionEmpty;
     public static ReactComponentType<
       ProjectVisibilityChipContainerProps
     > ProjectVisibilityChip;

--- a/src/main/java/org/sagebionetworks/web/client/widget/DiscussionEmpty.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/DiscussionEmpty.java
@@ -1,0 +1,8 @@
+package org.sagebionetworks.web.client.widget;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.sagebionetworks.web.client.jsinterop.DiscussionEmptyProps;
+
+public interface DiscussionEmpty extends IsWidget {
+  void configure(DiscussionEmptyProps.Callback onViewForumClicked);
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/DiscussionEmptyImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/DiscussionEmptyImpl.java
@@ -1,0 +1,26 @@
+package org.sagebionetworks.web.client.widget;
+
+import javax.inject.Inject;
+import org.sagebionetworks.web.client.jsinterop.DiscussionEmptyProps;
+import org.sagebionetworks.web.client.jsinterop.React;
+import org.sagebionetworks.web.client.jsinterop.ReactElement;
+import org.sagebionetworks.web.client.jsinterop.SRC;
+
+public class DiscussionEmptyImpl
+  extends ReactComponent
+  implements DiscussionEmpty {
+
+  @Inject
+  public DiscussionEmptyImpl() {}
+
+  public void configure(DiscussionEmptyProps.Callback onViewForumClicked) {
+    DiscussionEmptyProps props = DiscussionEmptyProps.create(
+      onViewForumClicked
+    );
+    ReactElement component = React.createElementWithSynapseContext(
+      SRC.SynapseComponents.DiscussionEmpty,
+      props
+    );
+    this.render(component);
+  }
+}

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
@@ -190,6 +190,7 @@ public class DiscussionThreadListWidget
 
   public void clear() {
     view.clearSort();
+    view.setNoThreadsFoundVisible(false);
     loadMoreWidgetContainer.clear();
     threadId2Widget.clear();
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
@@ -190,7 +190,6 @@ public class DiscussionThreadListWidget
 
   public void clear() {
     view.clearSort();
-    view.setNoThreadsFoundVisible(false);
     loadMoreWidgetContainer.clear();
     threadId2Widget.clear();
   }

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidget.java
@@ -39,6 +39,7 @@ public class DiscussionThreadListWidget
   private String forumId;
   private CallbackP<Boolean> emptyListCallback;
   private CallbackP<DiscussionThreadBundle> threadIdClickedCallback;
+  private Callback onViewForumClickedCallback;
   Set<String> moderatorIds;
   private DiscussionFilter filter;
   private String entityId;
@@ -189,6 +190,7 @@ public class DiscussionThreadListWidget
 
   public void clear() {
     view.clearSort();
+    view.setNoThreadsFoundVisible(false);
     loadMoreWidgetContainer.clear();
     threadId2Widget.clear();
   }
@@ -197,6 +199,19 @@ public class DiscussionThreadListWidget
     CallbackP<DiscussionThreadBundle> threadIdClickedCallback
   ) {
     this.threadIdClickedCallback = threadIdClickedCallback;
+  }
+
+  public void setOnViewForumClickedCallback(
+    Callback onViewForumClickedCallback
+  ) {
+    this.onViewForumClickedCallback = onViewForumClickedCallback;
+    view.setViewForumEmptyStateEnabled(onViewForumClickedCallback != null);
+  }
+
+  public void onViewForumClicked() {
+    if (onViewForumClickedCallback != null) {
+      onViewForumClickedCallback.invoke();
+    }
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetView.java
@@ -11,6 +11,8 @@ public interface DiscussionThreadListWidgetView extends IsWidget {
 
   void setThreadCountAlert(Widget w);
 
+  // void setViewForumCallback(CallbackP<String> callback);
+
   void setPresenter(DiscussionThreadListWidget presenter);
 
   void setAlert(Widget w);

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetView.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetView.java
@@ -11,8 +11,6 @@ public interface DiscussionThreadListWidgetView extends IsWidget {
 
   void setThreadCountAlert(Widget w);
 
-  // void setViewForumCallback(CallbackP<String> callback);
-
   void setPresenter(DiscussionThreadListWidget presenter);
 
   void setAlert(Widget w);
@@ -20,6 +18,8 @@ public interface DiscussionThreadListWidgetView extends IsWidget {
   void setThreadHeaderVisible(boolean visible);
 
   void setNoThreadsFoundVisible(boolean visible);
+
+  void setViewForumEmptyStateEnabled(boolean enabled);
 
   void setThreadsContainer(IsWidget container);
 

--- a/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.java
@@ -12,6 +12,7 @@ import org.gwtbootstrap3.client.ui.html.Span;
 import org.sagebionetworks.repo.model.discussion.DiscussionThreadOrder;
 import org.sagebionetworks.repo.model.table.SortDirection;
 import org.sagebionetworks.web.client.jsinterop.mui.Grid;
+import org.sagebionetworks.web.client.widget.DiscussionEmpty;
 import org.sagebionetworks.web.client.widget.table.v2.results.SortableTableHeaderImpl;
 import org.sagebionetworks.web.client.widget.table.v2.results.SortingListener;
 
@@ -46,16 +47,26 @@ public class DiscussionThreadListWidgetViewImpl
   Div threadHeader;
 
   @UiField
-  Span noThreadsFound;
+  Div noThreadsFoundContainer;
+
+  @UiField
+  Span noThreadsFoundText;
+
+  private boolean viewForumEmptyStateEnabled = false;
 
   Widget widget;
   private DiscussionThreadListWidget presenter;
 
+  private final DiscussionEmpty discussionEmpty;
+
   private final Binder binder = GWT.create(Binder.class);
 
   @Inject
-  public DiscussionThreadListWidgetViewImpl() {
+  public DiscussionThreadListWidgetViewImpl(DiscussionEmpty discussionEmpty) {
+    this.discussionEmpty = discussionEmpty;
     widget = binder.createAndBindUi(this);
+    discussionEmpty.configure(() -> presenter.onViewForumClicked());
+    noThreadsFoundContainer.add(discussionEmpty);
 
     SortingListener onSortRepliesClick = headerName -> {
       clearSort();
@@ -118,7 +129,13 @@ public class DiscussionThreadListWidgetViewImpl
 
   @Override
   public void setNoThreadsFoundVisible(boolean visible) {
-    noThreadsFound.setVisible(visible);
+    noThreadsFoundContainer.setVisible(visible && viewForumEmptyStateEnabled);
+    noThreadsFoundText.setVisible(visible && !viewForumEmptyStateEnabled);
+  }
+
+  @Override
+  public void setViewForumEmptyStateEnabled(boolean enabled) {
+    this.viewForumEmptyStateEnabled = enabled;
   }
 
   @Override

--- a/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
+++ b/src/main/java/org/sagebionetworks/web/client/widget/entity/tabs/FilesTab.java
@@ -251,6 +251,11 @@ public class FilesTab {
       titleBar.configure(bundle, tab.getEntityActionMenu());
 
       previewWidget.configure(bundle);
+      discussionThreadListWidget.setOnViewForumClickedCallback(() ->
+        globalApplicationState
+          .getPlaceChanger()
+          .goTo(new Synapse(projectEntityId, null, EntityArea.DISCUSSION, null))
+      );
       discussionThreadListWidget.configure(currentEntityId, null, null);
       view.setDiscussionText(currentEntity.getName());
     }

--- a/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/discussion/DiscussionThreadListWidgetViewImpl.ui.xml
@@ -50,7 +50,8 @@
     </MUI:Grid>
     <MUI:Grid container="true">
       <MUI:Grid xs="12">
-        <bh:Span ui:field="noThreadsFound" visible="false" paddingLeft="10">
+        <bh:Div ui:field="noThreadsFoundContainer" visible="false" addStyleNames="contentSectionContainer margin-top-20" />
+        <bh:Span ui:field="noThreadsFoundText" visible="false" paddingLeft="10">
           No threads found.
         </bh:Span>
       </MUI:Grid>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/docker/DockerRepoWidgetViewImpl.ui.xml
@@ -56,7 +56,7 @@
             </bh:Div>
             <bh:Div
               ui:field="dockerRepoProvenanceContainer"
-              addStyleNames="contentSectionContainer"
+              addStyleNames="contentSectionContainer padding-15"
             />
           </g:FlowPanel>
         </MUI:Grid>

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/FilesTabViewImpl.ui.xml
@@ -50,7 +50,7 @@
                 pull="RIGHT"
               />
             </bh:Div>
-            <bh:Div addStyleNames="contentSectionContainer">
+            <bh:Div addStyleNames="contentSectionContainer padding-15">
               <bh:Div ui:field="filePreviewWidgetContainer" addStyleNames="file-preview-video-container" />
             </bh:Div>
           </g:FlowPanel>
@@ -66,7 +66,7 @@
                 pull="RIGHT"
               />
             </bh:Div>
-            <bh:Div addStyleNames="contentSectionContainer">
+            <bh:Div addStyleNames="contentSectionContainer padding-15">
               <bh:Div
                 ui:field="fileProvenanceGraphContainer"
               />

--- a/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
+++ b/src/main/resources/org/sagebionetworks/web/client/widget/entity/tabs/TablesTabViewImpl.ui.xml
@@ -66,7 +66,7 @@
               </bh:Div>
               <bh:Div
                 ui:field="provenanceContainerHighlightBox"
-                addStyleNames="margin-bottom-10 contentSectionContainer"
+                addStyleNames="margin-bottom-10 contentSectionContainer padding-15"
               />
             </g:FlowPanel>
           </MUI:Grid>

--- a/src/main/webapp/sass/_core.scss
+++ b/src/main/webapp/sass/_core.scss
@@ -1883,7 +1883,6 @@ h6 {
 .contentSectionContainer,
 #rootPanel .contentSectionContainer {
   background-color: #f9f9f9;
-  padding: 15px;
 }
 
 .highlight-reply,

--- a/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListWidgetTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitclient/widget/discussion/DiscussionThreadListWidgetTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -350,7 +351,7 @@ public class DiscussionThreadListWidgetTest {
       .configure(any(DiscussionThreadBundle.class));
     verify(mockEmptyListCallback).invoke(anyBoolean());
     verify(mockView).setThreadHeaderVisible(true);
-    verify(mockView).setNoThreadsFoundVisible(false);
+    verify(mockView, atLeastOnce()).setNoThreadsFoundVisible(false);
     verify(mockThreadsContainer).setIsMore(false);
 
     // test scroll to thread, rpc failure


### PR DESCRIPTION
Jira: https://sagebionetworks.jira.com/browse/PORTALS-4327?atlOrigin=eyJpIjoiZTc3MzFkYTc3YzhjNGY3MmI0ZjAwMjlmNjA1NzRmYWYiLCJwIjoiaiJ9

SRC: https://github.com/Sage-Bionetworks/synapse-web-monorepo/pull/3059

Replace "No threads found" text span on file entity page discussion section with the new DiscussionEmpty React component. Callback to navigate to project's discussion tab.

<img width="1512" height="982" alt="Screenshot 2026-07-29 at 2 13 16 PM" src="https://github.com/user-attachments/assets/99d951e8-0df7-460f-b3d8-e4d4d4dce965" />
<img width="1512" height="982" alt="Screenshot 2026-07-29 at 2 15 42 PM" src="https://github.com/user-attachments/assets/b7013f32-1bb3-412e-bbfa-6a2235805596" />

