### PR TITLE
SWC-7865

### DIFF
--- a/js/moduleLoadDiagnostics.js
+++ b/js/moduleLoadDiagnostics.js
@@ -9,23 +9,34 @@
  * This module hooks the browser-level signals that fire
  * regardless of the boundary (Vite's `vite:preloadError`, global `error`, and
  * `unhandledrejection`) to answer two questions:
- *   1. How often and when is this happening? (an event is pushed to GTM `dataLayer` + logged)
+ *   1. How often and when is this happening? (logged to CloudWatch via
+ *      `POST /repo/v1/log`, see `sendLog`, and to the console)
  *   2. Why? When a failing chunk URL is known, we re-fetch BOTH the cached copy and a fresh
- *      network copy and record status / size / encoding / whether the trailing `export {...}`
- *      is present. That distinguishes the competing hypotheses at the point of failure:
- *        - truncated / corrupted body (parses but has no exports)
- *        - stale-or-wrong cached body (cached copy differs from network copy)
- *        - a missing export name (build/skew)
+ *      network copy and record status / size / head+tail bytes / encoding / how many times the
+ *      URL was actually requested on this page (via Resource Timing) / whether the *specific*
+ *      named export Vite reported missing is present (`hasNamedExport` - not just "some export
+ *      {...} exists somewhere in the body", which is true of every valid module and false of
+ *      every stylesheet, and so cannot distinguish any of the following). That distinguishes the
+ *      competing hypotheses at the point of failure:
+ *        - a short read (body ends cleanly, but before the trailing export statement)
+ *        - wrong bytes (a different module's body under this URL)
+ *        - a duplicate module record (the URL was fetched more than once on this page)
  *
  * This module must never throw or interfere with the app: every path is guarded.
  */
-
 const MAX_REPORTS = 25
 const seen = new Set()
+// Separate from `seen`: which (url, message) pairs have already been counted
+// against MAX_REPORTS and had the forensic re-fetch run. `seen` dedupes per
+// *boundary* (kind is part of its key); this dedupes per *failure*, so a
+// failure caught by two boundaries only spends one report-budget slot and
+// only triggers one forensic re-fetch. See the comment at its use in
+// `report()`.
+const firstSeenFailures = new Set()
 let reportCount = 0
 
 // Chunk load/link failures are usually transient (bad cache entry, edge
-// glitch) - a page reload reliably picks up a clean copy (this mirrors
+// glitch); a page reload reliably picks up a clean copy (this mirrors
 // Vite's own documented handling of vite:preloadError, and the existing
 // GWT runAsync-failure reload in Portal.java). Cap attempts per tab so a
 // genuinely broken deploy doesn't reload every affected session forever;
@@ -34,22 +45,142 @@ const MAX_RELOAD_ATTEMPTS = 3
 const RELOAD_COUNT_KEY = 'swcModuleReloadCount'
 let hasAttemptedRecoveryThisLoad = false
 
+// A reload cancels any in-flight fetches, which would silently drop the
+// forensic re-fetch (and its `swc_module_load_error_inspection` log entry)
+// this module just kicked off. Give it a bounded amount of time to finish
+// before navigating away.
+const INSPECTION_TIMEOUT_MS = 3000
+
 window.__swcModuleLoadErrors = window.__swcModuleLoadErrors || []
 
-/** Regexes that identify a lazy-module load/link failure (across browsers). */
-const MODULE_ERROR_PATTERNS = [
-  /doesn't provide an export named/i,
-  /does not provide an export named/i,
-  /failed to fetch dynamically imported module/i,
-  /error loading dynamically imported module/i,
-  /importing a module script failed/i,
-  /unable to preload (css|module)/i,
+/**
+ * The raw `message` is free-form JS-engine wording, so it can't be grouped
+ * or counted on its own. This maps each engine's wording onto a short,
+ * stable enum so the *shape* of a failure is groupable in CloudWatch (via
+ * `messageShape` in the JSON `message` body) without parsing the full text.
+ * Emitted alongside the raw `message`, never instead of it.
+ *
+ * Covers known engine wordings, plus Vite's own preload-helper wording:
+ *
+ *   missing-export      Firefox/SpiderMonkey "doesn't provide an export named"
+ *                       Chrome-Edge/V8       "does not provide an export named"
+ *                       Safari/JSC           "Importing binding name '...' is
+ *                                             not found."
+ *   fetch-failed        Firefox/SpiderMonkey "error loading dynamically
+ *                                             imported module"
+ *                       Chrome-Edge/V8       "Failed to fetch dynamically
+ *                                             imported module"
+ *                       Safari/JSC           "Importing a module script
+ *                                             failed."
+ *                       Vite helper          "Unable to preload module ..."
+ *   css-preload-failed  Vite helper          "Unable to preload CSS for ..."
+ *   other               Defensive default only. `MODULE_ERROR_PATTERNS` is
+ *                       derived from this table, so any message that passes
+ *                       `isModuleError` necessarily matches a shape above.
+ *                       This is the single place a new engine wording gets
+ *                       added, which makes a message both *reportable* and
+ *                       *classifiable* in one edit. That coupling is the
+ *                       point: Safari's missing-export wording once existed
+ *                       in one list but not the other.
+ *
+ * Order matters: the CSS test runs first because "Unable to preload CSS" is a
+ * distinct population (the redirector path) that must not be folded into the
+ * generic fetch-failure bucket.
+ */
+const MESSAGE_SHAPE_PATTERNS = [
+  ['css-preload-failed', [/unable to preload css/i]],
+  [
+    'missing-export',
+    [
+      /doesn't provide an export named/i,
+      /does not provide an export named/i,
+      /importing binding name .* is not found/i,
+    ],
+  ],
+  [
+    'fetch-failed',
+    [
+      /failed to fetch dynamically imported module/i,
+      /error loading dynamically imported module/i,
+      /importing a module script failed/i,
+      /unable to preload module/i,
+    ],
+  ],
 ]
+
+/**
+ * Regexes that identify a lazy-module load/link failure (across browsers),
+ * derived from MESSAGE_SHAPE_PATTERNS so the two can never drift apart. Do not
+ * re-inline this list: a wording present here but absent from the shape table
+ * would be reported as an unclassifiable `other`, and a wording present there
+ * but absent here would not be reported at all.
+ */
+const MODULE_ERROR_PATTERNS = MESSAGE_SHAPE_PATTERNS.flatMap(
+  ([, patterns]) => patterns,
+)
 
 function isModuleError(message) {
   if (!message) return false
   return MODULE_ERROR_PATTERNS.some(re => re.test(message))
 }
+
+function classifyMessageShape(message) {
+  try {
+    if (!message) return 'other'
+    for (const [shape, patterns] of MESSAGE_SHAPE_PATTERNS) {
+      if (patterns.some(re => re.test(message))) return shape
+    }
+  } catch {
+    /* diagnostics must never break the app */
+  }
+  return 'other'
+}
+
+/** Matches a content-hashed Vite asset filename, e.g. `main-D2GRFy7k.js`. */
+const HASHED_ASSET_RE = /([^/]+-[A-Za-z0-9_-]{8,})\.(?:js|mjs)(?:$|[?#])/
+
+function buildIdFromUrl(value) {
+  if (typeof value !== 'string') return undefined
+  const m = value.match(HASHED_ASSET_RE)
+  return m ? m[1] : undefined
+}
+
+/**
+ * Which JavaScript build the failing tab is actually *executing*, e.g.
+ * `main-D2GRFy7k.js`.
+ *
+ * We can use this to determine which version the Synapse UI is running in the
+ * tab, and would identify the case where a user is using stale UI assets
+ * that they acquired before the latest release of Synapse.
+ */
+function detectBuildId() {
+  try {
+    const fromSelf = buildIdFromUrl(
+      typeof import.meta !== 'undefined' && import.meta
+        ? import.meta.url
+        : undefined,
+    )
+    if (fromSelf) return fromSelf
+
+    if (typeof document !== 'undefined' && document.querySelectorAll) {
+      const tags = [
+        ...document.querySelectorAll('script[type="module"][src]'),
+        ...document.querySelectorAll('link[rel="modulepreload"][href]'),
+      ]
+      for (const tag of tags) {
+        const fromTag = buildIdFromUrl(
+          tag.getAttribute('src') || tag.getAttribute('href'),
+        )
+        if (fromTag) return fromTag
+      }
+    }
+  } catch {
+    /* diagnostics must never break the app */
+  }
+  return 'unknown'
+}
+
+const BUILD_ID = detectBuildId()
 
 /** Pull the offending asset URL out of an error message, when present. */
 function extractUrl(message) {
@@ -74,11 +205,136 @@ function extractExportName(message) {
   return m ? m[1] : undefined
 }
 
+/**
+ * Whether `text` (a fetched module body) actually exports `name` as a
+ * binding. Unlike `/export\s*\{/.test(text)`, this checks for the specific
+ * name Vite's helper reported missing - true of every valid ESM module and
+ * false of every stylesheet, so it can't tell a truncated/corrupted module
+ * apart from a merely-different one. Vite/rolldown emit named exports as a
+ * single trailing statement, e.g. `export{f as t}` or `export{y as n,w as
+ * t}` - `t`/`n` (right of `as`, or bare) are the *exported* names.
+ *
+ * Returns `true`/`false` when the final `export{...}` statement resolves
+ * the question, or `null` when it can't be answered from static text alone
+ * (no `export{...}` found at all, e.g. a CSS response; or the module only
+ * re-exports via `export * from '...'`, which would require following the
+ * chain to know whether it supplies `name`). Callers must not treat `null`
+ * as `false` - that would reintroduce the exact ambiguity this replaces.
+ */
+function hasNamedExport(text, name) {
+  if (!name || typeof text !== 'string') return null
+
+  const exportBlockRe = /export\s*\{([^}]*)\}/g
+  let lastBindings = null
+  let match
+  while ((match = exportBlockRe.exec(text)) !== null) {
+    lastBindings = match[1]
+  }
+
+  if (lastBindings !== null) {
+    const bindings = lastBindings.split(',')
+    for (const binding of bindings) {
+      const trimmed = binding.trim()
+      if (!trimmed) continue
+      const asMatch = trimmed.match(/^(\S+)\s+as\s+(\S+)$/)
+      const exportedName = asMatch ? asMatch[2] : trimmed
+      if (exportedName === name) return true
+    }
+    // The final export statement doesn't bind `name` - but only trust that
+    // as a genuine "missing" if there's no `export * from` re-export chain
+    // elsewhere in the body that could be supplying it instead.
+    if (!/export\s*\*\s*from/.test(text)) return false
+  }
+
+  return null
+}
+
 function safeHeader(res, name) {
   try {
     return res.headers.get(name)
   } catch {
     return null
+  }
+}
+
+/**
+ * How many times `url` was actually requested by this page, via the
+ * browser's Resource Timing entries. This is the direct evidence for
+ * whether a chunk was fetched at two different URLs that happened to
+ * resolve to the same module, e.g. a `/Portal/cdn/...` preload vs. a direct
+ * `import()`.
+ *
+ * Cross-origin size fields on these entries (decodedBodySize/encodedBodySize/
+ * transferSize) read as 0 unless the response sends `Timing-Allow-Origin`;
+ * see CORSFilter.
+ */
+function collectResourceTiming(url) {
+  try {
+    if (
+      typeof performance === 'undefined' ||
+      typeof performance.getEntriesByName !== 'function'
+    ) {
+      return { fetchCount: null, entries: [], error: 'no-resource-timing' }
+    }
+
+    const candidates = [url]
+    // `PerformanceResourceTiming.name` is the entry's serialized, absolute
+    // requested URL, so `getEntriesByName` only matches an absolute URL.
+    // Every candidate below must therefore be absolute, or the whole
+    // duplicate-fetch probe (`fetchCount`, `resourceTimingEntries`) silently
+    // becomes dead code.
+    try {
+      const documentOrigin =
+        (typeof window !== 'undefined' &&
+          window.location &&
+          window.location.href) ||
+        undefined
+      const parsed = new URL(url, documentOrigin)
+      // The reported URL is itself sometimes root-relative, which for the
+      // same reason can never match either; add its absolute form too.
+      if (parsed.href !== url) candidates.push(parsed.href)
+
+      const m = parsed.pathname.match(/\/generated\/vite\/(.*)$/)
+      if (m) {
+        const redirectorPath = `/Portal/cdn/generated/vite/${m[1]}`
+        const origins = [parsed.origin]
+        if (
+          typeof window !== 'undefined' &&
+          window.location &&
+          window.location.origin
+        ) {
+          origins.push(window.location.origin)
+        }
+        for (const origin of origins) {
+          if (origin && origin !== 'null') {
+            candidates.push(`${origin}${redirectorPath}`)
+          }
+        }
+      }
+    } catch {
+      /* url wasn't absolute/parseable; skip the alternate forms */
+    }
+
+    const uniqueCandidates = [...new Set(candidates)]
+    const entries = uniqueCandidates.flatMap(candidate =>
+      performance.getEntriesByName(candidate),
+    )
+
+    return {
+      fetchCount: entries.length,
+      entries: entries.map(e => ({
+        name: e.name,
+        decodedBodySize: e.decodedBodySize,
+        encodedBodySize: e.encodedBodySize,
+        transferSize: e.transferSize,
+      })),
+    }
+  } catch (e) {
+    return {
+      fetchCount: null,
+      entries: [],
+      error: String((e && e.message) || e),
+    }
   }
 }
 
@@ -90,7 +346,7 @@ function safeHeader(res, name) {
  * not populate the cached version, overwriting the stale version we hope to
  * capture.
  */
-async function inspectModule(url) {
+async function inspectModule(url, expectedExport) {
   const probe = async init => {
     try {
       const res = await fetch(url, {
@@ -103,6 +359,8 @@ async function inspectModule(url) {
         status: res.status,
         bytes: text.length,
         hasExport: /export\s*\{/.test(text),
+        hasNamedExport: hasNamedExport(text, expectedExport),
+        head: text.slice(0, 64),
         tail: text.slice(-96),
         xCache: safeHeader(res, 'x-cache'),
         age: safeHeader(res, 'age'),
@@ -120,66 +378,232 @@ async function inspectModule(url) {
   return { cached, network }
 }
 
+// --- Backend logging --------------------------------------------------
+//
+// The server logs each entry as `"{label} - {userAgent}: {message}"` (see
+// LogServiceImpl in Synapse-Repository-Services), so `label` is the only
+// field cheaply filterable without parsing; the full payload travels in
+// `message` as a JSON string instead, and includes `portalVersion`/
+// `repoVersion` (see `getVersions`) on every entry. A typical Logs Insights
+// query:
+//   fields @timestamp, @message
+//   | filter @message like /swc_module_load_error/
+//   | parse @message '* - *: *' as label, userAgent, jsonBody
+//   | parse jsonBody '"buildId":"*"' as buildId
+//   | stats count(*) by buildId
+
+const LOG_ENDPOINT_PATH = '/log'
+// Mirrors the fallback in synapse-react-client's getEndpoint(): if GWT
+// hasn't set `window.SRC_OVERRIDE_ENDPOINT_CONFIG` yet (this module can run
+// before GWT bootstraps), assume production.
+const PRODUCTION_REPO_ENDPOINT = 'https://repo-prod.prod.sagebase.org/repo/v1'
+// Same idea for the Portal's own origin (used only for `GET /Portal/versions`
+// below, not for the log service itself).
+const PRODUCTION_PORTAL_ENDPOINT = 'https://www.synapse.org/'
+const PORTAL_VERSIONS_PATH = 'Portal/versions'
+const LOG_LABEL_ERROR = 'swc_module_load_error'
+const LOG_LABEL_INSPECTION = 'swc_module_load_error_inspection'
+const LOG_LABEL_RECOVERY = 'swc_module_load_recovery'
+
+function getRepoEndpoint() {
+  try {
+    const override =
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG &&
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG.REPO
+    return override || PRODUCTION_REPO_ENDPOINT
+  } catch {
+    return PRODUCTION_REPO_ENDPOINT
+  }
+}
+
+function getPortalEndpoint() {
+  try {
+    const override =
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG &&
+      window.SRC_OVERRIDE_ENDPOINT_CONFIG.PORTAL
+    return override || PRODUCTION_PORTAL_ENDPOINT
+  } catch {
+    return PRODUCTION_PORTAL_ENDPOINT
+  }
+}
+
+// `/repo/v1/log` doesn't require a bearer token. We still attach one when
+// available so an authenticated user's failures are attributable to their
+// account instead of logged anonymously. Its absence, e.g. very early in page
+// life, before GWT starts `SynapseSessionManager`, is not a failure mode.
+function getAccessToken() {
+  try {
+    return (
+      (window.SynapseSessionManager &&
+        window.SynapseSessionManager.getSnapshot &&
+        window.SynapseSessionManager.getSnapshot().token) ||
+      undefined
+    )
+  } catch {
+    return undefined
+  }
+}
+
+let versionsPromise = null
+
+/**
+ * Fetch and cache `{ portalVersion, repoVersion }`.
+ */
+function getVersions() {
+  if (!versionsPromise) {
+    versionsPromise = fetch(
+      `${getPortalEndpoint().replace(/\/+$/, '')}/${PORTAL_VERSIONS_PATH}`,
+      { mode: 'cors', credentials: 'omit', keepalive: true },
+    )
+      .then(res => res.text())
+      .then(text => {
+        const [portalVersion, repoVersion] = text.split(',')
+        return { portalVersion, repoVersion }
+      })
+      .catch(() => ({}))
+  }
+  return versionsPromise
+}
+
+/**
+ * Send one entry to the backend log service. `keepalive` lets the request
+ * survive a page reload (e.g. the one `attemptRecovery` triggers) without
+ * needing to be awaited first.
+ */
+function sendLog(label, messagePayload, stacktrace) {
+  try {
+    return getVersions()
+      .then(versions => {
+        const token = getAccessToken()
+        return fetch(`${getRepoEndpoint()}${LOG_ENDPOINT_PATH}`, {
+          method: 'POST',
+          mode: 'cors',
+          credentials: 'omit',
+          keepalive: true,
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            label,
+            message: JSON.stringify({ ...messagePayload, ...versions }),
+            stacktrace: stacktrace || '',
+          }),
+        })
+      })
+      .catch(() => {})
+  } catch {
+    return Promise.resolve()
+  }
+}
+
+/** Build the payload reported for one failure/boundary combination. */
+function buildPayload(kind, message, stack, url) {
+  return {
+    kind,
+    message,
+    // Short groupable enum for `message`; see MESSAGE_SHAPE_PATTERNS.
+    messageShape: classifyMessageShape(message),
+    url,
+    expectedExport: extractExportName(message),
+    stack,
+    buildId: BUILD_ID,
+    reloadAttempts: getReloadCount(),
+    recoveryAttemptedThisLoad: hasAttemptedRecoveryThisLoad,
+    pageUrl: window.location && window.location.href,
+    referrer: document.referrer || undefined,
+    userAgent: navigator.userAgent,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/**
+ * Forensic re-fetch and its own log entry (async, best-effort). Returned so
+ * callers (the recovery path) can wait for the re-fetch before navigating
+ * away - a reload cancels in-flight fetches, which would silently drop it.
+ */
+function runInspectionAndReport(url, payload) {
+  return inspectModule(url, payload.expectedExport)
+    .then(inspection => {
+      const timing = collectResourceTiming(url)
+      const enriched = { ...payload, inspection, timing }
+      // `probe()` always resolves to an object, so these defaults only
+      // matter if `inspectModule` itself is ever changed to resolve without
+      // one; they keep every key below present rather than throwing.
+      const cached = inspection.cached || {}
+      const network = inspection.network || {}
+      sendLog(LOG_LABEL_INSPECTION, {
+        url,
+        expectedExport: payload.expectedExport,
+        messageShape: payload.messageShape,
+        buildId: BUILD_ID,
+        cachedHasExport: cached.hasExport,
+        networkHasExport: network.hasExport,
+        cachedHasNamedExport: cached.hasNamedExport,
+        networkHasNamedExport: network.hasNamedExport,
+        cachedBytes: cached.bytes,
+        networkBytes: network.bytes,
+        cachedHead: cached.head,
+        networkHead: network.head,
+        cachedTail: cached.tail,
+        networkTail: network.tail,
+        cachedXCache: cached.xCache,
+        cachedStatus: cached.status,
+        networkStatus: network.status,
+        cachedEtag: cached.etag,
+        networkEtag: network.etag,
+        cachedContentLength: cached.contentLength,
+        networkContentLength: network.contentLength,
+        cachedContentEncoding: cached.contentEncoding,
+        networkContentEncoding: network.contentEncoding,
+        cachedAge: cached.age,
+        networkAge: network.age,
+        cachedError: cached.error,
+        networkError: network.error,
+        fetchCount: timing.fetchCount,
+        resourceTimingEntries: timing.entries,
+      })
+      // eslint-disable-next-line no-console
+      console.error('[swc-module-load-error] inspection', enriched)
+    })
+    .catch(() => {})
+}
+
 function report(kind, message, stack) {
   try {
-    if (!isModuleError(message)) return
-    if (reportCount >= MAX_REPORTS) return
+    if (!isModuleError(message)) return undefined
+    if (reportCount >= MAX_REPORTS) return undefined
 
     const url = extractUrl(message)
-    const key = `${url || ''}|${message}`
-    if (seen.has(key)) return
+    const key = `${kind}|${url || ''}|${message}`
+    if (seen.has(key)) return undefined
     seen.add(key)
-    reportCount++
 
-    const payload = {
-      kind,
-      message,
-      url,
-      expectedExport: extractExportName(message),
-      stack,
-      pageUrl: window.location && window.location.href,
-      referrer: document.referrer || undefined,
-      userAgent: navigator.userAgent,
-      timestamp: new Date().toISOString(),
+    const payload = buildPayload(kind, message, stack, url)
+
+    const failureKey = `${url || ''}|${message}`
+    const isFirstSightingOfFailure = !firstSeenFailures.has(failureKey)
+    if (isFirstSightingOfFailure) {
+      firstSeenFailures.add(failureKey)
+      reportCount++
     }
 
     window.__swcModuleLoadErrors.push(payload)
 
-    // Frequency tracking via GTM. Safe if GTM has not loaded yet.
-    window.dataLayer = window.dataLayer || []
-    window.dataLayer.push({
-      event: 'swc_module_load_error',
-      swcModuleError: payload,
-    })
+    const loggablePayload = { ...payload }
+    // Remove `stack` from the payload, put it in the `stack` argument to the log method
+    delete loggablePayload.stack
+    sendLog(LOG_LABEL_ERROR, loggablePayload, stack)
 
     // eslint-disable-next-line no-console
     console.error('[swc-module-load-error]', payload)
 
-    // Forensic re-fetch (async, best-effort).
-    if (url) {
-      inspectModule(url)
-        .then(inspection => {
-          const enriched = { ...payload, inspection }
-          window.dataLayer.push({
-            event: 'swc_module_load_error_inspection',
-            swcModuleError: {
-              url,
-              expectedExport: payload.expectedExport,
-              cachedHasExport: inspection.cached && inspection.cached.hasExport,
-              networkHasExport:
-                inspection.network && inspection.network.hasExport,
-              cachedBytes: inspection.cached && inspection.cached.bytes,
-              networkBytes: inspection.network && inspection.network.bytes,
-              cachedXCache: inspection.cached && inspection.cached.xCache,
-            },
-          })
-          // eslint-disable-next-line no-console
-          console.error('[swc-module-load-error] inspection', enriched)
-        })
-        .catch(() => {})
-    }
+    if (!url || !isFirstSightingOfFailure) return undefined
+
+    return runInspectionAndReport(url, payload)
   } catch {
     /* diagnostics must never break the app */
+    return undefined
   }
 }
 
@@ -221,40 +645,47 @@ function showReloadBanner() {
 }
 
 /**
- * Report the recovery outcome to GTM so GA4 can measure whether the reload
- * actually resolves incidents (vs. exhausting the cap into a visible
- * banner) - separate from the raw error-volume signal, which only reflects
- * how often the underlying bug occurs, not whether this mitigation works.
+ * Report the recovery outcome so we can measure whether the reload actually
+ * resolves incidents (vs. exhausting the cap into a visible banner), separate
+ * from the raw error-volume signal, which only reflects how often the
+ * underlying bug occurs, not whether this mitigation works.
  */
 function pushRecoveryEvent(outcome, attempt, url) {
-  try {
-    window.dataLayer = window.dataLayer || []
-    window.dataLayer.push({
-      event: 'swc_module_load_recovery',
-      swcModuleRecovery: { outcome, attempt, url },
-    })
-  } catch {
-    /* diagnostics must never break the app */
-  }
+  sendLog(LOG_LABEL_RECOVERY, { outcome, attempt, url })
 }
 
 /**
  * Attempt to self-heal from a preload failure by reloading, bounded by
  * MAX_RELOAD_ATTEMPTS per tab session. At most one attempt is spent per
  * page load, even if several chunks fail together in the same load.
+ *
+ * `inspectionPromise` (the in-flight forensic re-fetch kicked off by
+ * `report()`, if any) is awaited - with a timeout, since it must never
+ * block recovery indefinitely - before reloading, so the navigation
+ * doesn't cancel it and drop the `swc_module_load_error_inspection` log
+ * entry.
  */
-function attemptRecovery(message) {
+async function attemptRecovery(message, inspectionPromise) {
   try {
     if (hasAttemptedRecoveryThisLoad) return
-    hasAttemptedRecoveryThisLoad = true
 
     const url = extractUrl(message)
     const count = getReloadCount()
+
     if (count >= MAX_RELOAD_ATTEMPTS) {
+      hasAttemptedRecoveryThisLoad = true
       pushRecoveryEvent('banner_shown', count, url)
       showReloadBanner()
       return
     }
+
+    hasAttemptedRecoveryThisLoad = true
+
+    await Promise.race([
+      inspectionPromise || Promise.resolve(),
+      new Promise(resolve => setTimeout(resolve, INSPECTION_TIMEOUT_MS)),
+    ])
+
     const attempt = count + 1
     sessionStorage.setItem(RELOAD_COUNT_KEY, String(attempt))
     pushRecoveryEvent('reloaded', attempt, url)
@@ -264,24 +695,50 @@ function attemptRecovery(message) {
   }
 }
 
+/**
+ * Report a failure and, if it's a module error, attempt recovery. Shared by
+ * all three listeners in `install()` below; only how `message`/`stack` get
+ * pulled off the event differs between them.
+ */
+function handleFailure(kind, message, stack, { alwaysRecover = false } = {}) {
+  const inspectionPromise = report(kind, message, stack)
+  if (alwaysRecover || isModuleError(message)) {
+    attemptRecovery(message, inspectionPromise)
+  }
+  return inspectionPromise
+}
+
 function install() {
   try {
     // Vite fires this when a dynamically imported chunk fails to load/preload.
     window.addEventListener('vite:preloadError', event => {
       const err = event && (event.payload || event.detail)
-      const message =
-        (err && err.message) || String(err) || 'vite:preloadError'
-      report('vite:preloadError', message, err && err.stack)
-      attemptRecovery(message)
+      const message = (err && err.message) || String(err) || 'vite:preloadError'
+      // Vite's default handling for this event is to rethrow the original
+      // error (see Vite's vite:preloadError docs) unless we call
+      // preventDefault(). Only take over when we're actually about to
+      // reload ourselves - if recovery is already spent for this load, or
+      // the per-tab cap is exhausted (banner shown instead), let the
+      // original error propagate as it did before this change; we aren't
+      // superseding it with anything in that case.
+      const willReload =
+        !hasAttemptedRecoveryThisLoad && getReloadCount() < MAX_RELOAD_ATTEMPTS
+      if (willReload && event && typeof event.preventDefault === 'function') {
+        event.preventDefault()
+      }
+      handleFailure('vite:preloadError', message, err && err.stack, {
+        alwaysRecover: true,
+      })
     })
 
-    // Module instantiation/link failures surface as a global error event.
+    // Module instantiation/link failures can also surface as a global error
+    // event, so recovery must be attempted from here too.
     window.addEventListener(
       'error',
       event => {
         const err = event && event.error
         const message = (err && err.message) || (event && event.message) || ''
-        report('error', message, err && err.stack)
+        handleFailure('error', message, err && err.stack)
       },
       true,
     )
@@ -291,7 +748,7 @@ function install() {
       const reason = event && event.reason
       const message =
         (reason && reason.message) || (typeof reason === 'string' ? reason : '')
-      report('unhandledrejection', message, reason && reason.stack)
+      handleFailure('unhandledrejection', message, reason && reason.stack)
     })
   } catch {
     /* never break startup */

--- a/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImpl.java
@@ -12,8 +12,7 @@ import org.json.JSONObject;
 public class ViteHTMLGeneratorImpl implements ViteHTMLGenerator {
 
   private static final String VITE_DEV_SERVER_ORIGIN = "http://localhost:5173";
-  // The base path should match the value in the Vite config.
-  private static final String VITE_BASE_PATH = "/Portal/cdn/generated/vite";
+  private static final String VITE_BASE_PATH = "";
 
   private static final String VITE_DEV_SERVER_URL =
     VITE_DEV_SERVER_ORIGIN + VITE_BASE_PATH;

--- a/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/filter/CORSFilter.java
@@ -30,6 +30,14 @@ public class CORSFilter extends OncePerRequestFilter {
   // they're present on the wire.
   public static final String EXPOSED_HEADERS =
     "Age, X-Cache, ETag, Content-Encoding, Content-Length";
+  // Enables moduleLoadDiagnostics.js to capture size fields (decodedBodySize,
+  // encodedBodySize, transferSize) on cross-origin requests.
+  //
+  // Deliberately NOT sent on every response. `Timing-Allow-Origin: *` lets any
+  // origin read a resource's transferred/encoded size even when the CORS check
+  // denied it the body. This is public info for static assets.
+  public static final String TIMING_ALLOW_ORIGIN_HEADER = "Timing-Allow-Origin";
+  public static final String STATIC_ASSET_PATH_SEGMENT = "/generated/";
 
   // DNS Records pulled from: https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/tree/develop/src/main/resources/templates/dns
   // Note that not all records need to have an explicitly-allowed origin; the subdomains in this list need only be the sites that should persist authentication state between *.synapse.org sites.
@@ -115,6 +123,16 @@ public class CORSFilter extends OncePerRequestFilter {
     return false;
   }
 
+  /**
+   * Whether this request is for build output rather than an application endpoint. Covers both
+   * `/generated/vite/...` and the redirector's `/Portal/cdn/generated/vite/...`, since a lazily loaded
+   * chunk is requested at both.
+   */
+  static boolean isStaticAssetRequest(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    return uri != null && uri.toLowerCase().contains(STATIC_ASSET_PATH_SEGMENT);
+  }
+
   @Override
   protected void doFilterInternal(
     HttpServletRequest request,
@@ -130,6 +148,9 @@ public class CORSFilter extends OncePerRequestFilter {
 
     response.addHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, allowOrigin);
     response.addHeader(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER, EXPOSED_HEADERS);
+    if (isStaticAssetRequest(request)) {
+      response.addHeader(TIMING_ALLOW_ORIGIN_HEADER, DEFAULT_ALLOW_ORIGIN);
+    }
     if (
       request.getHeader("Access-Control-Request-Method") != null &&
       "OPTIONS".equals(request.getMethod())

--- a/src/test/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImplTest.java
+++ b/src/test/java/org/sagebionetworks/web/server/servlet/ViteHTMLGeneratorImplTest.java
@@ -13,8 +13,8 @@ public class ViteHTMLGeneratorImplTest extends TestCase {
     String html = generator.getViteDevelopmentHTML(List.of("js/main.js"));
 
     assertEquals(
-      "<script type=\"module\" src=\"http://localhost:5173/Portal/cdn/generated/vite/@vite/client\"></script>\n" +
-      "<script type=\"module\" src=\"http://localhost:5173/Portal/cdn/generated/vite/js/main.js\"></script>\n",
+      "<script type=\"module\" src=\"http://localhost:5173/@vite/client\"></script>\n" +
+      "<script type=\"module\" src=\"http://localhost:5173/js/main.js\"></script>\n",
       html
     );
   }

--- a/src/test/java/org/sagebionetworks/web/unitserver/filter/CORSFilterTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/filter/CORSFilterTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.web.unitserver.filter;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -10,6 +11,7 @@ import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.ACCESS_CO
 import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.DEFAULT_ALLOW_ORIGIN;
 import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.ORIGIN_HEADER;
 import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.SYNAPSE_ORG_SUFFIX;
+import static org.sagebionetworks.web.server.servlet.filter.CORSFilter.TIMING_ALLOW_ORIGIN_HEADER;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -150,5 +152,48 @@ public class CORSFilterTest {
     // and Access-Control-Allow-Credentials is not added to the response
     verify(mockResponse, never())
       .addHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+  }
+
+  @Test
+  public void testTimingAllowOriginSetOnStaticAssets()
+    throws ServletException, IOException {
+    // SWC-7865/SWC-7954: client-side chunk-load diagnostics read cross-origin
+    // PerformanceResourceTiming size fields, which silently read as 0 without
+    // this header.
+    when(mockRequest.getRequestURI())
+      .thenReturn("/generated/vite/assets/main-D2GRFy7k.js");
+
+    filter.testFilter(mockRequest, mockResponse, mockFilterChain);
+
+    verify(mockResponse)
+      .addHeader(TIMING_ALLOW_ORIGIN_HEADER, DEFAULT_ALLOW_ORIGIN);
+  }
+
+  @Test
+  public void testTimingAllowOriginSetOnAssetsBehindTheCdnRedirector()
+    throws ServletException, IOException {
+    // A lazily loaded chunk is requested at both URLs, so both need the header
+    // for the diagnostics to see a duplicate fetch.
+    when(mockRequest.getRequestURI())
+      .thenReturn("/Portal/cdn/generated/vite/assets/main-D2GRFy7k.js");
+
+    filter.testFilter(mockRequest, mockResponse, mockFilterChain);
+
+    verify(mockResponse)
+      .addHeader(TIMING_ALLOW_ORIGIN_HEADER, DEFAULT_ALLOW_ORIGIN);
+  }
+
+  @Test
+  public void testTimingAllowOriginNotSetOnApplicationEndpoints()
+    throws ServletException, IOException {
+    // `Timing-Allow-Origin: *` lets any origin read a response's size even when
+    // the CORS check denied it the body, so on an authenticated endpoint it
+    // must not be present.
+    when(mockRequest.getRequestURI()).thenReturn("/Portal/synapseclient");
+
+    filter.testFilter(mockRequest, mockResponse, mockFilterChain);
+
+    verify(mockResponse, never())
+      .addHeader(eq(TIMING_ALLOW_ORIGIN_HEADER), anyString());
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,7 @@ import path from 'path'
  * Vite config to generate the ESM & CJS bundles for Synapse React Client.
  */
 const config = defineConfig({
-  // Assets will be served from the `/Portal/cdn` servlet, which will redirect requests to the CDN when appropriate
-  base: '/Portal/cdn/generated/vite/',
+  base: './',
   server: {
     host: '0.0.0.0', // Bind to all interfaces so Docker can access it
     cors: {


### PR DESCRIPTION
- Simplify Vite config to reduce redirects
- More diagnostics & CORS header tweaks to collect more info about static paths
- Send diagnostics to CloudWatch via /log service instead of GTM