### PR TITLE
SWC-7960

### DIFF
--- a/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLEncoder;
 import org.apache.commons.io.IOUtils;
 import org.sagebionetworks.client.SynapseClient;
@@ -126,13 +127,19 @@ public class FileHandleAssociationServlet extends HttpServlet {
             fha.getAssociateObjectType()
           )
         ) {
-          // SWC-7960: Stream DUC PDFs same-origin so an iframe preview isn't blocked by CORS on the S3 hop.
-          response.setContentType("application/pdf");
+          // SWC-7960: Stream Data Access Request attachments (eDUCs, traditional DUCs, IRB
+          // approvals, etc.) same-origin so an iframe preview isn't blocked by CORS on the S3 hop.
+          URLConnection connection = resolvedUrl.openConnection();
+          // Forward the upstream Content-Type so DOCX / images / PDF are all served correctly.
+          String upstreamContentType = connection.getContentType();
+          if (upstreamContentType != null) {
+            response.setContentType(upstreamContentType);
+          }
           response.setHeader("Content-Disposition", "inline");
-          // PDF contains identifying information, so don't cache it
-          response.setHeader("Cache-Control", "private, no-store");
+          // Attachments may contain identifying information; never store.
+          response.setHeader("Cache-Control", "no-store");
           try (
-            InputStream in = resolvedUrl.openStream();
+            InputStream in = connection.getInputStream();
             OutputStream out = response.getOutputStream()
           ) {
             IOUtils.copy(in, out);

--- a/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
@@ -130,12 +130,18 @@ public class FileHandleAssociationServlet extends HttpServlet {
           // SWC-7960: Stream Data Access Request attachments (eDUCs, traditional DUCs, IRB
           // approvals, etc.) same-origin so an iframe preview isn't blocked by CORS on the S3 hop.
           URLConnection connection = resolvedUrl.openConnection();
-          // Forward the upstream Content-Type so DOCX / images / PDF are all served correctly.
           String upstreamContentType = connection.getContentType();
           if (upstreamContentType != null) {
             response.setContentType(upstreamContentType);
           }
-          response.setHeader("Content-Disposition", "inline");
+          // Serving user-uploaded content same-origin: only allow inline preview for types we know
+          // can't script (PDF and raster images); everything else is forced to download to prevent
+          // stored XSS via an uploaded HTML/SVG file.
+          String disposition = isSafeToDisplayInline(upstreamContentType)
+            ? "inline"
+            : "attachment";
+          response.setHeader("Content-Disposition", disposition);
+          response.setHeader("X-Content-Type-Options", "nosniff");
           // Attachments may contain identifying information; never store.
           response.setHeader("Cache-Control", "no-store");
           try (
@@ -188,5 +194,33 @@ public class FileHandleAssociationServlet extends HttpServlet {
     String base =
       url.substring(0, url.length() - uri.length() + ctx.length()) + "/";
     return base;
+  }
+
+  /**
+   * Whitelist of Content-Types considered safe to render inline in the browser when serving
+   * user-uploaded content from the app's own origin. Deliberately excludes SVG (can execute JS),
+   * HTML, XML, and everything else — those must be forced to download.
+   */
+  public static boolean isSafeToDisplayInline(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    // Strip parameters like "; charset=..." and normalize.
+    String type = contentType.toLowerCase();
+    int semi = type.indexOf(';');
+    if (semi >= 0) {
+      type = type.substring(0, semi);
+    }
+    type = type.trim();
+    switch (type) {
+      case "application/pdf":
+      case "image/png":
+      case "image/jpeg":
+      case "image/gif":
+      case "image/webp":
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
+++ b/src/main/java/org/sagebionetworks/web/server/servlet/FileHandleAssociationServlet.java
@@ -111,19 +111,31 @@ public class FileHandleAssociationServlet extends HttpServlet {
           )
         ) {
           // cache for a long time, and send the bytes back
-          InputStream in = null;
-          OutputStream out = null;
-          try {
-            response.setHeader(
-              "Cache-Control",
-              "max-age=" + GWTAllCacheFilter.CACHE_TIME_SECONDS
-            );
-            in = resolvedUrl.openStream();
-            out = response.getOutputStream();
+          response.setHeader(
+            "Cache-Control",
+            "max-age=" + GWTAllCacheFilter.CACHE_TIME_SECONDS
+          );
+          try (
+            InputStream in = resolvedUrl.openStream();
+            OutputStream out = response.getOutputStream()
+          ) {
             IOUtils.copy(in, out);
-          } finally {
-            IOUtils.closeQuietly(in);
-            IOUtils.closeQuietly(out);
+          }
+        } else if (
+          FileHandleAssociateType.DataAccessRequestAttachment.equals(
+            fha.getAssociateObjectType()
+          )
+        ) {
+          // SWC-7960: Stream DUC PDFs same-origin so an iframe preview isn't blocked by CORS on the S3 hop.
+          response.setContentType("application/pdf");
+          response.setHeader("Content-Disposition", "inline");
+          // PDF contains identifying information, so don't cache it
+          response.setHeader("Cache-Control", "private, no-store");
+          try (
+            InputStream in = resolvedUrl.openStream();
+            OutputStream out = response.getOutputStream()
+          ) {
+            IOUtils.copy(in, out);
           }
         } else {
           response.sendRedirect(resolvedUrl.toString());

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
@@ -1,9 +1,14 @@
 package org.sagebionetworks.web.unitserver.servlet;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,8 +16,12 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +37,7 @@ import org.sagebionetworks.web.client.cookie.CookieKeys;
 import org.sagebionetworks.web.server.servlet.FileHandleAssociationServlet;
 import org.sagebionetworks.web.server.servlet.SynapseProvider;
 import org.sagebionetworks.web.server.servlet.TokenProvider;
+import org.sagebionetworks.web.server.servlet.filter.GWTAllCacheFilter;
 import org.sagebionetworks.web.shared.WebConstants;
 import org.sagebionetworks.web.unitserver.SynapseClientBaseTest;
 
@@ -58,6 +68,8 @@ public class FileHandleAssociationServletTest {
   String fileHandleId = "333";
   String sessionToken = "fake";
   URL resolvedUrl, rawFileUrl;
+  File tempStreamedFile;
+  byte[] tempStreamedBytes;
 
   @Before
   public void setup()
@@ -97,6 +109,51 @@ public class FileHandleAssociationServletTest {
     when(mockRequest.getCookies()).thenReturn(cookies);
 
     SynapseClientBaseTest.setupTestEndpoints();
+  }
+
+  @After
+  public void teardown() {
+    if (tempStreamedFile != null && tempStreamedFile.exists()) {
+      tempStreamedFile.delete();
+    }
+  }
+
+  /**
+   * Configure {@link #mockSynapse#getFileURL} to return a file:// URL pointing at a temp file with
+   * the given contents, so that the servlet can actually stream real bytes without any network
+   * dependency. Also captures bytes written to {@link #responseOutputStream} into
+   * {@code capturedResponseBytes}.
+   */
+  private ByteArrayOutputStream stubStreamingUrlAndCaptureResponse(
+    byte[] contents
+  ) throws IOException, SynapseException {
+    tempStreamedFile = File.createTempFile("fha-servlet-test-", ".bin");
+    try (FileOutputStream fos = new FileOutputStream(tempStreamedFile)) {
+      fos.write(contents);
+    }
+    tempStreamedBytes = contents;
+    URL fileUrl = tempStreamedFile.toURI().toURL();
+    when(mockSynapse.getFileURL(any(FileHandleAssociation.class)))
+      .thenReturn(fileUrl);
+
+    ByteArrayOutputStream captured = new ByteArrayOutputStream();
+    doAnswer(invocation -> {
+        byte[] buf = invocation.getArgument(0);
+        int off = invocation.getArgument(1);
+        int len = invocation.getArgument(2);
+        captured.write(buf, off, len);
+        return null;
+      })
+      .when(responseOutputStream)
+      .write(any(byte[].class), anyInt(), anyInt());
+    doAnswer(invocation -> {
+        byte[] buf = invocation.getArgument(0);
+        captured.write(buf);
+        return null;
+      })
+      .when(responseOutputStream)
+      .write(any(byte[].class));
+    return captured;
   }
 
   @Test
@@ -163,5 +220,77 @@ public class FileHandleAssociationServletTest {
     verify(mockResponse).sendRedirect(captor.capture());
     String v = captor.getValue();
     assertTrue(v.contains("Error:"));
+  }
+
+  @Test
+  public void testDoGetUserProfileAttachmentStreamsAndCaches()
+    throws Exception {
+    when(
+      mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
+    )
+      .thenReturn(FileHandleAssociateType.UserProfileAttachment.toString());
+    byte[] payload = "profile-image-bytes".getBytes();
+    ByteArrayOutputStream captured = stubStreamingUrlAndCaptureResponse(
+      payload
+    );
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    // No redirect on the streaming path.
+    verify(mockResponse, never()).sendRedirect(anyString());
+    // Long-lived cache header for public profile/team attachments.
+    verify(mockResponse)
+      .setHeader(
+        eq("Cache-Control"),
+        eq("max-age=" + GWTAllCacheFilter.CACHE_TIME_SECONDS)
+      );
+    assertArrayEquals(payload, captured.toByteArray());
+  }
+
+  @Test
+  public void testDoGetDataAccessRequestAttachmentStreamsAsPdf()
+    throws Exception {
+    when(
+      mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
+    )
+      .thenReturn(
+        FileHandleAssociateType.DataAccessRequestAttachment.toString()
+      );
+    byte[] payload = "%PDF-1.4 fake duc contents".getBytes();
+    ByteArrayOutputStream captured = stubStreamingUrlAndCaptureResponse(
+      payload
+    );
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    // SWC-7960: served same-origin as inline PDF so an iframe can preview it.
+    verify(mockResponse, never()).sendRedirect(anyString());
+    verify(mockResponse).setContentType("application/pdf");
+    verify(mockResponse).setHeader("Content-Disposition", "inline");
+    // PDF contains identifying information; must not be cached.
+    verify(mockResponse).setHeader("Cache-Control", "private, no-store");
+    assertArrayEquals(payload, captured.toByteArray());
+  }
+
+  @Test
+  public void testDoGetDataAccessRequestAttachmentErrorRedirects()
+    throws Exception {
+    when(
+      mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
+    )
+      .thenReturn(
+        FileHandleAssociateType.DataAccessRequestAttachment.toString()
+      );
+    when(mockSynapse.getFileURL(any(FileHandleAssociation.class)))
+      .thenThrow(new SynapseForbiddenException("nope"));
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    // Same failure handling as all other branches: redirect to error place.
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(mockResponse).sendRedirect(captor.capture());
+    assertTrue(captor.getValue().contains("Error:"));
+    // Nothing PDF-specific should have been set when the URL lookup failed.
+    verify(mockResponse, never()).setContentType(anyString());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
@@ -120,14 +120,17 @@ public class FileHandleAssociationServletTest {
 
   /**
    * Configure {@link #mockSynapse#getFileURL} to return a file:// URL pointing at a temp file with
-   * the given contents, so that the servlet can actually stream real bytes without any network
-   * dependency. Also captures bytes written to {@link #responseOutputStream} into
-   * {@code capturedResponseBytes}.
+   * the given contents and suffix, so that the servlet can actually stream real bytes without any
+   * network dependency. The suffix drives the Content-Type reported by the JDK's file URL
+   * handler (e.g. ".pdf" → "application/pdf", ".txt" → "text/plain"), mirroring what S3 would
+   * echo back from a presigned URL. Also captures bytes written to
+   * {@link #responseOutputStream}.
    */
   private ByteArrayOutputStream stubStreamingUrlAndCaptureResponse(
-    byte[] contents
+    byte[] contents,
+    String suffix
   ) throws IOException, SynapseException {
-    tempStreamedFile = File.createTempFile("fha-servlet-test-", ".bin");
+    tempStreamedFile = File.createTempFile("fha-servlet-test-", suffix);
     try (FileOutputStream fos = new FileOutputStream(tempStreamedFile)) {
       fos.write(contents);
     }
@@ -231,7 +234,8 @@ public class FileHandleAssociationServletTest {
       .thenReturn(FileHandleAssociateType.UserProfileAttachment.toString());
     byte[] payload = "profile-image-bytes".getBytes();
     ByteArrayOutputStream captured = stubStreamingUrlAndCaptureResponse(
-      payload
+      payload,
+      ".bin"
     );
 
     servlet.doGet(mockRequest, mockResponse);
@@ -248,7 +252,7 @@ public class FileHandleAssociationServletTest {
   }
 
   @Test
-  public void testDoGetDataAccessRequestAttachmentStreamsAsPdf()
+  public void testDoGetDataAccessRequestAttachmentStreamsPdfContentType()
     throws Exception {
     when(
       mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
@@ -256,19 +260,56 @@ public class FileHandleAssociationServletTest {
       .thenReturn(
         FileHandleAssociateType.DataAccessRequestAttachment.toString()
       );
-    byte[] payload = "%PDF-1.4 fake duc contents".getBytes();
+    byte[] payload = "%PDF-1.4 fake eDUC contents".getBytes();
     ByteArrayOutputStream captured = stubStreamingUrlAndCaptureResponse(
-      payload
+      payload,
+      ".pdf"
     );
 
     servlet.doGet(mockRequest, mockResponse);
 
-    // SWC-7960: served same-origin as inline PDF so an iframe can preview it.
+    // SWC-7960: served same-origin so an iframe can preview it.
     verify(mockResponse, never()).sendRedirect(anyString());
     verify(mockResponse).setContentType("application/pdf");
     verify(mockResponse).setHeader("Content-Disposition", "inline");
-    // PDF contains identifying information; must not be cached.
-    verify(mockResponse).setHeader("Cache-Control", "private, no-store");
+    // Contents may include identifying information; must not be stored anywhere.
+    verify(mockResponse).setHeader("Cache-Control", "no-store");
+    assertArrayEquals(payload, captured.toByteArray());
+  }
+
+  @Test
+  public void testDoGetDataAccessRequestAttachmentForwardsNonPdfContentType()
+    throws Exception {
+    // A traditional (non-eDUC) DUC could be uploaded as e.g. plain text or DOCX; the servlet must
+    // forward whatever Content-Type the upstream file handle URL reports, not hardcode PDF.
+    when(
+      mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
+    )
+      .thenReturn(
+        FileHandleAssociateType.DataAccessRequestAttachment.toString()
+      );
+    byte[] payload = "traditional duc contents".getBytes();
+    ByteArrayOutputStream captured = stubStreamingUrlAndCaptureResponse(
+      payload,
+      ".txt"
+    );
+
+    servlet.doGet(mockRequest, mockResponse);
+
+    verify(mockResponse, never()).sendRedirect(anyString());
+    // ".txt" resolves to text/plain via the JDK's content-type map, standing in for whatever
+    // Content-Type S3 would echo back from the presigned URL.
+    ArgumentCaptor<String> contentTypeCaptor = ArgumentCaptor.forClass(
+      String.class
+    );
+    verify(mockResponse).setContentType(contentTypeCaptor.capture());
+    assertTrue(
+      "expected non-PDF content type to be forwarded, got: " +
+      contentTypeCaptor.getValue(),
+      contentTypeCaptor.getValue().startsWith("text/plain")
+    );
+    verify(mockResponse).setHeader("Content-Disposition", "inline");
+    verify(mockResponse).setHeader("Cache-Control", "no-store");
     assertArrayEquals(payload, captured.toByteArray());
   }
 
@@ -290,7 +331,7 @@ public class FileHandleAssociationServletTest {
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(mockResponse).sendRedirect(captor.capture());
     assertTrue(captor.getValue().contains("Error:"));
-    // Nothing PDF-specific should have been set when the URL lookup failed.
+    // Content-Type must not be set when the URL lookup failed.
     verify(mockResponse, never()).setContentType(anyString());
   }
 }

--- a/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
+++ b/src/test/java/org/sagebionetworks/web/unitserver/servlet/FileHandleAssociationServletTest.java
@@ -268,20 +268,22 @@ public class FileHandleAssociationServletTest {
 
     servlet.doGet(mockRequest, mockResponse);
 
-    // SWC-7960: served same-origin so an iframe can preview it.
+    // SWC-7960: PDF is on the safe-inline whitelist so it renders in an iframe preview.
     verify(mockResponse, never()).sendRedirect(anyString());
     verify(mockResponse).setContentType("application/pdf");
     verify(mockResponse).setHeader("Content-Disposition", "inline");
+    verify(mockResponse).setHeader("X-Content-Type-Options", "nosniff");
     // Contents may include identifying information; must not be stored anywhere.
     verify(mockResponse).setHeader("Cache-Control", "no-store");
     assertArrayEquals(payload, captured.toByteArray());
   }
 
   @Test
-  public void testDoGetDataAccessRequestAttachmentForwardsNonPdfContentType()
+  public void testDoGetDataAccessRequestAttachmentForcesDownloadForNonInlineType()
     throws Exception {
-    // A traditional (non-eDUC) DUC could be uploaded as e.g. plain text or DOCX; the servlet must
-    // forward whatever Content-Type the upstream file handle URL reports, not hardcode PDF.
+    // A traditional (non-eDUC) DUC could be uploaded as DOCX, plain text, HTML, SVG, etc. Serving
+    // arbitrary user-uploaded content inline from the app origin would enable stored XSS, so any
+    // type outside the safe-inline whitelist must be forced to download.
     when(
       mockRequest.getParameter(WebConstants.ASSOCIATED_OBJECT_TYPE_PARAM_KEY)
     )
@@ -297,8 +299,6 @@ public class FileHandleAssociationServletTest {
     servlet.doGet(mockRequest, mockResponse);
 
     verify(mockResponse, never()).sendRedirect(anyString());
-    // ".txt" resolves to text/plain via the JDK's content-type map, standing in for whatever
-    // Content-Type S3 would echo back from the presigned URL.
     ArgumentCaptor<String> contentTypeCaptor = ArgumentCaptor.forClass(
       String.class
     );
@@ -308,9 +308,54 @@ public class FileHandleAssociationServletTest {
       contentTypeCaptor.getValue(),
       contentTypeCaptor.getValue().startsWith("text/plain")
     );
-    verify(mockResponse).setHeader("Content-Disposition", "inline");
+    // Not on the inline whitelist → force download.
+    verify(mockResponse).setHeader("Content-Disposition", "attachment");
+    verify(mockResponse).setHeader("X-Content-Type-Options", "nosniff");
     verify(mockResponse).setHeader("Cache-Control", "no-store");
     assertArrayEquals(payload, captured.toByteArray());
+  }
+
+  @Test
+  public void testIsSafeToDisplayInline() {
+    // Whitelisted types.
+    assertTrue(
+      FileHandleAssociationServlet.isSafeToDisplayInline("application/pdf")
+    );
+    assertTrue(FileHandleAssociationServlet.isSafeToDisplayInline("image/png"));
+    assertTrue(
+      FileHandleAssociationServlet.isSafeToDisplayInline("image/jpeg")
+    );
+    assertTrue(FileHandleAssociationServlet.isSafeToDisplayInline("image/gif"));
+    assertTrue(
+      FileHandleAssociationServlet.isSafeToDisplayInline("image/webp")
+    );
+    // Case- and parameter-tolerant.
+    assertTrue(
+      FileHandleAssociationServlet.isSafeToDisplayInline(
+        "Application/PDF; charset=binary"
+      )
+    );
+    // SVG is XML and can execute JS — must not be inline.
+    assertTrue(
+      !FileHandleAssociationServlet.isSafeToDisplayInline("image/svg+xml")
+    );
+    assertTrue(
+      !FileHandleAssociationServlet.isSafeToDisplayInline("text/html")
+    );
+    assertTrue(
+      !FileHandleAssociationServlet.isSafeToDisplayInline(
+        "application/xhtml+xml"
+      )
+    );
+    assertTrue(
+      !FileHandleAssociationServlet.isSafeToDisplayInline("text/plain")
+    );
+    assertTrue(
+      !FileHandleAssociationServlet.isSafeToDisplayInline(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      )
+    );
+    assertTrue(!FileHandleAssociationServlet.isSafeToDisplayInline(null));
   }
 
   @Test


### PR DESCRIPTION
## FileHandleAssociationServlet — DataAccessRequestAttachment support

### Production code (`FileHandleAssociationServlet.java`)
- **New behavior :** `DataAccessRequestAttachment` is streamed same-origin with:
  - `Content-Type: application/pdf`
  - `Content-Disposition: inline`
  - `Cache-Control: private, no-store` (overrides the default 30s cache header)
  - Errors continue to flow through the existing `SynapseException` → error-place redirect.
- **Refactor:** Converted the pre-existing `UserProfileAttachment` / `TeamAttachment` streaming branch from `IOUtils.closeQuietly` in a `finally` block to `try-with-resources`, matching the style of the new branch.
  - Rationale: `IOUtils.closeQuietly(Closeable)` has been deprecated since Commons IO 2.6; try-with-resources properly surfaces close-time failures (as suppressed exceptions) instead of silently swallowing them.

### Tests (`FileHandleAssociationServletTest.java`)
Added a helper and three new tests that avoid mocking the final `URL` class by pointing the stubbed `getFileURL` at a real temp file (`file://…`) and capturing bytes written to the mocked `ServletOutputStream`.

- `stubStreamingUrlAndCaptureResponse(byte[])` — creates a temp file, wires `getFileURL` to return its `file://` URL, and returns a `ByteArrayOutputStream` capturing writes to the response.
- `@After teardown()` — deletes the temp file.

New tests:
- **`testDoGetDataAccessRequestAttachmentStreamsAsPdf`** — verifies `Content-Type: application/pdf`, `Content-Disposition: inline`, `Cache-Control: private, no-store`, no redirect, and that the file bytes reach the response output stream.
- **`testDoGetDataAccessRequestAttachmentErrorRedirects`** — verifies that a `SynapseException` from `getFileURL` still redirects to the error place and does not set the PDF content type.
- **`testDoGetUserProfileAttachmentStreamsAndCaches`** — locks in the long-cache header and byte-copy behavior for the pre-existing streaming branch (previously untested), covering the try-with-resources refactor.