### PR TITLE
another set of vulnerability updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     <daggerVersion>2.59.2</daggerVersion>
     <xstream.version>1.3.1</xstream.version>
     <schema-to-pojo.version>0.6.10</schema-to-pojo.version>
-    <jackson.version>2.18.6</jackson.version>
-    <jackson.databind.version>2.18.6</jackson.databind.version>
+    <jackson.version>2.18.8</jackson.version>
+    <jackson.databind.version>2.18.8</jackson.databind.version>
     <log4j.version>2.25.4</log4j.version>
     <gwtbootstrap3.version>1.5.10</gwtbootstrap3.version>
     <gwtbootstrap3.extras.version>1.5.2</gwtbootstrap3.extras.version>
@@ -610,7 +610,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>
@@ -933,7 +933,7 @@
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>neko-htmlunit</artifactId>
-      <version>2.55.0</version>
+      <version>2.70.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.james</groupId>


### PR DESCRIPTION
**jackson-core + jackson-databind**: `2.18.6` → `2.18.8`
- GHSA-r7wm-3cxj-wff9: Async parser `maxNumberLength` bypass via chunked digit
  accumulation (incomplete fix for GHSA-72hv-8253-57qq) — High
- GHSA-j3rv-43j4-c7qm: `PolymorphicTypeValidator` bypass via generic type
  parameters allows arbitrary class instantiation (CVE-2026-54512) — High
- GHSA-rmj7-2vxq-3g9f: Array subtype allowlist bypass in
  `BasicPolymorphicTypeValidator` (CVE-2026-54513) — High

**commons-beanutils**: `1.9.4` → `1.11.0` (forced via `<dependencyManagement>`)
- GHSA-wxr5-93ph-8wr9 / CVE-2025-48734: Improper Access Control — High
- Note: `1.9.4` falls within the affected range (`>= 1.0, <= 1.10.1`);
  `1.11.0` is the first patched release

**neko-htmlunit**: `2.55.0` → `2.70.0`
- GHSA-6jmm-mp6w-4rrg / CVE-2022-29546: OutOfMemory Exception via crafted
  processing instruction — High
- Patched at `2.61.0`; upgraded to `2.70.0` (latest available)